### PR TITLE
chore: remove add_tag/remove_tag from backend trait, rmove tag wrapper

### DIFF
--- a/rust/src/backend/backend.rs
+++ b/rust/src/backend/backend.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use super::{ReportBatch, ThreadTag};
+use super::ReportBatch;
 
 /// Backend Config
 #[derive(Debug, Copy, Clone, Default)]
@@ -24,8 +24,6 @@ pub trait Backend: Send {
     fn shutdown(self: Box<Self>) -> Result<()>;
     /// Generate profiling report
     fn report(&mut self) -> Result<ReportBatch>;
-    fn add_tag(&self, tag: ThreadTag) -> Result<()>;
-    fn remove_tag(&self, tag: ThreadTag) -> Result<()>;
 }
 
 /// Marker struct for Empty BackendImpl
@@ -93,23 +91,7 @@ impl BackendImpl<BackendUninitialized> {
     }
 }
 
-impl<S: BackendAccessible> BackendImpl<S> {
-    pub fn add_tag(&self, tag: ThreadTag) -> Result<()> {
-        self.backend
-            .lock()?
-            .as_ref()
-            .ok_or(PyroscopeError::BackendImpl)?
-            .add_tag(tag)
-    }
-
-    pub fn remove_tag(&self, rule: ThreadTag) -> Result<()> {
-        self.backend
-            .lock()?
-            .as_ref()
-            .ok_or(PyroscopeError::BackendImpl)?
-            .remove_tag(rule)
-    }
-}
+impl<S: BackendAccessible> BackendImpl<S> {}
 
 impl BackendImpl<BackendReady> {
     /// Shutdown the backend and destroy BackendImpl

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 pub use utils::ThreadId;
 pub mod ffikit;
 
-use crate::backend::{BackendConfig, BackendImpl, Tag};
+use crate::backend::{BackendConfig, BackendImpl, Tag, ThreadTagsSet};
 use crate::pyroscope::PyroscopeAgentBuilder;
 use crate::pyspy_backend::Pyspy;
 use std::ffi::CStr;
@@ -148,8 +148,13 @@ pub unsafe extern "C" fn initialize_agent(
 
     let tags_ref = tags_string.as_str();
     let tags = string_to_tags(tags_ref);
+    let dynamic_tags = ThreadTagsSet::new();
 
-    let pyspy = BackendImpl::new(Box::new(Pyspy::new(config, backend_config)));
+    let pyspy = BackendImpl::new(Box::new(Pyspy::new(
+        config,
+        backend_config,
+        dynamic_tags.clone(),
+    )));
 
     let mut agent_builder = pyroscope::PyroscopeConfig::new(
         server_address,
@@ -191,7 +196,12 @@ pub unsafe extern "C" fn initialize_agent(
     }
 
     // mem::start(&pyroscope_config.mem_config);
-    ffikit::run(PyroscopeAgentBuilder::new(agent_builder, pyspy)).is_ok()
+    ffikit::run(PyroscopeAgentBuilder::new(
+        agent_builder,
+        pyspy,
+        dynamic_tags,
+    ))
+    .is_ok()
 }
 
 #[unsafe(no_mangle)]

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::get_time_range,
 };
 
-use crate::backend::{BackendImpl, ThreadTag};
+use crate::backend::{BackendImpl, ThreadTag, ThreadTagsSet};
 
 const LOG_TAG: &str = "Pyroscope::Agent";
 #[derive(Clone)]
@@ -157,11 +157,20 @@ pub struct PyroscopeAgentBuilder {
     backend: BackendImpl<BackendUninitialized>,
     /// Configuration Object
     config: PyroscopeConfig,
+    ruleset: ThreadTagsSet,
 }
 
 impl PyroscopeAgentBuilder {
-    pub fn new(config: PyroscopeConfig, backend: BackendImpl<BackendUninitialized>) -> Self {
-        Self { backend, config }
+    pub fn new(
+        config: PyroscopeConfig,
+        backend: BackendImpl<BackendUninitialized>,
+        ruleset: ThreadTagsSet,
+    ) -> Self {
+        Self {
+            backend,
+            config,
+            ruleset,
+        }
     }
 
     pub fn build(self) -> Result<PyroscopeAgent<PyroscopeAgentReady>> {
@@ -198,6 +207,7 @@ impl PyroscopeAgentBuilder {
                 Condvar::new(),
             )),
             _state: PhantomData,
+            ruleset: self.ruleset,
         })
     }
 }
@@ -241,6 +251,8 @@ pub struct PyroscopeAgent<S: PyroscopeAgentState> {
     pub config: PyroscopeConfig,
     /// PyroscopeAgent State
     _state: PhantomData<S>,
+
+    ruleset: ThreadTagsSet,
 }
 
 impl<S: PyroscopeAgentState> PyroscopeAgent<S> {
@@ -255,6 +267,7 @@ impl<S: PyroscopeAgentState> PyroscopeAgent<S> {
             backend: self.backend,
             config: self.config,
             _state: PhantomData,
+            ruleset: self.ruleset,
         }
     }
 }
@@ -448,80 +461,11 @@ impl PyroscopeAgent<PyroscopeAgentRunning> {
         Ok(())
     }
 
