### PR TITLE
chore: restrict renovate to patch updates, add dependabot for actions security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,15 @@
   "extends": [
     "config:recommended"
   ],
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
     {
       "matchDepNames": [
         "openssl/openssl"


### PR DESCRIPTION
Renovate will now only propose patch-level updates by default. Minor and major version bumps are disabled globally. Security fixes from the OSV database (`osvVulnerabilityAlerts: true`) still create PRs regardless of update type, as they go through a separate code path.

A new `.github/dependabot.yml` registers the `github-actions` ecosystem with Dependabot. `open-pull-requests-limit: 0` disables routine version-update PRs from Dependabot, while GitHub's separate security update mechanism (which ignores this limit) will still create PRs for vulnerable pinned actions.