### PR TITLE
build: build Linux wheels per Python minor version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,12 @@ jobs:
 
       - name: Check wheel tags
         run: |
-          whl=$(ls dist/*.whl)
-          echo "Wheel: $whl"
-          unzip -p "$whl" '*.dist-info/WHEEL'
-          unzip -p "$whl" '*.dist-info/WHEEL' | grep -qE 'Tag:.*(manylinux|musllinux)' || { echo "ERROR: expected manylinux or musllinux tag not found"; exit 1; }
+          set -euxo pipefail
+          for whl in dist/*.whl; do
+              echo "Wheel: $whl"
+              unzip -p "$whl" '*.dist-info/WHEEL'
+              unzip -p "$whl" '*.dist-info/WHEEL' | grep -qE 'Tag:.*(manylinux|musllinux)' || { echo "ERROR: expected manylinux or musllinux tag not found"; exit 1; }
+          done
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -117,7 +119,7 @@ jobs:
             --network=host \
             -v ${{ github.workspace }}:/pyroscope-python \
             python:${{ matrix.PYTHON_VERSION }}-${{ matrix.image-suffix }} \
-            sh -c "pip install /pyroscope-python/python/*.whl && python /pyroscope-python/scripts/tests/test.py"
+            sh -c "pip install cffi && pip install --no-index --find-links /pyroscope-python/python pyroscope-io && python /pyroscope-python/scripts/tests/test.py"
 
   sdist-build:
     name: sdist

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ffi/python/header:
 
 .PHONY: ffi/python/cffi
 ffi/python/cffi:
-	python scripts/tests/compile_ffi.py
+	python3 scripts/tests/compile_ffi.py
 
 .PHONY: linux/amd64
 linux/amd64:
@@ -44,12 +44,12 @@ musllinux/arm64:
 
 .PHONY: mac/amd64
 mac/amd64:
-	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=x86_64-apple-darwin python -m build --wheel
+	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=x86_64-apple-darwin python3 -m build --wheel
 	wheel tags --platform-tag macosx_11_0_x86_64 --remove dist/*.whl
 
 .PHONY: mac/arm64
 mac/arm64:
-	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=aarch64-apple-darwin python -m build --wheel
+	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=aarch64-apple-darwin python3 -m build --wheel
 	wheel tags --platform-tag macosx_11_0_arm64 --remove dist/*.whl
 
 .PHONY: check/tag-version

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,5 +1,3 @@
-python/pyroscope/__pycache__/
-python/pyroscope_io.egg-info/
 build/
 dist/
 
@@ -16,4 +14,4 @@ flamegraph.svg
 perf.data
 perf.data.*
 /cpp/cmake-build-*/
-python/pyroscope_io.egg-info/
+/python/pyroscope_io.egg-info/

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -36,20 +36,17 @@ ENV PATH=/home/builder/.cargo/bin:$PATH
 
 WORKDIR /pyroscope-python
 
-RUN /opt/python/cp310-cp310/bin/python -m pip install --user build
-
 ADD --chown=builder:builder pyproject.toml \
     setup.py \
     ./
 
 ADD --chown=builder:builder rust/ rust/
 ADD --chown=builder:builder python/ python/
+ADD --chown=builder:builder docker/wheels.sh wheels.sh
 
 RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
     --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \
-    /opt/python/cp310-cp310/bin/python -m build --wheel
-
-RUN auditwheel repair dist/*.whl --wheel-dir dist-repaired/
+    bash wheels.sh
 
 FROM scratch
 COPY --from=builder  /pyroscope-python/dist-repaired dist/

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -36,20 +36,17 @@ ENV PATH=/home/builder/.cargo/bin:$PATH
 
 WORKDIR /pyroscope-python
 
-RUN /opt/python/cp310-cp310/bin/python -m pip install --user build
-
 ADD --chown=builder:builder pyproject.toml \
     setup.py \
     ./
 
 ADD --chown=builder:builder rust/ rust/
 ADD --chown=builder:builder python/ python/
+ADD --chown=builder:builder docker/wheels.sh wheels.sh
 
 RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
     --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \
-    /opt/python/cp310-cp310/bin/python -m build --wheel
-
-RUN auditwheel repair dist/*.whl --wheel-dir dist-repaired/
+    bash wheels.sh
 
 FROM scratch
 COPY --from=builder  /pyroscope-python/dist-repaired dist/

--- a/docker/wheels.sh
+++ b/docker/wheels.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+for PYBIN in /opt/python/cp{310,311,312,313,314}*/bin; do
+    rm -rf build/
+    "${PYBIN}/pip" install --user build
+    "${PYBIN}/python" -m build --wheel
+done
+
+auditwheel repair dist/*.whl --wheel-dir dist-repaired/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,6 @@ classifiers = [
 [tool.setuptools.packages]
 find = { where = ["python/"] }
 
-[tool.distutils.bdist_wheel]
-py_limited_api = "cp310"
-
-
 [build-system]
 requires = [
     "setuptools (>=82.0.0,<83.0.0)",

--- a/python/pyroscope/_native.py
+++ b/python/pyroscope/_native.py
@@ -1,8 +1,17 @@
 
 __all__ = ['lib', 'ffi']
 
+from importlib.machinery import EXTENSION_SUFFIXES
 import os
 from ._cffi import ffi
 
-lib = ffi.dlopen(os.path.join(os.path.dirname(__file__), '../pyroscope_python_extension', 'pyroscope_python_extension.abi3.so'))
-del os
+extension_dir = os.path.join(os.path.dirname(__file__), '../pyroscope_python_extension')
+for suffix in EXTENSION_SUFFIXES:
+    path = os.path.join(extension_dir, 'pyroscope_python_extension' + suffix)
+    if os.path.exists(path):
+        lib = ffi.dlopen(path)
+        break
+else:
+    raise ImportError(f'Could not find native pyroscope extension in {extension_dir}')
+
+del EXTENSION_SUFFIXES, extension_dir, os, path, suffix


### PR DESCRIPTION
## Summary
- Build Linux wheels for each supported CPython minor version instead of a single `cp310` limited-API wheel.
- Share the manylinux/musllinux wheel loop through `docker/wheels.sh` and update CI to validate/install from multiple wheel artifacts.
- Load the native extension by the current interpreter's extension suffix so non-ABI3 wheel imports work.

## Test plan
- `bash -n docker/wheels.sh`
- `python3 -m py_compile python/pyroscope/_native.py`
- `make linux/amd64`
- Inspect generated `dist/*.whl` WHEEL metadata for `cp310`, `cp311`, `cp312`, `cp313`, `cp314`, and `cp314t` manylinux tags.
- `docker run --rm --platform=linux/amd64 -v "$PWD/dist:/wheels:ro" python:3.11-slim sh -c "python -m pip install cffi && python -m pip install --no-index --find-links /wheels pyroscope-io && python -c 'import pyroscope'"`
- `make musllinux/amd64`
- Inspect generated `dist/*.whl` WHEEL metadata for musllinux tags.
- `docker run --rm --platform=linux/amd64 -v "$PWD/dist:/wheels:ro" python:3.12-alpine sh -c "python -m pip install cffi && python -m pip install --no-index --find-links /wheels pyroscope-io && python -c 'import pyroscope'"`