-    /// Return a tuple of functions to add and remove tags to the agent across
-    /// thread boundaries. This function can be called multiple times.
-    ///
-    /// # Example
-    /// ```no_run
-    /// # use pyroscope::pyroscope::PyroscopeAgentBuilder;
-    /// # use pyroscope::backend::{pprof_backend, PprofConfig, BackendConfig};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let agent = PyroscopeAgentBuilder::new("http://localhost:4040", "my-app", 100, "pyroscope-rs", "0.1.0", pprof_backend(PprofConfig::default(), BackendConfig::default())).build()?;
-    /// # let agent_running = agent.start()?;
-    /// let (add_tag, remove_tag) = agent_running.tag_wrapper();
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// The functions can be later called from any thread.
-    ///
-    /// # Example
-    /// ```ignore
-    /// add_tag("key".to_string(), "value".to_string());
-    /// // some computation
-    /// remove_tag("key".to_string(), "value".to_string());
-    /// ```
-    #[allow(clippy::type_complexity)]
-    pub fn tag_wrapper(
-        &self,
-    ) -> (
-        impl Fn(String, String) -> Result<()>,
-        impl Fn(String, String) -> Result<()>,
-    ) {
-        let backend_add = self.backend.backend.clone();
-        let backend_remove = self.backend.backend.clone();
-
-        (
-            move |key, value| {
-                // https://github.com/tikv/pprof-rs/blob/01cff82dbe6fe110a707bf2b38d8ebb1d14a18f8/src/profiler.rs#L405
-                let thread_id = crate::utils::ThreadId::pthread_self();
-                let rule = ThreadTag::new(thread_id, Tag::new(key, value));
-                let backend = backend_add.lock()?;
-                backend
-                    .as_ref()
-                    .ok_or_else(|| {
-                        PyroscopeError::AdHoc(
-                            "PyroscopeAgent - Failed to unwrap backend".to_string(),
-                        )
-                    })?
-                    .add_tag(rule)?;
-
-                Ok(())
-            },
-            move |key, value| {
-                // https://github.com/tikv/pprof-rs/blob/01cff82dbe6fe110a707bf2b38d8ebb1d14a18f8/src/profiler.rs#L405
-                let thread_id = crate::utils::ThreadId::pthread_self();
-                let rule = ThreadTag::new(thread_id, Tag::new(key, value));
-                let backend = backend_remove.lock()?;
-                backend
-                    .as_ref()
-                    .ok_or_else(|| {
-                        PyroscopeError::AdHoc(
-                            "PyroscopeAgent - Failed to unwrap backend".to_string(),
-                        )
-                    })?
-                    .remove_tag(rule)?;
-
-                Ok(())
-            },
-        )
-    }
-
     /// Add a thread Tag rule to the backend Ruleset. For tagging, it's
     /// recommended to use the `tag_wrapper` function.
     pub fn add_thread_tag(&self, thread_id: crate::utils::ThreadId, tag: Tag) -> Result<()> {
         let rule = ThreadTag::new(thread_id, tag);
-        self.backend.add_tag(rule)?;
+        self.ruleset.add(rule)?;
 
         Ok(())
     }
@@ -530,7 +474,7 @@ impl PyroscopeAgent<PyroscopeAgentRunning> {
     /// recommended to use the `tag_wrapper` function.
     pub fn remove_thread_tag(&self, thread_id: crate::utils::ThreadId, tag: Tag) -> Result<()> {
         let rule = ThreadTag::new(thread_id, tag);
-        self.backend.remove_tag(rule)?;
+        self.ruleset.remove(rule)?;
 
         Ok(())
     }

--- a/rust/src/pyspy_backend.rs
+++ b/rust/src/pyspy_backend.rs
@@ -1,7 +1,7 @@
 use crate::{
     backend::{
         Backend, BackendConfig, Report, ReportBatch, ReportData, StackBuffer, StackFrame,
-        StackTrace, ThreadTag, ThreadTagsSet,
+        StackTrace, ThreadTagsSet,
     },
     error::{PyroscopeError, Result},
 };
@@ -33,31 +33,23 @@ impl std::fmt::Debug for Pyspy {
 }
 
 impl Pyspy {
-    pub fn new(config: py_spy::config::Config, backend_config: BackendConfig) -> Self {
+    pub fn new(
+        config: py_spy::config::Config,
+        backend_config: BackendConfig,
+        ruleset: ThreadTagsSet,
+    ) -> Self {
         Pyspy {
             buffer: Arc::new(Mutex::new(StackBuffer::default())),
             config,
             backend_config,
             sampler_thread: None,
             running: Arc::new(AtomicBool::new(false)),
-            ruleset: ThreadTagsSet::new(),
+            ruleset,
         }
     }
 }
 
 impl Backend for Pyspy {
-    fn add_tag(&self, rule: ThreadTag) -> Result<()> {
-        self.ruleset.add(rule)?;
-
-        Ok(())
-    }
-
-    fn remove_tag(&self, rule: ThreadTag) -> Result<()> {
-        self.ruleset.remove(rule)?;
-
-        Ok(())
-    }
-
     fn initialize(&mut self) -> Result<()> {
         if self.config.pid.is_none() {
             return Err(PyroscopeError::new("Pyspy: No Process ID Specified"));


### PR DESCRIPTION
- remove tag_wrapper as unused
- remove add_tag / remove_tag from backend trait
- pass a shared `ThreadTagsSet` as argument to both `Pyspy` and `Agent`. The `Agent` is responsible for writing/removing tags, `PySpy` is reading them