### PR TITLE
fix: support Python 3.14.5

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "py-spy"
 version = "0.4.2"
-source = "git+https://github.com/benfred/py-spy?rev=32080cc#32080cc0c22bc23938541dfa7dabb6090e40be14"
+source = "git+https://github.com/korniltsev-grafanista/py-spy?rev=4a905e80a1dacc907087d0ec829c622c970ca27e#4a905e80a1dacc907087d0ec829c622c970ca27e"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 name = "_native"
 
 [dependencies]
-py-spy = { git = "https://github.com/benfred/py-spy", rev = "32080cc", default-features = false }
+py-spy = { git = "https://github.com/korniltsev-grafanista/py-spy", rev = "4a905e80a1dacc907087d0ec829c622c970ca27e", default-features = false }
 pretty_env_logger = "0.5"
 log = "0.4"
 libc = "0.2"


### PR DESCRIPTION
## Summary

- patch the `py-spy` dependency to use korniltsev-grafanista/py-spy@4a905e80a1dacc907087d0ec829c622c970ca27e
- pick up the generated Python 3.14.5 bindings
- update `Cargo.lock` to pin the patched revision

## Testing

- `cargo test --locked`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features --locked -- --deny warnings`