### PR TITLE
fix: set --openssldir=/etc/ssl so profiler finds system CA bundle

### DIFF
--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -10,7 +10,7 @@ RUN curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${O
     -o /tmp/openssl.tar.gz \
     && tar xzf /tmp/openssl.tar.gz -C /tmp \
     && cd /tmp/openssl-${OPENSSL_VERSION} \
-    && ./config no-shared no-tests --prefix=/usr/local/openssl \
+    && ./config no-shared no-tests --prefix=/usr/local/openssl --openssldir=/etc/ssl \
     && make -j$(nproc) \
     && make install_sw \
     && ln -sf /usr/local/openssl/lib64 /usr/local/openssl/lib || true \

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -10,7 +10,7 @@ RUN curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${O
     -o /tmp/openssl.tar.gz \
     && tar xzf /tmp/openssl.tar.gz -C /tmp \
     && cd /tmp/openssl-${OPENSSL_VERSION} \
-    && ./config no-shared no-tests --prefix=/usr/local/openssl \
+    && ./config no-shared no-tests --prefix=/usr/local/openssl --openssldir=/etc/ssl \
     && make -j$(nproc) \
     && make install_sw \
     && ln -sf /usr/local/openssl/lib64 /usr/local/openssl/lib || true \


### PR DESCRIPTION
Without --openssldir, OpenSSL's compiled-in default cert search path is /usr/local/openssl/ssl (based on --prefix), which does not exist on user machines. SSL_CTX_set_default_verify_paths() found no CAs and all HTTPS profile uploads failed with "SSL server verification failed".

Setting --openssldir=/etc/ssl makes OpenSSL look in /etc/ssl/cert.pem and /etc/ssl/certs/, which are present on both Debian/Ubuntu and Alpine.

Same fix as grafana/pyroscope-dotnet@d5c4ca7d57c90a3e2d9de5cb9b96859e75beb2ab