### PR TITLE
chore: warn when forking after profiler starts

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -45,7 +45,8 @@ fn warn_about_fork(py: Python<'_>) -> PyResult<()> {
     let message = CString::new(format!(
         "This process (pid={}) is running Pyroscope, use of fork() may lead to \
          deadlocks in the child. Forking after Pyroscope starts is unsupported; \
-         configure Pyroscope after forking or call pyroscope.shutdown() before forking.",
+         configure Pyroscope after forking or call pyroscope.shutdown() before forking. \
+         See https://github.com/grafana/pyroscope-python/issues/122 for details.",
         std::process::id()
     ))
     .expect("fork warning does not contain null bytes");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,16 +15,53 @@ mod utils;
 pub use utils::ThreadId;
 pub mod ffikit;
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::backend::{BackendConfig, BackendImpl, Tag, ThreadTagsSet};
 use crate::pyroscope::PyroscopeAgentBuilder;
 use crate::pyspy_backend::Pyspy;
+use pyo3::exceptions::PyDeprecationWarning;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
 
 const PYSPY_NAME: &str = "pyspy";
 const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+static AGENT_RUNNING: AtomicBool = AtomicBool::new(false);
+
+#[pyfunction]
+fn warn_about_fork(py: Python<'_>) -> PyResult<()> {
+    if !AGENT_RUNNING.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    // The native agent starts threads and is not safe to inherit across a fork.
+    // See https://github.com/grafana/pyroscope-python/issues/122.
+    let message = CString::new(format!(
+        "This process (pid={}) is running Pyroscope, use of fork() may lead to \
+         deadlocks in the child. Forking after Pyroscope starts is unsupported; \
+         configure Pyroscope after forking or call pyroscope.shutdown() before forking.",
+        std::process::id()
+    ))
+    .expect("fork warning does not contain null bytes");
+
+    PyErr::warn(py, &py.get_type::<PyDeprecationWarning>(), &message, 2)
+}
+
+fn register_fork_warning(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
+    let register_at_fork = py.import("os")?.getattr("register_at_fork")?;
+
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("after_in_parent", wrap_pyfunction!(warn_about_fork, m)?)?;
+    register_at_fork.call((), Some(&kwargs))?;
+    Ok(())
+}
 
 #[pyfunction]
 fn initialize_logging(logging_level: u32) -> bool {
@@ -132,17 +169,25 @@ fn initialize_agent(
     agent_builder = agent_builder.http_headers(http_headers);
 
     // mem::start(&pyroscope_config.mem_config);
-    ffikit::run(PyroscopeAgentBuilder::new(
+    let started = ffikit::run(PyroscopeAgentBuilder::new(
         agent_builder,
         pyspy,
         dynamic_tags,
     ))
-    .is_ok()
+    .is_ok();
+    if started {
+        AGENT_RUNNING.store(true, Ordering::Release);
+    }
+    started
 }
 
 #[pyfunction]
 fn drop_agent() -> bool {
-    ffikit::stop().is_ok()
+    let dropped = ffikit::stop().is_ok();
+    if dropped {
+        AGENT_RUNNING.store(false, Ordering::Release);
+    }
+    dropped
 }
 
 #[pyfunction]
@@ -181,6 +226,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(drop_agent, m)?)?;
     m.add_function(wrap_pyfunction!(add_thread_tag, m)?)?;
     m.add_function(wrap_pyfunction!(remove_thread_tag, m)?)?;
+    register_fork_warning(m)?;
     Ok(())
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
 use crate::backend::{BackendConfig, BackendImpl, Tag, ThreadTagsSet};
 use crate::pyroscope::PyroscopeAgentBuilder;
 use crate::pyspy_backend::Pyspy;
-use pyo3::exceptions::PyDeprecationWarning;
+use pyo3::exceptions::{PyDeprecationWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
@@ -49,7 +49,7 @@ fn warn_about_fork(py: Python<'_>) -> PyResult<()> {
          See https://github.com/grafana/pyroscope-python/issues/122 for details.",
         std::process::id()
     ))
-    .expect("fork warning does not contain null bytes");
+    .map_err(|error| PyValueError::new_err(error.to_string()))?;
 
     PyErr::warn(py, &py.get_type::<PyDeprecationWarning>(), &message, 2)
 }

--- a/scripts/tests/test_fork_warning.py
+++ b/scripts/tests/test_fork_warning.py
@@ -1,0 +1,48 @@
+import os
+import warnings
+
+import pyroscope
+
+
+WARNING_TEXT = "Forking after Pyroscope starts is unsupported"
+
+
+def fork_and_capture_pyroscope_warnings():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pid = os.fork()
+        if pid == 0:
+            os._exit(0)
+
+        _, status = os.waitpid(pid, 0)
+        if os.waitstatus_to_exitcode(status) != 0:
+            raise AssertionError(f"forked child exited with status {status}")
+
+    return [warning for warning in caught if WARNING_TEXT in str(warning.message)]
+
+
+def main():
+    if fork_and_capture_pyroscope_warnings():
+        raise AssertionError("Pyroscope warned before the agent was started")
+
+    pyroscope.configure(application_name="pyroscope.fork-warning-test")
+    try:
+        active_warnings = fork_and_capture_pyroscope_warnings()
+        if len(active_warnings) != 1:
+            raise AssertionError(
+                "expected exactly one Pyroscope fork warning while the agent "
+                f"was running, got {len(active_warnings)}"
+            )
+        if active_warnings[0].category is not DeprecationWarning:
+            raise AssertionError(
+                "expected the Pyroscope fork warning to be a DeprecationWarning"
+            )
+    finally:
+        pyroscope.shutdown()
+
+    if fork_and_capture_pyroscope_warnings():
+        raise AssertionError("Pyroscope warned after the agent was shut down")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This warns when CPython forks after the Pyroscope agent has started because inherited profiler state is not fork safe. The Rust extension registers a parent callback with os.register_at_fork and tracks lifecycle state atomically. A standalone script covers warning behavior before startup, while running, and after shutdown. The fork-safety context is documented in https://github.com/grafana/pyroscope-python/issues/122.