### PR TITLE
chore: switch PyPI publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Remove explicit `user`/`password` credentials from the `pypa/gh-action-pypi-publish` step so the action uses the OIDC `id-token` (already granted at the job level) for authentication instead.

Before merging, a trusted publisher must be registered on pypi.org for the `pyroscope-io` project: owner `grafana`, repo `pyroscope-python`, workflow `publish.yml`.

After this is working, the `PYPI_API_TOKEN` repository secret can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change is limited to the release publishing GitHub Action and reduces reliance on long-lived PyPI credentials; the main risk is misconfigured trusted publisher/OIDC permissions causing publish failures.
> 
> **Overview**
> Updates the PyPI publish GitHub Actions workflow to stop passing `user`/`password` (token-based auth) to `pypa/gh-action-pypi-publish`, relying instead on **trusted publishing via OIDC** using the job’s `id-token: write` permission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0090ee584b12bc5116b3d9afac1d187286f43c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->