### PR TITLE
ci: add Python 3.14 to Linux test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13"]
+        PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         variant:
           [
             "manylinux-amd64",


### PR DESCRIPTION
Adds Python 3.14 to the python-linux-test matrix so wheels are exercised on the latest stable Python. The existing musllinux-arm64 exclusions only target 3.10 and 3.11, so 3.14 runs across all four variants.