### PR TITLE
fix: expose LineNo as a native PyO3 enum

### DIFF
--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -1,7 +1,6 @@
 import warnings
 import logging
 import sys
-from enum import Enum
 
 from . import _native as lib
 
@@ -9,10 +8,7 @@ from contextlib import contextmanager
 
 LOGGER = logging.getLogger(__name__)
 
-class LineNo(Enum):
-    LastInstruction = lib.LastInstruction
-    First = lib.First
-    NoLine = lib.NoLine
+LineNo = lib.LineNo
 
 def configure(
         app_name=None,
@@ -62,7 +58,7 @@ def configure(
         tags or {},
         tenant_id or "",
         http_headers or {},
-        line_no.value
+        line_no
     )
 
 def shutdown():

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -26,10 +26,6 @@ use pyo3::wrap_pyfunction;
 const PYSPY_NAME: &str = "pyspy";
 const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const LAST_INSTRUCTION: u32 = LineNo::LastInstruction as u32;
-const FIRST: u32 = LineNo::First as u32;
-const NO_LINE: u32 = LineNo::NoLine as u32;
-
 #[pyfunction]
 fn initialize_logging(logging_level: u32) -> bool {
     // Force rustc to display the log messages in the console.
@@ -77,7 +73,7 @@ fn initialize_agent(
     tags: HashMap<String, String>,
     tenant_id: String,
     http_headers: HashMap<String, String>,
-    line_no: u32,
+    line_no: LineNo,
 ) -> bool {
     let pid = std::process::id();
 
@@ -98,7 +94,7 @@ fn initialize_agent(
         include_thread_ids: true,
         subprocesses: false,
         gil_only,
-        lineno: LineNo::from(line_no).into(),
+        lineno: line_no.into(),
         duration: py_spy::config::RecordDuration::Unlimited,
         ..py_spy::Config::default()
     };
@@ -159,22 +155,12 @@ fn remove_thread_tag(key: String, value: String) -> bool {
     ffikit::remove_thread_tag(self_thread_id(), Tag { key, value }).is_ok()
 }
 
-#[repr(C)]
-#[derive(Debug)]
+#[pyclass(eq, eq_int, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LineNo {
     LastInstruction = 0,
     First = 1,
     NoLine = 2,
-}
-
-impl From<u32> for LineNo {
-    fn from(val: u32) -> Self {
-        match val {
-            FIRST => LineNo::First,
-            NO_LINE => LineNo::NoLine,
-            _ => LineNo::LastInstruction,
-        }
-    }
 }
 
 impl From<LineNo> for py_spy::config::LineNo {
@@ -189,9 +175,7 @@ impl From<LineNo> for py_spy::config::LineNo {
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("LastInstruction", LAST_INSTRUCTION)?;
-    m.add("First", FIRST)?;
-    m.add("NoLine", NO_LINE)?;
+    m.add_class::<LineNo>()?;
     m.add_function(wrap_pyfunction!(initialize_logging, m)?)?;
     m.add_function(wrap_pyfunction!(initialize_agent, m)?)?;
     m.add_function(wrap_pyfunction!(drop_agent, m)?)?;


### PR DESCRIPTION
## Summary

- Make the Rust `LineNo` enum a `#[pyclass(eq, eq_int, from_py_object)]` and register it on the `_native` module, replacing the three `u32` constants (`LastInstruction`, `First`, `NoLine`).
- `initialize_agent` now takes `line_no: LineNo` directly instead of `u32`, removing the lossy `From<u32> for LineNo` conversion.
- The Python package re-exports `LineNo = lib.LineNo` instead of rebuilding a stdlib `enum.Enum` from int constants; the public API (`pyroscope.LineNo.LastInstruction` etc.) is unchanged.

## Test plan

- [x] `cargo check` passes
- [x] Built the extension locally and verified `pyroscope.LineNo` members import, compare equal to their previous int values (`eq_int`), and that passing a raw int to `initialize_agent` raises `TypeError`