### PR TITLE
chore(renovate): vulnerabilities-only with allowlist for openssl/pyroscope/py-spy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,43 +1,36 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "security:only-security-updates"
   ],
   "packageRules": [
     {
-      "matchDepNames": [
+      "description": "Always update these to latest, all update types. Overrides the wildcard enabled:false from security:only-security-updates.",
+      "matchPackageNames": [
+        "pyroscope",
+        "py-spy",
         "openssl/openssl"
       ],
+      "enabled": true
+    },
+    {
+      "description": "Split openssl/openssl patch updates into their own stream so they survive when minor/major are disabled below.",
+      "matchPackageNames": ["openssl/openssl"],
       "separateMinorPatch": true
     },
     {
-      "matchDepNames": [
-        "openssl/openssl"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
+      "description": "Restrict openssl/openssl to patch-level updates only. Vulnerability alerts still bypass this and can produce minor/major bumps when needed for CVE fixes.",
+      "matchPackageNames": ["openssl/openssl"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
-    },
-    {
-      "description": "Allow all updates for critical profiling dependencies",
-      "matchDepNames": [
-        "py-spy",
-        "pyroscope"
-      ],
-      "enabled": true
     }
   ],
   "customManagers": [
     {
+      "description": "Track the OpenSSL C library version pinned via ARG OPENSSL_VERSION in the Dockerfile, resolved against openssl/openssl GitHub releases.",
       "customType": "regex",
-      "managerFilePatterns": [
-        "/Dockerfile/"
-      ],
-      "matchStrings": [
-        "ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"
-      ],
+      "managerFilePatterns": ["/Dockerfile/"],
+      "matchStrings": ["ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"],
       "depNameTemplate": "openssl/openssl",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^openssl-(?<version>.*)$"


### PR DESCRIPTION
Switches renovate to extend the built-in `security:only-security-updates` preset, then adds an explicit allowlist for `pyroscope`, `py-spy`, and `openssl/openssl` so those three are the only deps that get routine update PRs; everything else only gets a PR in response to an OSV or GHSA advisory. The existing custom regex manager that pins the OpenSSL C library via `ARG OPENSSL_VERSION` in the Dockerfile is preserved, and `openssl/openssl` is restricted to patch-level updates only (vulnerability alerts can still pull in minor/major bumps when needed for a CVE fix). Mirrors the equivalent change made in pyroscope-ruby (grafana/pyroscope-ruby#71). Note that `py-spy` here is a git-pinned dependency, so the cargo manager won't produce routine version PRs for it under either config; the entry stays in the allowlist for parity with the previous behavior in case the dep is ever switched back to a registry version. Transitive cargo CVE fixes continue to come through Dependabot security updates, which complements rather than overlaps with renovate under this config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it alters dependency update flow by limiting routine updates to an allowlist and restricting `openssl/openssl` to patch releases, which could change update coverage and PR volume.
> 
> **Overview**
> Switches Renovate to the `security:only-security-updates` preset so routine update PRs are suppressed by default and only security advisories trigger updates.
> 
> Adds an explicit allowlist to keep regular updates enabled for `pyroscope`, `py-spy`, and `openssl/openssl`, while splitting OpenSSL patch updates into a separate stream and disabling OpenSSL minor/major updates (except when required by vulnerability alerts). Also documents/preserves the custom regex manager that tracks `ARG OPENSSL_VERSION` in the `Dockerfile` against `openssl/openssl` GitHub releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f79a180916f518f79601ca86df4d6e5100d40d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->