### PR TITLE
chore: address review followups

### DIFF
--- a/rust/src/backend/backend.rs
+++ b/rust/src/backend/backend.rs
@@ -44,11 +44,6 @@ impl BackendState for BackendBare {}
 impl BackendState for BackendUninitialized {}
 impl BackendState for BackendReady {}
 
-/// Backend Accessibility Trait
-pub trait BackendAccessible: BackendState {}
-impl BackendAccessible for BackendUninitialized {}
-impl BackendAccessible for BackendReady {}
-
 /// Precursor Backend Implementation
 /// This struct is used to implement the Backend trait. It serves two purposes:
 /// 1. It enforces state transitions using the Type System.
@@ -90,8 +85,6 @@ impl BackendImpl<BackendUninitialized> {
         })
     }
 }
-
-impl<S: BackendAccessible> BackendImpl<S> {}
 
 impl BackendImpl<BackendReady> {
     /// Shutdown the backend and destroy BackendImpl

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -4,13 +4,6 @@ use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
 use std::sync::Mutex;
 
-#[derive(Debug, PartialEq, Clone)]
-pub enum Signal {
-    Kill,
-    AddThreadTag(ThreadId, Tag),
-    RemoveThreadTag(ThreadId, Tag),
-}
-
 static RUNNING_AGENT: Mutex<Option<PyroscopeAgent<PyroscopeAgentRunning>>> = Mutex::new(None);
 
 pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -461,8 +461,7 @@ impl PyroscopeAgent<PyroscopeAgentRunning> {
         Ok(())
     }
 
-    /// Add a thread Tag rule to the backend Ruleset. For tagging, it's
-    /// recommended to use the `tag_wrapper` function.
+    /// Add a thread Tag rule to the agent Ruleset.
     pub fn add_thread_tag(&self, thread_id: crate::utils::ThreadId, tag: Tag) -> Result<()> {
         let rule = ThreadTag::new(thread_id, tag);
         self.ruleset.add(rule)?;
@@ -470,8 +469,7 @@ impl PyroscopeAgent<PyroscopeAgentRunning> {
         Ok(())
     }
 
-    /// Remove a thread Tag rule from the backend Ruleset. For tagging, it's
-    /// recommended to use the `tag_wrapper` function.
+    /// Remove a thread Tag rule from the agent Ruleset.
     pub fn remove_thread_tag(&self, thread_id: crate::utils::ThreadId, tag: Tag) -> Result<()> {
         let rule = ThreadTag::new(thread_id, tag);
         self.ruleset.remove(rule)?;


### PR DESCRIPTION

- Remove leftover Rust cleanup artifacts called out in recent merged PR reviews.
- Drop stale `tag_wrapper` references from tag method docs after the wrapper was removed.

