### PR TITLE
ci: drive release artifact build from release-please draft release

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,15 +1,54 @@
-name: Python Release
+name: Build Release Artifacts
 
 on:
-  push:
-    tags:
-      - 'python-*'
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+        description: "Existing draft release tag, e.g. python-1.0.8"
+      sha:
+        required: true
+        type: string
+        description: "Commit SHA to build from"
+
+permissions:
+  contents: read
 
 jobs:
+  verify:
+    permissions:
+      contents: read
+    name: Verify versions
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
+      - name: Verify tag matches package version
+        env:
+          TAG: ${{ inputs.tag_name }}
+        run: make check/tag-version
+      - name: Verify Cargo version matches Python version
+        run: cargo test --locked -- test_cargo_version_matches_python_version
+        working-directory: rust
+
   python-release-linux:
     permissions:
       contents: write
-    needs: [ 'python-release' ]
+    needs: [verify]
     strategy:
       fail-fast: false
       matrix:
@@ -31,22 +70,24 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
       - run: make ${{ matrix.make-target }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.sha }}-python-${{ matrix.name }}
+          name: ${{ inputs.sha }}-python-${{ matrix.name }}
           path: dist/*
 
       - name: Upload release artifact
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ inputs.tag_name }}
           draft: true
           files: dist/pyroscope*.whl
   python-release-macos:
     permissions:
       contents: write
-    needs: [ 'python-release' ]
+    needs: [verify]
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -80,24 +122,26 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.sha }}-python-macos-${{ matrix.target }}
+          name: ${{ inputs.sha }}-python-macos-${{ matrix.target }}
           path: dist/*
 
       - name: Upload release artifact
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ inputs.tag_name }}
           draft: true
           files: dist/pyroscope*.whl
   python-release-sdist:
     permissions:
       contents: write
-    needs: [ 'python-release' ]
+    needs: [verify]
     name: sdist
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
@@ -107,37 +151,12 @@ jobs:
       - run: python -m build --sdist
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.sha }}-python-sdist
+          name: ${{ inputs.sha }}-python-sdist
           path: dist/*
 
       - name: Upload release artifact
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ inputs.tag_name }}
           draft: true
           files: dist/pyroscope_io-*.tar.gz
-  python-release:
-    permissions:
-      contents: write
-    name: Python Package
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-        with:
-          toolchain: stable
-      - name: Verify tag matches package version
-        env:
-          TAG: ${{ github.ref_name }}
-        run: make check/tag-version
-      - name: Verify Cargo version matches Python version
-        run: cargo test --locked -- test_cargo_version_matches_python_version
-        working-directory: rust
-      - id: auto-release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          tag_name: "${{ github.ref_name }}"
-          name: "Python Package: ${{ github.ref_name }}"
-          draft: true
-          prerelease: false

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,9 @@ jobs:
       pull-requests: write
     outputs:
       pr: ${{ steps.rp.outputs.pr }}
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
+      sha: ${{ steps.rp.outputs.sha }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
@@ -44,3 +47,14 @@ jobs:
           git add rust/Cargo.lock
           git diff --cached --quiet || git commit -m "chore: update Cargo.lock"
           git push
+
+  build-artifacts:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-release-artifacts.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}
+    secrets: inherit

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
       "include-component-in-tag": true,
-      "skip-github-release": true,
+      "draft": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": true,
       "draft": true,
+      "draft-pull-request": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
The current release flow has an undocumented manual step. `release-please.yml` runs with `skip-github-release: true` which (per the schema) skips both the GitHub release object and the git tag, and `release.yml` fires on `push: tags: python-*`. release-please does not push a tag, and even if it did the default `GITHUB_TOKEN` would not trigger downstream workflows. Empirically, the tags `python-1.0.5..python-1.0.7` are annotated tags signed by a human, not by `github-actions[bot]`, which means each release has required someone to manually create and push the tag for the build to fire.

This PR removes the manual tagging step and folds the build into the release-please flow.

- `release-please-config.json`: replace `skip-github-release: true` with `draft: true` and `draft-pull-request: true`. release-please now opens its release PR as a draft and creates a draft GitHub release on merge. The draft is published manually via the GitHub UI to ship to PyPI through the existing `publish.yml`.
- `release.yml` -> `build-release-artifacts.yml`: trigger is `workflow_call` and `workflow_dispatch` instead of tag push. Drop the gate job that used to create the draft release (release-please does it now); fold its tag/version verification into a `verify` job the build jobs depend on. Build jobs check out `inputs.sha` and pass `inputs.tag_name` to `softprops/action-gh-release` to attach assets to the draft.
- `release-please.yml`: expose `release_created`, `tag_name`, `sha` outputs and add a `build-artifacts` job that calls the new reusable workflow when a release was just cut.
- `ci.yml`, `ci-rust.yml`: add `ready_for_review` to the `pull_request` types so the test suites run when a maintainer flips the draft release PR to ready. The bot-created `opened` event does not trigger downstream workflows.

End-to-end flow after this change: conventional commits land on main, release-please opens a draft PR, the maintainer flips it ready (CI runs), merge, release-please cuts a draft GitHub release on the next push, `build-artifacts` auto-fires and attaches wheels and sdist, the maintainer clicks "Publish release", `publish.yml` ships to PyPI via OIDC.

Validated end-to-end on https://github.com/korniltsev-grafanista/pyroscope-python — draft release `python-1.0.8` was created automatically on PR merge and `pyroscope_io-1.0.8.tar.gz` was attached by the `sdist` job. The reusable-workflow call, the `verify` gate, and the draft-asset upload all worked.

One known race: if a maintainer clicks "Mark ready for review" on the release PR before the `update-lockfile` job has pushed its `Cargo.lock` update, CI runs against the stale HEAD and the `Cargo.lock`-update push from `GITHUB_TOKEN` does not trigger `pull_request: synchronize`. Workaround: wait for `update-lockfile` to finish before flipping the PR ready, or rerun the failed checks. A structural fix would require pushing the lock update with a PAT or GitHub App token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation trigger and artifact upload path (moving from tag-push to `workflow_call` driven by release-please), which could break or delay release builds if inputs/outputs or permissions are miswired. No runtime product code changes, but it affects the shipping pipeline.
> 
> **Overview**
> **Release automation is now driven by `release-please` draft releases instead of manual tag pushes.** `build-release-artifacts.yml` becomes a reusable workflow (`workflow_call`/`workflow_dispatch`) that checks out `inputs.sha`, verifies version/tag alignment in a new `verify` gate, then builds Linux/macOS wheels and an sdist and uploads them to the draft release via `tag_name`.
> 
> `release-please.yml` now exposes `release_created`/`tag_name`/`sha` outputs and conditionally calls the reusable build workflow when a release is cut, while `release-please-config.json` switches from skipping GitHub releases to creating **draft** release PRs and **draft** GitHub releases. CI workflows (`ci.yml`, `ci-rust.yml`) add `ready_for_review` so checks run when draft PRs are marked ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c839cd2ec08ecb943ca2c441486a3dee24f6d616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->