### PR TITLE
chore: prepare for memory profiling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1206,6 +1206,7 @@ dependencies = [
 name = "pyroscope_python_extension"
 version = "1.0.11"
 dependencies = [
+ "hashbrown 0.17.1",
  "lazy_static",
  "libc",
  "libflate",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,4 +24,4 @@ libflate = "2.1.0"
 prost = "0.14"
 serde_json = "1.0.115"
 lazy_static = "1.5.0"
-
+hashbrown = "0.17.1"

--- a/rust/src/encode/pprof.rs
+++ b/rust/src/encode/pprof.rs
@@ -92,8 +92,8 @@ impl PProfBuilder {
         ];
         self.profile.period = heap_sample_rate as i64;
         self.profile.period_type = Some(ValueType {
-            r#type: strings.add("cpu").pprof(),
-            unit: strings.add("nanoseconds").pprof(),
+            r#type: strings.add("space").pprof(),
+            unit: strings.add("bytes").pprof(),
         });
     }
 

--- a/rust/src/encode/pprof.rs
+++ b/rust/src/encode/pprof.rs
@@ -1,15 +1,20 @@
-use std::collections::HashMap;
-
 use crate::backend::types::Report;
+use crate::backend::StackTrace;
 use crate::encode::gen::google::{Function, Label, Line, Location, Profile, Sample, ValueType};
+use crate::encode::pprof::ffi::FFIInternedString;
+use crate::encode::pprof::ffi::{FFIFrame, FFIHeapSampleValues};
+use crate::utils::TimeRange;
+use hashbrown::hash_map::EntryRef;
+use prost::Message;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
-struct PProfBuilder {
+pub struct PProfBuilder {
     profile: Profile,
-    strings: HashMap<String, i64>,
     functions: HashMap<FunctionMirror, u64>,
     locations: HashMap<LocationMirror, u64>,
 }
-
 #[derive(Hash, PartialEq, Eq, Clone)]
 pub struct LocationMirror {
     pub function_id: u64,
@@ -18,24 +23,137 @@ pub struct LocationMirror {
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 pub struct FunctionMirror {
-    pub name: i64,
-    pub filename: i64,
+    pub name: StringID,
+    pub filename: StringID,
+}
+
+impl Default for PProfBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PProfBuilder {
-    fn add_string(&mut self, s: &String) -> i64 {
-        let v = self.strings.get(s);
-        if let Some(v) = v {
-            return *v;
+    pub fn new() -> Self {
+        PProfBuilder {
+            functions: HashMap::new(),
+            locations: HashMap::new(),
+            profile: Profile {
+                sample_type: vec![],
+                sample: vec![],
+                mapping: vec![],
+                location: vec![],
+                function: vec![],
+                string_table: vec![],
+                drop_frames: 0,
+                keep_frames: 0,
+                time_nanos: 0,
+                duration_nanos: 0,
+                period_type: None,
+                period: 0,
+                comment: vec![],
+                default_sample_type: 0,
+            },
         }
-        assert_ne!(self.strings.len(), self.profile.string_table.len() + 1);
-        let id: i64 = self.strings.len() as i64;
-        self.strings.insert(s.to_owned(), id);
-        self.profile.string_table.push(s.to_owned());
-        id
     }
 
-    fn add_function(&mut self, fm: FunctionMirror) -> u64 {
+    pub fn set_time_range(&mut self, time_range: &TimeRange) {
+        let start_time_nanos = time_range.from * 1_000_000_000;
+        let duration_nanos = (time_range.until - time_range.from) * 1_000_000_000;
+        self.profile.time_nanos = start_time_nanos as i64;
+        self.profile.duration_nanos = duration_nanos as i64;
+    }
+    pub fn set_cpu_profile_type(&mut self, strings: &mut StringTable, sample_rate: u32) {
+        self.profile.sample_type.push(ValueType {
+            r#type: strings.add("cpu").pprof(),
+            unit: strings.add("nanoseconds").pprof(),
+        });
+        self.profile.period = 1_000_000_000 / sample_rate as i64;
+        self.profile.period_type = Some(ValueType {
+            r#type: strings.add("cpu").pprof(),
+            unit: strings.add("nanoseconds").pprof(),
+        });
+    }
+
+    pub fn set_memory_profile_type(&mut self, strings: &mut StringTable, heap_sample_rate: u64) {
+        self.profile.sample_type = vec![
+            ValueType {
+                r#type: strings.add("alloc_objects").pprof(),
+                unit: strings.add("count").pprof(),
+            },
+            ValueType {
+                r#type: strings.add("alloc_space").pprof(),
+                unit: strings.add("bytes").pprof(),
+            },
+            ValueType {
+                r#type: strings.add("inuse_space").pprof(),
+                unit: strings.add("bytes").pprof(),
+            },
+        ];
+        self.profile.period = heap_sample_rate as i64;
+        self.profile.period_type = Some(ValueType {
+            r#type: strings.add("cpu").pprof(),
+            unit: strings.add("nanoseconds").pprof(),
+        });
+    }
+
+    pub fn add_stacktrace(
+        &mut self,
+        strings: &mut StringTable,
+        stacktrace: StackTrace,
+        value: usize,
+    ) {
+        let mut sample = Sample {
+            location_id: vec![],
+            value: vec![value as i64 * self.profile.period],
+            label: vec![],
+        };
+        for sf in stacktrace.frames {
+            let (Some(name), Some(filename)) = (&sf.name, &sf.filename) else {
+                continue;
+            };
+            let name = strings.add(name); //todo move
+            let filename = strings.add(filename); //todo move
+            let line = sf.line.unwrap_or(0) as i64;
+            let function_id = self.add_function_mirror(FunctionMirror { name, filename });
+            let location_id = self.add_location_mirror(LocationMirror { function_id, line });
+            sample.location_id.push(location_id);
+        }
+        for l in stacktrace.metadata.tags {
+            sample.label.push(Label {
+                key: strings.add(&l.key).pprof(),   //todo move
+                str: strings.add(&l.value).pprof(), //todo move
+                num: 0,
+                num_unit: 0,
+            });
+        }
+        self.profile.sample.push(sample);
+    }
+
+    pub fn add_ffi_sample(&mut self, frames: &[FFIFrame], values: &FFIHeapSampleValues) {
+        let mut sample = Sample {
+            location_id: Vec::with_capacity(frames.len()),
+            value: vec![
+                values.alloc_count as i64,
+                values.alloc_space as i64,
+                values.heap_space as i64,
+            ],
+            label: vec![],
+        };
+
+        for f in frames {
+            let line = f.line as i64;
+            let function_id = self.add_function_mirror(FunctionMirror {
+                name: (&f.function_name).into(),
+                filename: (&f.file_name).into(),
+            });
+            let location_id = self.add_location_mirror(LocationMirror { function_id, line });
+            sample.location_id.push(location_id);
+        }
+        self.profile.sample.push(sample);
+    }
+
+    pub fn add_function_mirror(&mut self, fm: FunctionMirror) -> u64 {
         let v = self.functions.get(&fm);
         if let Some(v) = v {
             return *v;
@@ -44,9 +162,9 @@ impl PProfBuilder {
         let id: u64 = self.functions.len() as u64 + 1;
         let f = Function {
             id,
-            name: fm.name,
+            name: fm.name.pprof(),
             system_name: 0,
-            filename: fm.filename,
+            filename: fm.filename.pprof(),
             start_line: 0,
         };
         self.functions.insert(fm, id);
@@ -54,7 +172,7 @@ impl PProfBuilder {
         id
     }
 
-    fn add_location(&mut self, lm: LocationMirror) -> u64 {
+    pub fn add_location_mirror(&mut self, lm: LocationMirror) -> u64 {
         let v = self.locations.get(&lm);
         if let Some(v) = v {
             return *v;
@@ -75,85 +193,218 @@ impl PProfBuilder {
         self.profile.location.push(l);
         id
     }
-}
 
-pub fn encode(
-    reports: &Vec<Report>,
-    sample_rate: u32,
-    start_time_nanos: u64,
-    duration_nanos: u64,
-) -> Profile {
-    let mut b = PProfBuilder {
-        strings: HashMap::new(),
-        functions: HashMap::new(),
-        locations: HashMap::new(),
-        profile: Profile {
-            sample_type: vec![],
-            sample: vec![],
-            mapping: vec![],
-            location: vec![],
-            function: vec![],
-            string_table: vec![],
-            drop_frames: 0,
-            keep_frames: 0,
-            time_nanos: start_time_nanos as i64,
-            duration_nanos: duration_nanos as i64,
-            period_type: None,
-            period: 0,
-            comment: vec![],
-            default_sample_type: 0,
-        },
-    };
-    b.add_string(&"".to_string());
-    {
-        let cpu = b.add_string(&"cpu".to_string());
-        let nanoseconds = b.add_string(&"nanoseconds".to_string());
-        b.profile.sample_type.push(ValueType {
-            r#type: cpu,
-            unit: nanoseconds,
-        });
-        b.profile.period = 1_000_000_000 / sample_rate as i64;
-        b.profile.period_type = Some(ValueType {
-            r#type: cpu,
-            unit: nanoseconds,
-        });
+    pub fn reset(&mut self) {
+        self.profile.sample.clear();
+        self.profile.function.clear();
+        self.profile.location.clear();
+        self.profile.string_table.clear();
+        self.profile.time_nanos = 0;
+        self.profile.duration_nanos = 0;
+        self.locations.clear();
+        self.functions.clear();
     }
-    for report in reports {
-        for (stacktrace, value) in &report.data {
-            let mut sample = Sample {
-                location_id: vec![],
-                value: vec![*value as i64 * b.profile.period],
-                label: vec![],
-            };
-            for sf in &stacktrace.frames {
-                let name = b.add_string(sf.name.as_ref().unwrap_or(&"".to_string()));
-                let filename = b.add_string(sf.filename.as_ref().unwrap_or(&"".to_string()));
-                let line = sf.line.unwrap_or(0) as i64;
-                let function_id = b.add_function(FunctionMirror { name, filename });
-                let location_id = b.add_location(LocationMirror { function_id, line });
-                sample.location_id.push(location_id);
-            }
-            let mut labels = HashMap::new();
-            for l in &stacktrace.metadata.tags {
-                let k = b.add_string(&l.key);
-                let v = b.add_string(&l.value);
-                labels.insert(k, v);
-            }
-            for l in &report.metadata.tags {
-                let k = b.add_string(&l.key);
-                let v = b.add_string(&l.value);
-                labels.insert(k, v);
-            }
-            for (k, v) in &labels {
-                sample.label.push(Label {
-                    key: *k,
-                    str: *v,
-                    num: 0,
-                    num_unit: 0,
-                })
-            }
-            b.profile.sample.push(sample);
+    pub fn encode_and_reset(
+        &mut self,
+        st: &StringTable,
+        time_range: &TimeRange,
+    ) -> Option<Vec<u8>> {
+        if self.profile.sample.is_empty() {
+            self.reset();
+            None
+        } else {
+            self.set_time_range(time_range);
+            st.clone_pprof_table(&mut self.profile.string_table);
+            let res = self.profile.encode_to_vec();
+            self.reset();
+            Some(res)
         }
     }
+}
+
+pub fn encode(reports: Vec<Report>, sample_rate: u32, time_range: TimeRange) -> Profile {
+    let mut strings: StringTable = StringTable::new();
+    let mut b = PProfBuilder::new();
+    b.set_time_range(&time_range);
+    b.set_cpu_profile_type(&mut strings, sample_rate);
+    for report in reports {
+        for (stacktrace, value) in report.data {
+            b.add_stacktrace(&mut strings, stacktrace, value);
+        }
+    }
+    b.profile.string_table = strings.into_pprof_table();
     b.profile
+}
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+pub struct StringID {
+    pub index: u32,
+}
+
+impl StringID {
+    pub(crate) fn pprof(&self) -> i64 {
+        self.index as i64
+    }
+}
+
+impl StringID {
+    pub fn new(vec: &hashbrown::HashMap<StringSetKey, ()>) -> Self {
+        let id: usize = vec.len();
+        assert!(id < u32::MAX as usize);
+        let id: u32 = id as u32;
+        Self { index: id }
+    }
+    pub fn empty_ffi_string() -> FFIInternedString {
+        FFIInternedString { index: 0 }
+    }
+}
+
+impl From<&FFIInternedString> for StringID {
+    fn from(value: &FFIInternedString) -> Self {
+        Self { index: value.index }
+    }
+}
+
+impl From<&StringID> for FFIInternedString {
+    fn from(value: &StringID) -> Self {
+        Self { index: value.index }
+    }
+}
+
+pub struct StringTable {
+    pub set: hashbrown::HashMap<StringSetKey, ()>,
+}
+
+pub struct StringSetKey {
+    pub str: String,
+    pub index: StringID,
+}
+
+impl Borrow<str> for StringSetKey {
+    fn borrow(&self) -> &str {
+        &self.str
+    }
+}
+
+// impl Borrow<String> for StringSetKey {
+//     fn borrow(&self) -> &String {
+//         &self.str
+//     }
+// }
+
+impl Hash for StringSetKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.str.hash(state)
+    }
+}
+
+impl PartialEq<Self> for StringSetKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.str == other.str
+    }
+}
+
+impl Eq for StringSetKey {}
+
+impl Default for StringTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StringTable {
+    pub fn new() -> Self {
+        let mut s = Self {
+            set: hashbrown::HashMap::new(),
+        };
+        s.add("");
+        s
+    }
+
+    pub fn add(&mut self, s: &str) -> StringID {
+        let next_id = StringID::new(&self.set);
+        let k = self.set.entry_ref(s);
+        match k {
+            EntryRef::Occupied(v) => v.key().index.clone(),
+            EntryRef::Vacant(v) => {
+                let k = StringSetKey {
+                    str: s.to_owned(),
+                    index: next_id.clone(),
+                };
+                v.insert_entry_with_key(k, ());
+                next_id
+            }
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn debug_get_ffi(&self, id: &FFIInternedString) -> &str {
+        self.set
+            .iter()
+            .find(|it| it.0.index.index == id.index)
+            .map(|it| it.0.str.as_str())
+            .unwrap_or("NOT FOUND WTF")
+    }
+
+    pub fn memory_size_bytes(&self) -> usize {
+        let mut sz: usize = self.set.allocation_size();
+        for x in self.set.keys() {
+            sz += x.str.len();
+        }
+        sz
+    }
+
+    pub fn into_pprof_table(self) -> Vec<String> {
+        let mut v = vec!["".to_string(); self.set.len()];
+        for x in self.set.into_keys() {
+            let idx = x.index.index as usize;
+            v[idx] = x.str;
+        }
+        v
+    }
+
+    pub fn clone_pprof_table(&self, dst: &mut Vec<String>) {
+        dst.clear();
+        dst.resize(self.set.len(), String::new());
+        for x in self.set.keys() {
+            let idx = x.index.index as usize;
+            dst[idx] = x.str.clone();
+        }
+    }
+}
+
+pub mod ffi {
+    use std::ffi::{c_char, c_int};
+
+    #[repr(C)]
+    pub struct FFIFrame {
+        pub function_name: FFIInternedString,
+        pub file_name: FFIInternedString,
+        pub line: c_int,
+    }
+
+    #[repr(C)]
+    pub struct FFIStringView {
+        pub data: *const c_char,
+        pub len: usize,
+    }
+
+    #[repr(C)]
+    pub struct FFISample {
+        pub frames: *const FFIFrame,
+        pub len: usize,
+        pub values: FFIHeapSampleValues,
+    }
+
+    #[repr(C)]
+    pub struct FFIHeapSampleValues {
+        pub heap_space: usize,
+        pub alloc_space: usize,
+        pub alloc_count: usize,
+    }
+
+    #[repr(C)]
+    pub struct FFIInternedString {
+        pub index: u32,
+    }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 mod pyspy_backend;
+// mod mem;
 
 // Re-exports structs
 pub use crate::pyroscope::PyroscopeAgent;
@@ -138,13 +139,18 @@ pub unsafe extern "C" fn initialize_agent(
 
     let pyspy = BackendImpl::new(Box::new(Pyspy::new(config, backend_config)));
 
-    let mut agent_builder = PyroscopeAgentBuilder::new(
+    let mut agent_builder = pyroscope::PyroscopeConfig::new(
         server_address,
         application_name,
         sample_rate,
         PYSPY_NAME,
         PYSPY_VERSION,
-        pyspy,
+        // mem::Config {
+        //     enabled: mem_enabled,
+        //     enable_mem_domain: mem_enable_mem_domain,
+        //     max_nframe: mem_max_nframe,
+        //     heap_sample_size: mem_heap_sample_size,
+        // },
     )
     .tags(tags);
 
@@ -171,7 +177,8 @@ pub unsafe extern "C" fn initialize_agent(
         },
     }
 
-    ffikit::run(agent_builder).is_ok()
+    // mem::start(&pyroscope_config.mem_config);
+    ffikit::run(PyroscopeAgentBuilder::new(agent_builder, pyspy)).is_ok()
 }
 
 #[no_mangle]

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    backend::{BackendReady, BackendUninitialized, Report, Tag},
+    backend::{BackendReady, BackendUninitialized, Tag},
     error::Result,
     session::{Session, SessionManager, SessionSignal},
     timer::{Timer, TimerSignal},
@@ -20,17 +20,7 @@ use crate::{
 use crate::backend::{BackendImpl, ThreadTag};
 
 const LOG_TAG: &str = "Pyroscope::Agent";
-const PPROFRS_SPY_NAME: &str = "pyroscope-rs";
-const PPROFRS_SPY_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Pyroscope Agent Configuration. This is the configuration that is passed to the agent.
-///
-/// # Example
-/// ```
-/// use pyroscope::pyroscope::PyroscopeConfig;
-/// let config = PyroscopeConfig::new("http://localhost:8080", "my-app", 100, "pyspy", "0.8.16");
-/// ```
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PyroscopeConfig {
     /// Pyroscope Server Address
     pub url: String,
@@ -45,10 +35,9 @@ pub struct PyroscopeConfig {
     /// Spy Version
     pub spy_version: String,
     pub basic_auth: Option<BasicAuth>,
-    /// Function to apply
-    pub func: Option<fn(Report) -> Report>,
     pub tenant_id: Option<String>,
     pub http_headers: HashMap<String, String>,
+    // pub mem_config: crate::mem::Config,
 }
 
 #[derive(Clone, Debug)]
@@ -57,37 +46,14 @@ pub struct BasicAuth {
     pub password: String,
 }
 
-impl Default for PyroscopeConfig {
-    fn default() -> Self {
-        Self {
-            url: "http://localhost:4040".to_string(),
-            application_name: "undefined".to_string(),
-            tags: HashMap::new(),
-            sample_rate: 100u32,
-            spy_name: PPROFRS_SPY_NAME.to_string(),
-            spy_version: PPROFRS_SPY_VERSION.to_string(),
-            basic_auth: None,
-            func: None,
-            tenant_id: None,
-            http_headers: HashMap::new(),
-        }
-    }
-}
-
 impl PyroscopeConfig {
-    /// Create a new PyroscopeConfig object.
-    ///
-    /// # Example
-    /// ```
-    /// use pyroscope::pyroscope::PyroscopeConfig;
-    /// let config = PyroscopeConfig::new("http://localhost:8080", "my-app", 100, "pyspy", "0.8.16");
-    /// ```
     pub fn new(
         url: impl AsRef<str>,
         application_name: impl AsRef<str>,
         sample_rate: u32,
         spy_name: impl AsRef<str>,
         spy_version: impl AsRef<str>,
+        // mem_config: mem::Config,
     ) -> Self {
         Self {
             url: url.as_ref().to_owned(),
@@ -97,9 +63,9 @@ impl PyroscopeConfig {
             spy_name: spy_name.as_ref().to_owned(),
             spy_version: spy_version.as_ref().to_owned(),
             basic_auth: None,
-            func: None,
             tenant_id: None,
             http_headers: HashMap::new(),
+            // mem_config,
         }
     }
 
@@ -114,14 +80,6 @@ impl PyroscopeConfig {
     pub fn basic_auth(self, username: String, password: String) -> Self {
         Self {
             basic_auth: Some(BasicAuth { username, password }),
-            ..self
-        }
-    }
-
-    /// Set the Function.
-    pub fn func(self, func: fn(Report) -> Report) -> Self {
-        Self {
-            func: Some(func),
             ..self
         }
     }
@@ -188,130 +146,10 @@ pub struct PyroscopeAgentBuilder {
 }
 
 impl PyroscopeAgentBuilder {
-    /// Create a new PyroscopeAgentBuilder object.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use pyroscope::pyroscope::PyroscopeAgentBuilder;
-    /// use pyroscope::backend::{pprof_backend, PprofConfig, BackendConfig};
-    ///
-    /// let builder = PyroscopeAgentBuilder::new(
-    ///     "http://localhost:8080", "my-app", 100, "pyroscope-rs", "0.1.0",
-    ///     pprof_backend(PprofConfig::default(), BackendConfig::default()),
-    /// );
-    /// ```
-    pub fn new(
-        url: impl AsRef<str>,
-        application_name: impl AsRef<str>,
-        sample_rate: u32,
-        spy_name: impl AsRef<str>,
-        spy_version: impl AsRef<str>,
-        backend: BackendImpl<BackendUninitialized>,
-    ) -> Self {
-        Self {
-            backend,
-            config: PyroscopeConfig::new(url, application_name, sample_rate, spy_name, spy_version),
-        }
+    pub fn new(config: PyroscopeConfig, backend: BackendImpl<BackendUninitialized>) -> Self {
+        Self { backend, config }
     }
 
-    /// Override the Pyroscope Server URL.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use pyroscope::pyroscope::PyroscopeAgentBuilder;
-    /// use pyroscope::backend::{pprof_backend, PprofConfig, BackendConfig};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let agent = PyroscopeAgentBuilder::new(
-    ///     "http://localhost:4040", "my-app", 100, "pyroscope-rs", "0.1.0",
-    ///     pprof_backend(PprofConfig::default(), BackendConfig::default()),
-    /// )
-    /// .url("http://localhost:8080")
-    /// .build()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn url(self, url: impl AsRef<str>) -> Self {
-        Self {
-            config: self.config.url(url),
-            ..self
-        }
-    }
-
-    pub fn basic_auth(self, username: impl AsRef<str>, password: impl AsRef<str>) -> Self {
-        Self {
-            config: self
-                .config
-                .basic_auth(username.as_ref().to_owned(), password.as_ref().to_owned()),
-            ..self
-        }
-    }
-
-    /// Set the Function.
-    /// This is optional. If not set, the agent will not apply any function.
-    /// # Example
-    /// ```no_run
-    /// use pyroscope::pyroscope::PyroscopeAgentBuilder;
-    /// use pyroscope::backend::{pprof_backend, PprofConfig, BackendConfig};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let agent = PyroscopeAgentBuilder::new(
-    ///     "http://localhost:8080", "my-app", 100, "pyroscope-rs", "0.1.0",
-    ///     pprof_backend(PprofConfig::default(), BackendConfig::default()),
-    /// )
-    /// .func(|report| report)
-    /// .build()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn func(self, func: fn(Report) -> Report) -> Self {
-        Self {
-            config: self.config.func(func),
-            ..self
-        }
-    }
-
-    /// Set tags. Default is empty.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use pyroscope::pyroscope::PyroscopeAgentBuilder;
-    /// use pyroscope::backend::{pprof_backend, PprofConfig, BackendConfig};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let agent = PyroscopeAgentBuilder::new(
-    ///     "http://localhost:8080", "my-app", 100, "pyroscope-rs", "0.1.0",
-    ///     pprof_backend(PprofConfig::default(), BackendConfig::default()),
-    /// )
-    /// .tags(vec![("env", "dev")])
-    /// .build()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn tags(self, tags: Vec<(&str, &str)>) -> Self {
-        Self {
-            config: self.config.tags(tags),
-            ..self
-        }
-    }
-
-    pub fn tenant_id(self, tenant_id: String) -> Self {
-        Self {
-            config: self.config.tenant_id(tenant_id),
-            ..self
-        }
-    }
-
-    pub fn http_headers(self, http_headers: HashMap<String, String>) -> Self {
-        Self {
-            config: self.config.http_headers(http_headers),
-            ..self
-        }
-    }
-
-    /// Initialize the backend, timer and return a PyroscopeAgent with Ready
-    /// state. While you can call this method, you should call it through the
-    /// `PyroscopeAgent.build()` method.
     pub fn build(self) -> Result<PyroscopeAgent<PyroscopeAgentReady>> {
         let config = self.config;
 
@@ -503,6 +341,21 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
             while let Ok(signal) = rx.recv() {
                 match signal {
                     TimerSignal::NextSnapshot(until) => {
+                        // get_time_range should be used with "from". We balance this by reducing
+                        // 10s from the returned range.
+                        let mut time_range = get_time_range(until)?;
+                        time_range.from -= 10;
+                        time_range.until -= 10;
+
+                        let mut batch = Vec::with_capacity(2);
+
+                        // if let Some(pprof) = mem::dump_pprof(config.mem_config.heap_sample_size, &time_range) {
+                        //     batch.push(ReportBatch{
+                        //         profile_type: "memory".to_string(),
+                        //         data: ReportData::RawPprof(pprof),
+                        //     })
+                        // }
+
                         log::trace!(target: LOG_TAG, "Sending session {until}");
 
                         // Generate report from backend
@@ -516,15 +369,18 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
                             })?
                             .report()?;
 
+                        batch.push(report);
+
                         // Send new Session to SessionManager
                         stx.send(SessionSignal::Session(Box::new(Session::new(
-                            until,
+                            time_range,
                             config.clone(),
-                            report,
-                        )?)))?
+                            batch,
+                        ))))?
                     }
                     TimerSignal::Terminate => {
                         log::trace!(target: LOG_TAG, "Session Killed");
+                        // mem::stop();
 
                         // Notify the Stop function
                         let (lock, cvar) = &*pair;

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -7,11 +7,11 @@ use std::{
 
 use crate::encode::gen::push::{PushRequest, RawProfileSeries, RawSample};
 use crate::encode::gen::types::LabelPair;
+use crate::utils::TimeRange;
 use crate::{
-    backend::{Report, ReportBatch, ReportData},
+    backend::{ReportBatch, ReportData},
     encode::pprof,
     pyroscope::PyroscopeConfig,
-    utils::get_time_range,
     Result,
 };
 use libflate::gzip::Encoder;
@@ -89,92 +89,60 @@ impl SessionManager {
 
 pub struct Session {
     pub config: PyroscopeConfig,
-    pub batch: ReportBatch,
-    // unix time todo remove comment, use types
-    pub from: u64,
-    // unix time todo remove comment, use types
-    pub until: u64,
+    pub batch: Vec<ReportBatch>,
+    time_range: TimeRange,
 }
 
 impl Session {
-    /// Create a new Session
-    /// # Example
-    /// ```ignore
-    /// let config = PyroscopeConfig::new("https://localhost:8080", "my-app", 100, "pyspy", "0.8.16");
-    /// let report = vec![1, 2, 3];
-    /// let until = 154065120;
-    /// let session = Session::new(until, config, report)?;
-    /// ```
-    pub fn new(until: u64, config: PyroscopeConfig, batch: ReportBatch) -> Result<Self> {
-        log::info!(target: LOG_TAG, "Creating Session");
-
-        // get_time_range should be used with "from". We balance this by reducing
-        // 10s from the returned range.
-        let time_range = get_time_range(until)?;
-
-        Ok(Self {
+    pub fn new(time_range: TimeRange, config: PyroscopeConfig, batch: Vec<ReportBatch>) -> Self {
+        Self {
             config,
             batch,
-            from: time_range.from - 10,
-            until: time_range.until - 10,
-        })
+            time_range,
+        }
     }
 
     fn push(self, client: &reqwest::blocking::Client) -> Result<()> {
-        log::info!(target: LOG_TAG, "Sending Session: {} - {}", self.from, self.until);
+        log::info!(target: LOG_TAG, "Sending Session: {} - {}", self.time_range.from, self.time_range.until);
 
-        let ReportBatch { profile_type, data } = self.batch;
-
-        let raw_profile = match data {
-            ReportData::RawPprof(pprof_bytes) => {
-                if self.config.func.is_some() {
-                    log::warn!(target: LOG_TAG, "report transform function is not supported with raw pprof backends (e.g. jemalloc)");
-                }
-                pprof_bytes
-            }
-            ReportData::Reports(reports) => {
-                let transformed: Vec<Report>;
-                let encode_input = match self.config.func {
-                    None => &reports,
-                    Some(f) => {
-                        transformed = reports.iter().map(|r| f(r.to_owned())).collect();
-                        &transformed
-                    }
-                };
-                pprof::encode(
-                    encode_input,
-                    self.config.sample_rate,
-                    self.from * 1_000_000_000,
-                    (self.until - self.from) * 1_000_000_000,
-                )
-                .encode_to_vec()
-            }
+        let mut req = PushRequest {
+            series: Vec::with_capacity(self.batch.len()),
         };
+        for batch in self.batch {
+            let ReportBatch { profile_type, data } = batch;
 
-        let mut labels: Vec<LabelPair> = Vec::with_capacity(2 + self.config.tags.len());
-        labels.push(LabelPair {
-            name: "service_name".to_string(),
-            value: self.config.application_name.clone(),
-        });
-        labels.push(LabelPair {
-            name: "__name__".to_string(),
-            value: profile_type,
-        });
-        for tag in self.config.tags {
+            let raw_profile = match data {
+                ReportData::RawPprof(pprof_bytes) => pprof_bytes,
+                ReportData::Reports(reports) => {
+                    pprof::encode(reports, self.config.sample_rate, self.time_range.clone())
+                        .encode_to_vec()
+                }
+            };
+
+            let mut labels: Vec<LabelPair> = Vec::with_capacity(2 + self.config.tags.len());
             labels.push(LabelPair {
-                name: tag.0,
-                value: tag.1,
-            })
-        }
-        let req = PushRequest {
-            series: vec![RawProfileSeries {
+                name: "service_name".to_string(),
+                value: self.config.application_name.clone(),
+            });
+            labels.push(LabelPair {
+                name: "__name__".to_string(),
+                value: profile_type,
+            });
+            for (k, v) in &self.config.tags {
+                labels.push(LabelPair {
+                    name: k.clone(),
+                    value: v.clone(),
+                })
+            }
+            let series = RawProfileSeries {
                 labels,
                 samples: vec![RawSample {
                     raw_profile,
                     id: Uuid::new_v4().to_string(),
                 }],
-            }],
-        };
+            };
+            req.series.push(series);
+        }
 
         let req = Self::gzip(&req.encode_to_vec())?;
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -76,15 +76,12 @@ mod get_current_time_secs_tests {
     }
 }
 
-/// A representation of a time range. The time range is represented by a start
-/// time, an end time, a current time and remaining time in seconds. The
-/// remaining time is the duration in seconds until the end time.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TimeRange {
+    // unix time seconds
+    // todo remove comment, use types
     pub from: u64,
     pub until: u64,
-    pub current: u64,
-    pub rem: u64,
 }
 
 /// Return a range of timestamps in the form [start, end).
@@ -92,15 +89,13 @@ pub struct TimeRange {
 pub fn get_time_range(timestamp: u64) -> Result<TimeRange> {
     // if timestamp is 0, then get the current time
     if timestamp == 0 {
-        return get_time_range(get_current_time_secs()?);
+        return get_time_range(get_current_time_secs()?); //todo remove this
     }
 
     // Determine the start and end of the range
     Ok(TimeRange {
         from: timestamp / 10 * 10,
         until: timestamp / 10 * 10 + 10,
-        current: timestamp,
-        rem: 10 - (timestamp % 10),
     })
 }
 
@@ -115,8 +110,6 @@ mod get_time_range_tests {
             TimeRange {
                 from: 1644194470,
                 until: 1644194480,
-                current: 1644194479,
-                rem: 1,
             }
         );
         assert_eq!(
@@ -124,8 +117,6 @@ mod get_time_range_tests {
             TimeRange {
                 from: 1644194470,
                 until: 1644194480,
-                current: 1644194470,
-                rem: 10,
             }
         );
         assert_eq!(
@@ -133,8 +124,6 @@ mod get_time_range_tests {
             TimeRange {
                 from: 1644194470,
                 until: 1644194480,
-                current: 1644194476,
-                rem: 4,
             }
         );
     }


### PR DESCRIPTION
- pprof: decouple string table from PprofBuilder to allow separate string interning.
- pprof: make module reusable
- remove `PyroscopeConfig.func` - it is only used in ruby
- Session: accept `Vec<ReportBatch>` instead of `ReportBatch` - allowing sending both cpu and memory profile as one request.
- Session: accept `TimeRange` instead of `from` and `until`

Depends on https://github.com/grafana/pyroscope-python/pull/86