### PR TITLE
ci: run fork warning test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,9 @@ jobs:
             --network=host \
             -v ${{ github.workspace }}:/pyroscope-python \
             python:${{ matrix.PYTHON_VERSION }}-${{ matrix.image-suffix }} \
-            sh -c "pip install --no-index --find-links /pyroscope-python/python pyroscope-io && python /pyroscope-python/scripts/tests/test.py"
+            sh -c "pip install --no-index --find-links /pyroscope-python/python pyroscope-io \
+              && python /pyroscope-python/scripts/tests/test.py \
+              && python /pyroscope-python/scripts/tests/test_fork_warning.py"
 
   sdist-build:
     name: sdist


### PR DESCRIPTION
Runs `scripts/tests/test_fork_warning.py` in the Linux wheel test job after installing the built wheel. This covers the fork behavior across the existing Python and Linux platform matrix.

Follow-up to #124.