### PR TITLE
fix(ci): skip release PR after release merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,8 @@ jobs:
           token: ${{ steps.get-github-app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: >-
+            ${{ contains(github.event.head_commit.message, 'chore(main): release python') }}
 
   python-release-linux:
     permissions:


### PR DESCRIPTION
## Summary
- Skip release-please PR creation when the merged commit is a release PR commit.
- Keep release creation active for `chore(main): release python` pushes, matching the .NET SDK workflow pattern.

## Test plan
- `git diff --check -- .github/workflows/release-please.yml`
- `actionlint` unavailable locally; inspected YAML placement under the release-please action inputs.