### PR TITLE
fix: leak profiler in child after fork

### DIFF
--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -42,7 +42,7 @@ def configure(
         log_level = LOGGER.getEffectiveLevel()
         lib.initialize_logging(log_level)
 
-    lib.initialize_agent(
+    return lib.initialize_agent(
         application_name,
         server_address,
         basic_auth_username,
@@ -68,6 +68,8 @@ def shutdown():
         LOGGER.info("Pyroscope Agent successfully shutdown")
     else:
         LOGGER.warning("Pyroscope Agent shutdown failed")
+
+    return drop
 
 def add_thread_tag(key, value):
     lib.add_thread_tag(key, value)

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -2,25 +2,67 @@ use crate::backend::Tag;
 use crate::error::{PyroscopeError, Result};
 use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
+use pyo3::Python;
+use std::ops::DerefMut;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
-static RUNNING_AGENT: Mutex<Option<PyroscopeAgent<PyroscopeAgentRunning>>> = Mutex::new(None);
+static STATE: AtomicPtr<Mutex<State>> = AtomicPtr::new(std::ptr::null_mut());
+
+struct State {
+    agent: Option<PyroscopeAgent<PyroscopeAgentRunning>>,
+}
+impl State {
+    fn new_static() -> *mut Mutex<State> {
+        Box::into_raw(Box::new(Mutex::new(State { agent: None })))
+    }
+}
+
+fn state_lock() -> &'static Mutex<State> {
+    unsafe {
+        let cur = STATE.load(Ordering::SeqCst);
+        if !cur.is_null() {
+            return &*cur;
+        }
+
+        let new = State::new_static();
+        let res = STATE.compare_exchange(
+            std::ptr::null_mut(),
+            new,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+        match res {
+            Ok(_) => &*new,
+            Err(old) => {
+                drop(Box::from_raw(new));
+                &*old
+            }
+        }
+    }
+}
+
+fn leak_state() {
+    // this runs post-fork in the child, the old agent must never be dropped there (its
+    // stop() joins threads that don't survive fork)
+    STATE.store(State::new_static(), Ordering::SeqCst)
+}
 
 pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {
-    let mut guard = RUNNING_AGENT.lock()?;
-    if (*guard).is_some() {
+    let mut guard = state_lock().lock()?;
+    if guard.agent.is_some() {
         return Err(PyroscopeError::AgentAlreadyRunning);
     }
 
     let agent = agent.build()?.start()?;
 
-    *guard = Some(agent);
+    guard.agent = Some(agent);
 
     Ok(())
 }
 
 pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &*RUNNING_AGENT.lock()? {
+    if let Some(agent) = &state_lock().lock()?.deref_mut().agent {
         agent.add_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -28,7 +70,7 @@ pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
 }
 
 pub fn remove_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &*RUNNING_AGENT.lock()? {
+    if let Some(agent) = &state_lock().lock()?.deref_mut().agent {
         agent.remove_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -36,9 +78,13 @@ pub fn remove_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
 }
 
 pub fn stop() -> Result<()> {
-    if let Some(agent) = RUNNING_AGENT.lock()?.take() {
+    if let Some(agent) = state_lock().lock()?.agent.take() {
         agent.stop()
     } else {
         Err(PyroscopeError::AgentNotRunning)
     }
+}
+
+pub fn at_fork_after_in_child(_py: Python<'_>) {
+    leak_state()
 }

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -4,7 +4,6 @@ use crate::forksafety::LeakableMutex;
 use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
 use pyo3::Python;
-use std::ops::DerefMut;
 
 static STATE: LeakableMutex<State> = LeakableMutex::new();
 
@@ -27,7 +26,7 @@ pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {
 }
 
 pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &STATE.mutex().lock()?.deref_mut().agent {
+    if let Some(agent) = &STATE.mutex().lock()?.agent {
         agent.add_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -35,7 +34,7 @@ pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
 }
 
 pub fn remove_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &STATE.mutex().lock()?.deref_mut().agent {
+    if let Some(agent) = &STATE.mutex().lock()?.agent {
         agent.remove_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -1,55 +1,20 @@
 use crate::backend::Tag;
 use crate::error::{PyroscopeError, Result};
+use crate::forksafety::LeakableMutex;
 use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
 use pyo3::Python;
 use std::ops::DerefMut;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
-static STATE: AtomicPtr<Mutex<State>> = AtomicPtr::new(std::ptr::null_mut());
+static STATE: LeakableMutex<State> = LeakableMutex::new();
 
+#[derive(Default)]
 struct State {
     agent: Option<PyroscopeAgent<PyroscopeAgentRunning>>,
 }
-impl State {
-    fn new_static() -> *mut Mutex<State> {
-        Box::into_raw(Box::new(Mutex::new(State { agent: None })))
-    }
-}
-
-fn state_lock() -> &'static Mutex<State> {
-    unsafe {
-        let cur = STATE.load(Ordering::SeqCst);
-        if !cur.is_null() {
-            return &*cur;
-        }
-
-        let new = State::new_static();
-        let res = STATE.compare_exchange(
-            std::ptr::null_mut(),
-            new,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        );
-        match res {
-            Ok(_) => &*new,
-            Err(old) => {
-                drop(Box::from_raw(new));
-                &*old
-            }
-        }
-    }
-}
-
-fn leak_state() {
-    // this runs post-fork in the child, the old agent must never be dropped there (its
-    // stop() joins threads that don't survive fork)
-    STATE.store(State::new_static(), Ordering::SeqCst)
-}
 
 pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {
-    let mut guard = state_lock().lock()?;
+    let mut guard = STATE.mutex().lock()?;
     if guard.agent.is_some() {
         return Err(PyroscopeError::AgentAlreadyRunning);
     }
@@ -62,7 +27,7 @@ pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {
 }
 
 pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &state_lock().lock()?.deref_mut().agent {
+    if let Some(agent) = &STATE.mutex().lock()?.deref_mut().agent {
         agent.add_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -70,7 +35,7 @@ pub fn add_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
 }
 
 pub fn remove_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
-    if let Some(agent) = &state_lock().lock()?.deref_mut().agent {
+    if let Some(agent) = &STATE.mutex().lock()?.deref_mut().agent {
         agent.remove_thread_tag(tid, tag)
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -78,7 +43,7 @@ pub fn remove_thread_tag(tid: ThreadId, tag: Tag) -> Result<()> {
 }
 
 pub fn stop() -> Result<()> {
-    if let Some(agent) = state_lock().lock()?.agent.take() {
+    if let Some(agent) = STATE.mutex().lock()?.agent.take() {
         agent.stop()
     } else {
         Err(PyroscopeError::AgentNotRunning)
@@ -86,5 +51,8 @@ pub fn stop() -> Result<()> {
 }
 
 pub fn at_fork_after_in_child(_py: Python<'_>) {
-    leak_state()
+    // Here we intentionally leak the whole running agent.
+    // This runs post-fork in the child, the old agent must never be dropped there (its
+    // stop() joins threads that don't survive fork)
+    STATE.leak_and_reset();
 }

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -1,11 +1,11 @@
 use crate::backend::Tag;
 use crate::error::{PyroscopeError, Result};
-use crate::forksafety::LeakableMutex;
+use crate::forksafety;
 use crate::pyroscope::{PyroscopeAgentBuilder, PyroscopeAgentRunning};
 use crate::{PyroscopeAgent, ThreadId};
 use pyo3::Python;
 
-static STATE: LeakableMutex<State> = LeakableMutex::new();
+static STATE: forksafety::LeakableMutex<State> = forksafety::LeakableMutex::new();
 
 #[derive(Default)]
 struct State {

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -1,0 +1,45 @@
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+pub struct LeakableMutex<T> {
+    state: AtomicPtr<Mutex<T>>,
+}
+impl<T: Default> LeakableMutex<T> {
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicPtr::new(std::ptr::null_mut()),
+        }
+    }
+
+    pub fn mutex(&self) -> &Mutex<T> {
+        unsafe {
+            let cur = self.state.load(Ordering::SeqCst);
+            if !cur.is_null() {
+                return &*cur;
+            }
+
+            let new = Self::new_static();
+            let res = self.state.compare_exchange(
+                std::ptr::null_mut(),
+                new,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+            match res {
+                Ok(_) => &*new,
+                Err(old) => {
+                    drop(Box::from_raw(new));
+                    &*old
+                }
+            }
+        }
+    }
+
+    pub fn leak_and_reset(&self) {
+        self.state.store(Self::new_static(), Ordering::SeqCst)
+    }
+
+    fn new_static() -> *mut Mutex<T> {
+        Box::into_raw(Box::new(Mutex::new(T::default())))
+    }
+}

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -1,16 +1,67 @@
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
+/// A lazily-initialized global mutex whose contents can be abandoned
+/// (leaked) and replaced with a fresh default value.
+///
+/// # Why it exists
+///
+/// This type solves a fork-safety problem. After `fork()`, only the calling
+/// thread survives in the child process, but the child inherits a copy of the
+/// parent's memory, including global state such as a running profiler agent
+/// and any mutexes guarding it. That inherited state is unusable in the
+/// child:
+///
+/// - a mutex held by another thread at fork time stays locked forever, so
+///   any attempt to lock it deadlocks;
+/// - dropping the guarded value may block on threads that don't exist in the
+///   child (e.g. the agent's `stop()` joins its worker threads).
+///
+/// The only safe way out is to never touch the inherited value again. In an
+/// `os.register_at_fork` "after in child" hook, [`leak_and_reset`] swaps in a
+/// brand-new mutex around `T::default()`, deliberately leaking the old
+/// allocation and everything inside it. The child then starts from a clean
+/// slate, and the parent's state is never dropped or unlocked in the child.
+///
+/// [`leak_and_reset`]: LeakableMutex::leak_and_reset
+///
+/// # How to use it
+///
+/// ```ignore
+/// static STATE: LeakableMutex<State> = LeakableMutex::new();
+///
+/// // Normal access from anywhere:
+/// let guard = STATE.mutex().lock()?;
+///
+/// // In the post-fork child hook (os.register_at_fork(after_in_child=...)):
+/// STATE.leak_and_reset();
+/// ```
+///
+/// Do not cache the `&Mutex<T>` returned by [`mutex`] across a potential
+/// fork: after `leak_and_reset` it points at the abandoned parent-era mutex.
+/// Always re-fetch it via `STATE.mutex()` at the point of use.
+///
+/// [`mutex`]: LeakableMutex::mutex
 pub struct LeakableMutex<T> {
     state: AtomicPtr<Mutex<T>>,
 }
 impl<T: Default> LeakableMutex<T> {
+    /// Creates an empty (uninitialized) `LeakableMutex`.
+    ///
+    /// `const`, so it can be used in a `static`. The inner mutex is allocated
+    /// lazily on the first call to [`mutex`](LeakableMutex::mutex).
     pub const fn new() -> Self {
         Self {
             state: AtomicPtr::new(std::ptr::null_mut()),
         }
     }
 
+    /// Returns the current inner mutex, allocating `Mutex::new(T::default())`
+    /// on first use.
+    ///
+    /// Call this at every point of use instead of caching the returned
+    /// reference, so that after [`leak_and_reset`](LeakableMutex::leak_and_reset)
+    /// you observe the fresh mutex rather than the abandoned one.
     pub fn mutex(&self) -> &Mutex<T> {
         unsafe {
             let cur = self.state.load(Ordering::SeqCst);
@@ -35,6 +86,17 @@ impl<T: Default> LeakableMutex<T> {
         }
     }
 
+    /// Abandons the current mutex and its contents, replacing them with a
+    /// fresh `Mutex::new(T::default())`.
+    ///
+    /// The old allocation is intentionally leaked: neither the mutex nor the
+    /// `T` inside it is dropped. This is the whole point — after `fork()` the
+    /// child must never unlock or drop state inherited from the parent.
+    ///
+    /// Intended to be called only from a post-fork child hook while the
+    /// process is effectively single-threaded. Callers racing with this from
+    /// other threads may still hold references to the old mutex, which stays
+    /// valid (it is leaked, not freed), but their updates will be lost.
     pub fn leak_and_reset(&self) {
         self.state.store(Self::new_static(), Ordering::SeqCst)
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -35,6 +35,17 @@ const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 static AGENT_RUNNING: AtomicBool = AtomicBool::new(false);
 
 #[pyfunction]
+fn at_fork_after_in_parent(py: Python<'_>) -> PyResult<()> {
+    warn_about_fork(py)
+}
+
+#[pyfunction]
+fn at_fork_after_in_child(py: Python<'_>) -> PyResult<()> {
+    ffikit::at_fork_after_in_child(py);
+    AGENT_RUNNING.store(false, Ordering::Release);
+    Ok(())
+}
+
 fn warn_about_fork(py: Python<'_>) -> PyResult<()> {
     if !AGENT_RUNNING.load(Ordering::Acquire) {
         return Ok(());
@@ -59,7 +70,14 @@ fn register_fork_warning(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let register_at_fork = py.import("os")?.getattr("register_at_fork")?;
 
     let kwargs = PyDict::new(py);
-    kwargs.set_item("after_in_parent", wrap_pyfunction!(warn_about_fork, m)?)?;
+    kwargs.set_item(
+        "after_in_parent",
+        wrap_pyfunction!(at_fork_after_in_parent, m)?,
+    )?;
+    kwargs.set_item(
+        "after_in_child",
+        wrap_pyfunction!(at_fork_after_in_child, m)?,
+    )?;
     register_at_fork.call((), Some(&kwargs))?;
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod session;
 mod utils;
 pub use utils::ThreadId;
 pub mod ffikit;
+mod forksafety;
 
 use std::{
     collections::HashMap,

--- a/scripts/tests/test_fork_warning.py
+++ b/scripts/tests/test_fork_warning.py
@@ -21,12 +21,33 @@ def fork_and_capture_pyroscope_warnings():
     return [warning for warning in caught if WARNING_TEXT in str(warning.message)]
 
 
+def fork_and_configure_in_child():
+    pid = os.fork()
+    if pid == 0:
+        exit_code = 1
+        try:
+            configured = pyroscope.configure(
+                application_name="pyroscope.fork-child-test"
+            )
+            if configured and pyroscope.shutdown():
+                exit_code = 0
+        finally:
+            os._exit(exit_code)
+
+    _, status = os.waitpid(pid, 0)
+    if os.waitstatus_to_exitcode(status) != 0:
+        raise AssertionError(
+            "child failed to configure a new Pyroscope agent after fork"
+        )
+
+
 def main():
     if fork_and_capture_pyroscope_warnings():
         raise AssertionError("Pyroscope warned before the agent was started")
 
     pyroscope.configure(application_name="pyroscope.fork-warning-test")
     try:
+        fork_and_configure_in_child()
         active_warnings = fork_and_capture_pyroscope_warnings()
         if len(active_warnings) != 1:
             raise AssertionError(


### PR DESCRIPTION
This PR attempts to improve the [fork safety situation](https://github.com/grafana/pyroscope-python/issues/122) a bit by leaking the whole running agent and all the associated resources in the child.

This change allows to reconfigure the agent in child, but does not prevent all deadlocks (there are mutexes in tokio, openssl, glibc dns resolver, stderr logging)