### PR TITLE
chore: upgrade Rust toolchain

### DIFF
--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -27,7 +27,7 @@ RUN adduser -D builder \
 USER builder
 RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
 
-ENV RUST_VERSION=1.96
+ENV RUST_VERSION=1.96.0
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
     && chmod +x /tmp/rustup-init \
     && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -27,7 +27,7 @@ RUN useradd -m builder \
 USER builder
 RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
 
-ENV RUST_VERSION=1.96
+ENV RUST_VERSION=1.96.0
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
     && chmod +x /tmp/rustup-init \
     && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu \

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.0.12" # x-release-please-version
 authors = [
     "Tolyan Korniltsev <anatoly.korniltsev@grafana.com>"
 ]
-edition = "2021"
-rust-version = "1.66"
+edition = "2024"
+rust-version = "1.96.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust/src/backend/ruleset.rs
+++ b/rust/src/backend/ruleset.rs
@@ -63,10 +63,10 @@ impl StackTrace {
 
         if let Ok(rules) = other.rules.lock() {
             rules.iter().for_each(|rule| {
-                if let Some(stack_thread_id) = &self.thread_id {
-                    if rule.tid == *stack_thread_id {
-                        metadata.add_tag(rule.tag.clone());
-                    }
+                if let Some(stack_thread_id) = &self.thread_id
+                    && rule.tid == *stack_thread_id
+                {
+                    metadata.add_tag(rule.tag.clone());
                 }
             })
         }

--- a/rust/src/backend/types.rs
+++ b/rust/src/backend/types.rs
@@ -1,7 +1,7 @@
 use super::BackendConfig;
 use crate::error::Result;
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
 };
 
@@ -202,22 +202,22 @@ impl StackTrace {
     ) -> Self {
         let mut metadata = Metadata::default();
 
-        if config.report_pid {
-            if let Some(pid) = pid {
-                metadata.add_tag(Tag::new("pid".to_owned(), pid.to_string()));
-            }
+        if config.report_pid
+            && let Some(pid) = pid
+        {
+            metadata.add_tag(Tag::new("pid".to_owned(), pid.to_string()));
         }
 
-        if config.report_thread_id {
-            if let Some(thread_id) = &thread_id {
-                metadata.add_tag(Tag::new("thread_id".to_owned(), thread_id.to_string()));
-            }
+        if config.report_thread_id
+            && let Some(thread_id) = &thread_id
+        {
+            metadata.add_tag(Tag::new("thread_id".to_owned(), thread_id.to_string()));
         }
 
-        if config.report_thread_name {
-            if let Some(thread_name) = thread_name.clone() {
-                metadata.add_tag(Tag::new("thread_name".to_owned(), thread_name));
-            }
+        if config.report_thread_name
+            && let Some(thread_name) = thread_name.clone()
+        {
+            metadata.add_tag(Tag::new("thread_name".to_owned(), thread_name));
         }
 
         Self {

--- a/rust/src/encode/mod.rs
+++ b/rust/src/encode/mod.rs
@@ -1,2 +1,2 @@
-pub mod gen;
+pub mod r#gen;
 pub mod pprof;

--- a/rust/src/encode/pprof.rs
+++ b/rust/src/encode/pprof.rs
@@ -1,6 +1,6 @@
-use crate::backend::types::Report;
 use crate::backend::StackTrace;
-use crate::encode::gen::google::{Function, Label, Line, Location, Profile, Sample, ValueType};
+use crate::backend::types::Report;
+use crate::encode::r#gen::google::{Function, Label, Line, Location, Profile, Sample, ValueType};
 use crate::encode::pprof::ffi::FFIInternedString;
 use crate::encode::pprof::ffi::{FFIFrame, FFIHeapSampleValues};
 use crate::utils::TimeRange;

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -4,8 +4,8 @@ use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
 use lazy_static::lazy_static;
 use std::sync::{
-    mpsc::{self, Receiver, Sender},
     Mutex,
+    mpsc::{self, Receiver, Sender},
 };
 
 #[derive(Debug, PartialEq, Clone)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -26,7 +26,7 @@ const LOG_TAG: &str = "Pyroscope::pyspy::ffi";
 const PYSPY_NAME: &str = "pyspy";
 const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn initialize_logging(logging_level: u32) -> bool {
     // Force rustc to display the log messages in the console.
     match logging_level {
@@ -55,7 +55,7 @@ pub extern "C" fn initialize_logging(logging_level: u32) -> bool {
     true
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// # Safety
 /// All pointer arguments must be valid, non-null, null-terminated C strings.
 pub unsafe extern "C" fn initialize_agent(
@@ -181,12 +181,12 @@ pub unsafe extern "C" fn initialize_agent(
     ffikit::run(PyroscopeAgentBuilder::new(agent_builder, pyspy)).is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn drop_agent() -> bool {
     ffikit::send(ffikit::Signal::Kill).is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// # Safety
 /// `key` and `value` must be valid, non-null, null-terminated C strings.
 pub unsafe extern "C" fn add_thread_tag(key: *const c_char, value: *const c_char) -> bool {
@@ -203,7 +203,7 @@ pub unsafe extern "C" fn add_thread_tag(key: *const c_char, value: *const c_char
     .is_ok()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// # Safety
 /// `key` and `value` must be valid, non-null, null-terminated C strings.
 pub unsafe extern "C" fn remove_thread_tag(key: *const c_char, value: *const c_char) -> bool {

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -2,19 +2,19 @@ use std::{
     collections::HashMap,
     marker::PhantomData,
     sync::{
-        mpsc::{self, Sender},
         Arc, Condvar, Mutex,
+        mpsc::{self, Sender},
     },
     thread::JoinHandle,
 };
 
 use crate::{
+    PyroscopeError,
     backend::{BackendReady, BackendUninitialized, Tag},
     error::Result,
     session::{Session, SessionManager, SessionSignal},
     timer::{Timer, TimerSignal},
     utils::get_time_range,
-    PyroscopeError,
 };
 
 use crate::backend::{BackendImpl, ThreadTag};

--- a/rust/src/pyspy_backend.rs
+++ b/rust/src/pyspy_backend.rs
@@ -9,8 +9,8 @@ use py_spy::sampler::Sampler;
 use std::{
     ops::Deref,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     thread::JoinHandle,
 };
@@ -285,7 +285,10 @@ mod tests {
             assert!(
                 !name.contains('/'),
                 "Function name '{}' should not contain '/' path separator! Input: func={}, file={}, module={:?}",
-                name, func_name, filename, module
+                name,
+                func_name,
+                filename,
+                module
             );
         }
     }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -1,18 +1,18 @@
 use std::{
     io::Write,
-    sync::mpsc::{sync_channel, Receiver, SyncSender},
+    sync::mpsc::{Receiver, SyncSender, sync_channel},
     thread::{self, JoinHandle},
     time::Duration,
 };
 
-use crate::encode::gen::push::{PushRequest, RawProfileSeries, RawSample};
-use crate::encode::gen::types::LabelPair;
+use crate::encode::r#gen::push::{PushRequest, RawProfileSeries, RawSample};
+use crate::encode::r#gen::types::LabelPair;
 use crate::utils::TimeRange;
 use crate::{
+    Result,
     backend::{ReportBatch, ReportData},
     encode::pprof,
     pyroscope::PyroscopeConfig,
-    Result,
 };
 use libflate::gzip::Encoder;
 use prost::Message;

--- a/rust/src/timer/epoll.rs
+++ b/rust/src/timer/epoll.rs
@@ -1,12 +1,12 @@
 use super::TimerSignal;
 use crate::{
-    utils::{check_err, get_time_range},
     PyroscopeError, Result,
+    utils::{check_err, get_time_range},
 };
 
 use std::sync::{
-    mpsc::{channel, Sender},
     Arc, Mutex,
+    mpsc::{Sender, channel},
 };
 use std::{
     thread::{self, JoinHandle},

--- a/rust/src/timer/epoll.rs
+++ b/rust/src/timer/epoll.rs
@@ -254,7 +254,7 @@ pub unsafe fn epoll_wait(
     maxevents: libc::c_int,
     timeout: libc::c_int,
 ) -> Result<()> {
-    check_err(libc::epoll_wait(epoll_fd, events, maxevents, timeout))?;
+    check_err(unsafe { libc::epoll_wait(epoll_fd, events, maxevents, timeout) })?;
     Ok(())
 }
 
@@ -263,6 +263,6 @@ pub unsafe fn epoll_wait(
 /// # Safety
 /// This function is a wrapper for libc::read.
 pub unsafe fn read(timer_fd: i32, bufptr: *mut libc::c_void, count: libc::size_t) -> Result<()> {
-    check_err(libc::read(timer_fd, bufptr, count))?;
+    check_err(unsafe { libc::read(timer_fd, bufptr, count) })?;
     Ok(())
 }

--- a/rust/src/timer/kqueue.rs
+++ b/rust/src/timer/kqueue.rs
@@ -1,12 +1,12 @@
 use super::TimerSignal;
 use crate::{
-    utils::{check_err, get_time_range},
     Result,
+    utils::{check_err, get_time_range},
 };
 
 use std::sync::{
-    mpsc::{channel, Receiver, Sender},
     Arc, Mutex,
+    mpsc::{Receiver, Sender, channel},
 };
 use std::{
     thread::{self, JoinHandle},

--- a/rust/src/timer/sleep.rs
+++ b/rust/src/timer/sleep.rs
@@ -1,10 +1,10 @@
 use super::TimerSignal;
-use crate::{utils::get_time_range, Result};
+use crate::{Result, utils::get_time_range};
 
 use std::{
     sync::{
-        mpsc::{channel, Receiver, Sender},
         Arc, Mutex,
+        mpsc::{Receiver, Sender, channel},
     },
     thread::{self, JoinHandle},
     time::Duration,

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{error::Result, PyroscopeError};
+use crate::{PyroscopeError, error::Result};
 
 /// Error Wrapper for libc return. Only check for errors.
 pub fn check_err<T: Ord + Default>(num: T) -> Result<T> {
@@ -101,7 +101,7 @@ pub fn get_time_range(timestamp: u64) -> Result<TimeRange> {
 
 #[cfg(test)]
 mod get_time_range_tests {
-    use crate::utils::{get_time_range, TimeRange};
+    use crate::utils::{TimeRange, get_time_range};
 
     #[test]
     fn get_time_range_verify() {


### PR DESCRIPTION
## Summary
- Upgrade the crate to Rust 2024 and declare Rust 1.96.0 as the MSRV.
- Align Docker wheel builds with the exact Rust 1.96.0 toolchain pin used by CI.
- Apply Rust 2024 compatibility updates for reserved module names, unsafe export attributes, rustfmt ordering, and current Clippy lints.

## Test plan
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- --deny warnings
- cargo test --locked