### PR TITLE
fix: pass tags and headers as native PyO3 maps

### DIFF
--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -1,6 +1,5 @@
 import warnings
 import logging
-import json
 import sys
 from enum import Enum
 
@@ -60,9 +59,9 @@ def configure(
         report_thread_name,
         runtime_name(),
         runtime_version(),
-        tags_to_string(tags),
+        tags or {},
         tenant_id or "",
-        http_headers_to_json(http_headers),
+        http_headers or {},
         line_no.value
     )
 
@@ -80,11 +79,6 @@ def add_thread_tag(key, value):
 def remove_thread_tag(key, value):
     lib.remove_thread_tag(key, value)
 
-def tags_to_string(tags):
-    if tags is None:
-        return ""
-    return ",".join(["{}={}".format(key, value) for key, value in tags.items()])
-
 def runtime_name():
     return sys.implementation.name
 
@@ -93,11 +87,6 @@ def runtime_version():
     if vinfo.releaselevel == "final" and not vinfo.serial:
         vinfo = vinfo[:3]
     return ".".join(map(str, vinfo))
-
-def http_headers_to_json(headers):
-    if headers is None:
-        return "{}"
-    return json.dumps(headers)
 
 @contextmanager
 def tag_wrapper(tags):

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1278,7 +1278,6 @@ dependencies = [
  "py-spy",
  "pyo3",
  "reqwest",
- "serde_json",
  "thiserror",
  "url",
  "uuid",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,5 @@ uuid = { version = "1.20.0", features = ["v4"] }
 url = "2.2.2"
 libflate = "2.1.0"
 prost = "0.14"
-serde_json = "1.0.115"
 hashbrown = "0.17.1"
 pyo3 = { version = "0.29.0", features = ["extension-module"] }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -29,9 +29,6 @@ pub enum PyroscopeError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
-
     #[error("Agent not running")]
     AgentNotRunning,
     #[error("Agent already running")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,12 +16,13 @@ mod utils;
 pub use utils::ThreadId;
 pub mod ffikit;
 
+use std::collections::HashMap;
+
 use crate::backend::{BackendConfig, BackendImpl, Tag, ThreadTagsSet};
 use crate::pyroscope::PyroscopeAgentBuilder;
 use crate::pyspy_backend::Pyspy;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-const LOG_TAG: &str = "Pyroscope::pyspy::pyo3";
 
 const PYSPY_NAME: &str = "pyspy";
 const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -74,9 +75,9 @@ fn initialize_agent(
     report_thread_name: bool,
     runtime_name: String,
     runtime_version: String,
-    tags: String,
+    tags: HashMap<String, String>,
     tenant_id: String,
-    http_headers_json: String,
+    http_headers: HashMap<String, String>,
     line_no: u32,
 ) -> bool {
     let pid = std::process::id();
@@ -103,8 +104,6 @@ fn initialize_agent(
         ..py_spy::Config::default()
     };
 
-    let tags_ref = tags.as_str();
-    let tags = string_to_tags(tags_ref);
     let dynamic_tags = ThreadTagsSet::new();
 
     let pyspy = BackendImpl::new(Box::new(Pyspy::new(
@@ -135,22 +134,7 @@ fn initialize_agent(
     if !tenant_id.is_empty() {
         agent_builder = agent_builder.tenant_id(tenant_id);
     }
-
-    let http_headers = pyroscope::parse_http_headers_json(http_headers_json);
-    match http_headers {
-        Ok(http_headers) => {
-            agent_builder = agent_builder.http_headers(http_headers);
-        }
-        Err(e) => match e {
-            PyroscopeError::Json(e) => {
-                log::error!(target: LOG_TAG, "parse_http_headers_json error {}", e);
-            }
-            PyroscopeError::AdHoc(e) => {
-                log::error!(target: LOG_TAG, "parse_http_headers_json {}", e);
-            }
-            _ => {}
-        },
-    }
+    agent_builder = agent_builder.http_headers(http_headers);
 
     // mem::start(&pyroscope_config.mem_config);
     ffikit::run(PyroscopeAgentBuilder::new(
@@ -174,24 +158,6 @@ fn add_thread_tag(key: String, value: String) -> bool {
 #[pyfunction]
 fn remove_thread_tag(key: String, value: String) -> bool {
     ffikit::remove_thread_tag(self_thread_id(), Tag { key, value }).is_ok()
-}
-
-fn string_to_tags(tags: &str) -> Vec<(&str, &str)> {
-    let mut tags_vec = Vec::new();
-
-    // check if string is empty
-    if tags.is_empty() {
-        return tags_vec;
-    }
-
-    for tag in tags.split(',') {
-        let mut tag_split = tag.split('=');
-        let key = tag_split.next().unwrap();
-        let value = tag_split.next().unwrap();
-        tags_vec.push((key, value));
-    }
-
-    tags_vec
 }
 
 #[repr(C)]

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -90,27 +90,8 @@ impl PyroscopeConfig {
         }
     }
 
-    /// Set the tags.
-    ///
-    /// # Example
-    /// ```
-    /// use pyroscope::pyroscope::PyroscopeConfig;
-    /// let config = PyroscopeConfig::new("http://localhost:8080", "my-app", 100, "pyroscope-rs", "0.1.0")
-    ///    .tags(vec![("env", "dev")]);
-    /// ```
-    pub fn tags(self, tags: Vec<(&str, &str)>) -> Self {
-        // Convert &[(&str, &str)] to HashMap(String, String)
-        let tags_hashmap: HashMap<String, String> = tags
-            .to_owned()
-            .iter()
-            .cloned()
-            .map(|(a, b)| (a.to_owned(), b.to_owned()))
-            .collect();
-
-        Self {
-            tags: tags_hashmap,
-            ..self
-        }
+    pub fn tags(self, tags: HashMap<String, String>) -> Self {
+        Self { tags, ..self }
     }
 
     pub fn runtime(self, runtime_name: String, runtime_version: String) -> Self {
@@ -478,40 +459,4 @@ impl PyroscopeAgent<PyroscopeAgentRunning> {
 
         Ok(())
     }
-}
-
-pub fn parse_http_headers_json(http_headers_json: String) -> Result<HashMap<String, String>> {
-    let mut http_headers = HashMap::new();
-    let parsed: serde_json::Value = serde_json::from_str(&http_headers_json)?;
-    let parsed = parsed
-        .as_object()
-        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected object, got {parsed}")))?;
-    for (k, v) in parsed {
-        if let Some(value) = v.as_str() {
-            http_headers.insert(k.to_string(), value.to_string());
-        } else {
-            return Err(PyroscopeError::AdHoc(format!(
-                "invalid http header value, not a string: {v}"
-            )));
-        }
-    }
-    Ok(http_headers)
-}
-
-pub fn parse_vec_string_json(s: String) -> Result<Vec<String>> {
-    let parsed: serde_json::Value = serde_json::from_str(&s)?;
-    let parsed = parsed
-        .as_array()
-        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected array, got {parsed}")))?;
-    let mut res = Vec::with_capacity(parsed.len());
-    for v in parsed {
-        if let Some(s) = v.as_str() {
-            res.push(s.to_string());
-        } else {
-            return Err(PyroscopeError::AdHoc(format!(
-                "invalid element value, not a string: {v}"
-            )));
-        }
-    }
-    Ok(res)
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -246,11 +246,17 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn tags<const N: usize>(tags: [(&str, &str); N]) -> HashMap<String, String> {
+        tags.into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect()
+    }
+
     #[test]
     fn labels_for_profile_includes_scope_and_runtime_labels() {
         let config =
             PyroscopeConfig::new("http://localhost:4040", "my-app", 100, "pyspy", "1.0.12")
-                .tags(vec![("env", "prod")])
+                .tags(tags([("env", "prod")]))
                 .runtime("cpython".to_string(), "3.12.4".to_string());
 
         let labels = labels_for_profile(&config, "process_cpu".to_string());
@@ -296,7 +302,7 @@ mod tests {
     fn labels_for_profile_preserves_user_provided_semconv_labels() {
         let config =
             PyroscopeConfig::new("http://localhost:4040", "my-app", 100, "pyspy", "1.0.12")
-                .tags(vec![
+                .tags(tags([
                     (LABEL_SCOPE_NAME, "user-supplied-scope"),
                     (LABEL_SCOPE_VERSION, "user-supplied-scope-version"),
                     (LABEL_PROCESS_RUNTIME_NAME, "user-supplied-runtime"),
@@ -304,7 +310,7 @@ mod tests {
                         LABEL_PROCESS_RUNTIME_VERSION,
                         "user-supplied-runtime-version",
                     ),
-                ])
+                ]))
                 .runtime("cpython".to_string(), "3.12.4".to_string());
 
         let labels = labels_for_profile(&config, "process_cpu".to_string());
@@ -349,10 +355,10 @@ mod tests {
     fn labels_for_profile_uses_user_service_name_and_ignores_user_profile_name() {
         let config =
             PyroscopeConfig::new("http://localhost:4040", "my-app", 100, "pyspy", "1.0.12")
-                .tags(vec![
+                .tags(tags([
                     (LABEL_SERVICE_NAME, "user-service"),
                     (LABEL_PROFILE_NAME, "user-profile"),
-                ])
+                ]))
                 .runtime("cpython".to_string(), "3.12.4".to_string());
 
         let labels = labels_for_profile(&config, "process_cpu".to_string());


### PR DESCRIPTION

- Pass `tags` and `http_headers` from Python to Rust as native PyO3 maps instead of formatted strings/JSON.
- Simplify Rust config handling to accept `HashMap<String, String>` directly and remove obsolete JSON parsing/dependency code.