### PR TITLE
Reset memory profiler state after fork

### DIFF
--- a/cpp/_memalloc.cpp
+++ b/cpp/_memalloc.cpp
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include "Pyroscope.h"
 #include "_memalloc_debug.h"
 #include "_memalloc_heap.h"
 #include "_memalloc_reentrant.h"
@@ -41,6 +42,25 @@ static bool memalloc_enabled = false;
 static bool memalloc_mem_installed = false;
 #endif // _PY312_AND_LATER
 static std::once_flag memalloc_fork_handler_once_flag;
+
+static void
+memalloc_atfork_prepare(void)
+{
+    pyroscope_memprof_atfork_prepare();
+}
+
+static void
+memalloc_atfork_parent(void)
+{
+    pyroscope_memprof_atfork_parent();
+}
+
+static void
+memalloc_atfork_child(void)
+{
+    memalloc_heap_postfork_child();
+    pyroscope_memprof_atfork_child();
+}
 
 /* Two-slot buffer for atomically publishing the saved (original) allocator.
  *
@@ -276,15 +296,16 @@ extern "C" void memalloc_start(    uint16_t max_nframe,
     // memalloc also has to clear its state after fork via below fork handler.
     // ddup_start();
 
-    // Register fork handler
-    // Mainly to clear the heap tracker state before running any Python code,
-    // otherwise it can lead to undefined behaviors and/or crashes, ref:
-    // incident-48649.
+    // Register fork handlers. The prepare/parent callbacks keep Rust's
+    // profile mutexes from being inherited while locked, and the child
+    // callback clears inherited heap and Rust profile state before running any
+    // Python code. Otherwise prefork workers can deadlock on inherited locks or
+    // continue with parent profile data, ref: incident-48649.
     // We use std::call_once as registered fork handlers persist after fork, and
     // we want to ensure that the fork handlers are registered only once per
     // process, even when the memory profiler is restarted after fork.
     std::call_once(memalloc_fork_handler_once_flag,
-                   []() { pthread_atfork(nullptr, nullptr, memalloc_heap_postfork_child); });
+                   []() { pthread_atfork(memalloc_atfork_prepare, memalloc_atfork_parent, memalloc_atfork_child); });
 
     char* val = getenv("_DD_MEMALLOC_DEBUG_RNG_SEED");
     if (val) {

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -23,6 +23,9 @@ include = [
   "FFIFrame",
   "FFIHeapSampleValues",
   "FFISample",
+  "pyroscope_memprof_atfork_prepare",
+  "pyroscope_memprof_atfork_parent",
+  "pyroscope_memprof_atfork_child",
   "pyroscope_memprof_string_table_intern_string",
   "pyroscope_memprof_push_sample",
 ]

--- a/rust/include/pyroscope_ffi.h
+++ b/rust/include/pyroscope_ffi.h
@@ -37,6 +37,12 @@ typedef struct {
   FFIHeapSampleValues values;
 } FFISample;
 
+void pyroscope_memprof_atfork_prepare(void);
+
+void pyroscope_memprof_atfork_parent(void);
+
+void pyroscope_memprof_atfork_child(void);
+
 FFIInternedString pyroscope_memprof_string_table_intern_string(FFIStringView s);
 
 void pyroscope_memprof_push_sample(FFISample sample);

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -183,4 +183,31 @@ mod implementation {
             _ => None,
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::ffi::c_char;
+
+        fn intern_string(s: &str) -> FFIInternedString {
+            pyroscope_memprof_string_table_intern_string(FFIStringView {
+                data: s.as_ptr() as *const c_char,
+                len: s.len(),
+            })
+        }
+
+        #[test]
+        fn atfork_child_resets_inherited_memory_profile_state() {
+            ensure_initialized();
+
+            let parent_string = intern_string("parent-only-string");
+            assert!(parent_string.index > 0);
+
+            pyroscope_memprof_atfork_prepare();
+            pyroscope_memprof_atfork_child();
+
+            let child_string = intern_string("child-only-string");
+            assert_eq!(child_string.index, 1);
+        }
+    }
 }

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -13,6 +13,7 @@ pub fn start(_py: Python<'_>, config: &Config) {
     if !config.enabled {
         return;
     }
+    implementation::ensure_initialized();
     unsafe {
         implementation::memalloc_start(
             config.max_nframe,
@@ -43,8 +44,9 @@ mod implementation {
     use crate::utils::TimeRange;
     use lazy_static::lazy_static;
     use pyo3::prelude::*;
+    use std::cell::UnsafeCell;
     use std::ops::{Deref, DerefMut};
-    use std::sync::Mutex;
+    use std::sync::{Mutex, MutexGuard};
 
     lazy_static! {
         static ref STRING_TABLE: Mutex<StringTable> = Mutex::new(StringTable::new());
@@ -53,11 +55,87 @@ mod implementation {
     lazy_static! {
         static ref PROFILE_BUILDER: Mutex<PProfBuilder> = Mutex::new(PProfBuilder::new());
     }
+
+    struct AtForkGuards {
+        string_table: Option<MutexGuard<'static, StringTable>>,
+        profile_builder: Option<MutexGuard<'static, PProfBuilder>>,
+    }
+
+    struct AtForkGuardStore(UnsafeCell<AtForkGuards>);
+
+    // pthread_atfork runs these callbacks around a single fork operation. The
+    // prepare callback stores guards here so the parent and child callbacks can
+    // release the same locks without exposing this state to regular profiler
+    // code.
+    unsafe impl Sync for AtForkGuardStore {}
+
+    static ATFORK_GUARDS: AtForkGuardStore = AtForkGuardStore(UnsafeCell::new(AtForkGuards {
+        string_table: None,
+        profile_builder: None,
+    }));
+
     unsafe extern "C" {
         pub fn memalloc_start(max_nframe: u16, heap_sample_size: u64, enable_mem_domain: bool);
         pub fn memalloc_stop();
         // flush heap inuse samples
         pub fn memalloc_heap_py();
+    }
+
+    pub fn ensure_initialized() {
+        lazy_static::initialize(&STRING_TABLE);
+        lazy_static::initialize(&PROFILE_BUILDER);
+    }
+
+    fn lock_unpoisoned<T>(mutex: &'static Mutex<T>) -> MutexGuard<'static, T> {
+        match mutex.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    unsafe fn atfork_guards_mut() -> &'static mut AtForkGuards {
+        unsafe { &mut *ATFORK_GUARDS.0.get() }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyroscope_memprof_atfork_prepare() {
+        let string_table = lock_unpoisoned(&STRING_TABLE);
+        let profile_builder = lock_unpoisoned(&PROFILE_BUILDER);
+
+        let guards = unsafe { atfork_guards_mut() };
+        debug_assert!(guards.string_table.is_none());
+        debug_assert!(guards.profile_builder.is_none());
+        guards.string_table = Some(string_table);
+        guards.profile_builder = Some(profile_builder);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyroscope_memprof_atfork_parent() {
+        let guards = unsafe { atfork_guards_mut() };
+        let profile_builder = guards.profile_builder.take();
+        let string_table = guards.string_table.take();
+        drop(profile_builder);
+        drop(string_table);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyroscope_memprof_atfork_child() {
+        let guards = unsafe { atfork_guards_mut() };
+        let mut profile_builder = guards.profile_builder.take();
+        let mut string_table = guards.string_table.take();
+
+        if let Some(guard) = profile_builder.as_mut() {
+            **guard = PProfBuilder::new();
+        }
+        if let Some(guard) = string_table.as_mut() {
+            **guard = StringTable::new();
+        }
+
+        PROFILE_BUILDER.clear_poison();
+        STRING_TABLE.clear_poison();
+
+        drop(profile_builder);
+        drop(string_table);
     }
 
     #[unsafe(no_mangle)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- register Rust memory profiler state with the existing memalloc at-fork handling
- lock Rust profile mutexes before fork, release them in the parent, and reset/unpoison them in the child
- clear inherited Rust profile contents alongside the C++ heap tracker for prefork workers
- add a targeted unit test covering the child reset behavior

## Verification
- `git diff --check`
- `cargo +stable fmt -- --check`
- `CC=/usr/bin/gcc CXX=/usr/bin/g++ RUSTFLAGS="-L native=/usr/lib/gcc/x86_64-linux-gnu/13" PYROSCOPE__Python3_ROOT_DIR="$(python3 -c 'import sys; print(sys.prefix)')" cargo +stable test --locked --all-features atfork_child_resets_inherited_memory_profile_state`
- `CC=/usr/bin/gcc CXX=/usr/bin/g++ RUSTFLAGS="-L native=/usr/lib/gcc/x86_64-linux-gnu/13" PYROSCOPE__Python3_ROOT_DIR="$(python3 -c 'import sys; print(sys.prefix)')" cargo +stable test --locked --all-features`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-769b498e-d809-4354-a902-ecdfac3a38ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-769b498e-d809-4354-a902-ecdfac3a38ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

