### PR TITLE
fix: strip trailing comments when extracting Cargo.toml version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ mac/arm64:
 .PHONY: check/tag-version
 check/tag-version:
 	@TAG_VERSION=$${TAG#python-}; \
-	CARGO_VERSION=$$(sed -n 's/^version = "\(.*\)"/\1/p' rust/Cargo.toml); \
+	CARGO_VERSION=$$(sed -n 's/^version = "\([^"]*\)".*/\1/p' rust/Cargo.toml); \
 	if [ "$$TAG_VERSION" != "$$CARGO_VERSION" ]; then \
 		echo "error: tag version ($$TAG_VERSION) does not match Cargo.toml version ($$CARGO_VERSION)"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ mac/arm64:
 .PHONY: check/tag-version
 check/tag-version:
 	@TAG_VERSION=$${TAG#python-}; \
-	CARGO_VERSION=$$(sed -n 's/^version = "\([^"]*\)".*/\1/p' rust/Cargo.toml); \
+	CARGO_VERSION=$$(cd rust && cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version'); \
 	if [ "$$TAG_VERSION" != "$$CARGO_VERSION" ]; then \
 		echo "error: tag version ($$TAG_VERSION) does not match Cargo.toml version ($$CARGO_VERSION)"; \
 		exit 1; \


### PR DESCRIPTION
The `check/tag-version` Makefile target used `sed` to extract the version from `rust/Cargo.toml`. When release-please added a `# x-release-please-version` inline comment to the version line, the comment leaked into the extracted string, failing the tag comparison on the [Python Release workflow](https://github.com/grafana/pyroscope-python/actions/runs/24321141044/job/71007465226).

Replaced the `sed` parsing with `cargo metadata --no-deps | jq`, which outputs structured JSON and is immune to TOML formatting or comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to build/release tooling; the main risk is CI environments needing `cargo`/`jq` available and `cargo metadata` output matching expectations.
> 
> **Overview**
> `check/tag-version` now derives the Rust crate version using `cargo metadata --no-deps | jq` instead of parsing `rust/Cargo.toml` with `sed`, preventing tag/version mismatches when the version line includes inline comments (e.g., from release tooling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fc333e346bd38b45aec9d14b33574b544d7b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->