### PR TITLE
ci: use GitHub App token for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,17 +10,23 @@ jobs:
     name: Run release-please
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      id-token: write
     outputs:
       pr: ${{ steps.rp.outputs.pr }}
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
       sha: ${{ steps.rp.outputs.sha }}
     steps:
+      - id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: pyroscope-development-app
+
       - id: rp
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          token: ${{ steps.get-github-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -190,11 +196,17 @@ jobs:
     if: needs.release-please.outputs.pr != ''
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
     steps:
+      - id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: pyroscope-development-app
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: release-please--branches--main--components--python
+          token: ${{ steps.get-github-app-token.outputs.token }}
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: 1.96.0


### PR DESCRIPTION


- Replace the default `GITHUB_TOKEN` in the `release-please` job with a token from `pyroscope-development-app` via `grafana/shared-workflows/actions/create-github-app-token`, matching the pattern used in [grafana/otel-profiling-java](https://github.com/grafana/otel-profiling-java/blob/main/.github/workflows/release-please.yml)
- Drop the broad `contents: write` / `pull-requests: write` permissions from the `release-please` job; the app token carries those instead
- Apply the same GitHub App token to the `update-lockfile` job so it can push to the release-please PR branch without `contents: write` on the workflow token

