### PR TITLE
feat: allow memory-only profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Uses [py-spy](https://github.com/benfred/py-spy) for stack sampling and the [pyr
 pip install pyroscope-io
 ```
 
+## Memory-only profiling
+
+CPU profiling is enabled by default. To collect memory profiles without
+starting the py-spy CPU sampler, disable it explicitly:
+
+```python
+import pyroscope
+
+pyroscope.configure(
+    application_name="my-service",
+    server_address="http://localhost:4040",
+    cpu_enabled=False,
+    mem_enabled=True,
+)
+```
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -10,22 +10,6 @@ Uses [py-spy](https://github.com/benfred/py-spy) for stack sampling and the [pyr
 pip install pyroscope-io
 ```
 
-## Memory-only profiling
-
-CPU profiling is enabled by default. To collect memory profiles without
-starting the py-spy CPU sampler, disable it explicitly:
-
-```python
-import pyroscope
-
-pyroscope.configure(
-    application_name="my-service",
-    server_address="http://localhost:4040",
-    cpu_enabled=False,
-    mem_enabled=True,
-)
-```
-
 ## License
 
 Apache-2.0

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -94,6 +94,10 @@ func testPythonMemoryProfiler(t *testing.T) {
 			return true
 		}, 3*time.Minute, 5*time.Second, "expected memhog samples in %s", profile.name)
 	}
+
+	collapsed, err := queryProfile(pyroscopeURL, cpuProfileTypeID, labelSelector)
+	require.NoError(t, err)
+	require.Equal(t, "", collapsed)
 }
 
 func testPythonConcurrentConfigureShutdown(t *testing.T) {

--- a/integration-test/testdata/memory_workload.py
+++ b/integration-test/testdata/memory_workload.py
@@ -35,6 +35,7 @@ def main():
         application_name=os.environ["PYROSCOPE_APPLICATION_NAME"],
         server_address=os.environ["PYROSCOPE_SERVER_ADDRESS"],
         enable_logging=True,
+        cpu_enabled=False,
         mem_enabled=True,
         tags={
             "canary": os.environ["CANARY"],

--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -42,6 +42,9 @@ def configure(
     if native is not None:
         warnings.warn("native is deprecated and not supported", DeprecationWarning)
 
+    if not cpu_enabled and not mem_enabled:
+        raise ValueError("at least one of cpu_enabled or mem_enabled must be enabled")
+
     LOGGER.disabled = not enable_logging
     if enable_logging:
         log_level = LOGGER.getEffectiveLevel()

--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -42,9 +42,6 @@ def configure(
     if native is not None:
         warnings.warn("native is deprecated and not supported", DeprecationWarning)
 
-    if not cpu_enabled and not mem_enabled:
-        raise ValueError("at least one of cpu_enabled or mem_enabled must be enabled")
-
     LOGGER.disabled = not enable_logging
     if enable_logging:
         log_level = LOGGER.getEffectiveLevel()

--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -33,6 +33,7 @@ def configure(
         mem_max_nframe=128,
         mem_heap_sample_size=512 * 1024,
         mem_enable_mem_domain=True,
+        cpu_enabled=True,
 ):
     if app_name is not None:
         warnings.warn("app_name is deprecated, use application_name", DeprecationWarning)
@@ -68,6 +69,7 @@ def configure(
         mem_max_nframe,
         mem_heap_sample_size,
         mem_enable_mem_domain,
+        cpu_enabled,
     )
 
 def shutdown():

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -153,6 +153,14 @@ fn initialize_agent(
     mem_enable_mem_domain: bool,
     cpu_enabled: bool,
 ) -> bool {
+    if !cpu_enabled && !mem_enabled {
+        log::error!(
+            target: "pyroscope-python",
+            "at least one of CPU or memory profiling must be enabled"
+        );
+        return false;
+    }
+
     let backend_config = BackendConfig {
         report_thread_id,
         report_thread_name,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -151,21 +151,18 @@ fn initialize_agent(
     mem_max_nframe: u16,
     mem_heap_sample_size: u64,
     mem_enable_mem_domain: bool,
+    cpu_enabled: bool,
 ) -> bool {
-    let pid = std::process::id();
-
     let backend_config = BackendConfig {
         report_thread_id,
         report_thread_name,
         report_pid,
     };
 
-    let pid = pid.try_into().unwrap();
-
-    let config = py_spy::Config {
+    let pyspy_config = cpu_enabled.then(|| py_spy::Config {
         blocking: py_spy::config::LockingStrategy::NonBlocking,
         native: false,
-        pid: Some(pid),
+        pid: Some(std::process::id().try_into().unwrap()),
         sampling_rate: sample_rate.into(),
         include_idle: !oncpu,
         include_thread_ids: true,
@@ -174,7 +171,7 @@ fn initialize_agent(
         lineno: line_no.into(),
         duration: py_spy::config::RecordDuration::Unlimited,
         ..py_spy::Config::default()
-    };
+    });
 
     let dynamic_tags = ThreadTagsSet::new();
 
@@ -205,7 +202,7 @@ fn initialize_agent(
 
     let result = ffikit::run(
         py,
-        PyroscopeAgentBuilder::new(agent_builder, config, backend_config, dynamic_tags),
+        PyroscopeAgentBuilder::new(agent_builder, pyspy_config, backend_config, dynamic_tags),
     );
     match result {
         Ok(_) => {

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -28,6 +28,8 @@ pub struct PyroscopeConfig {
     pub tags: HashMap<String, String>,
     /// Sample Rate
     pub sample_rate: u32,
+    /// Whether CPU profiling is enabled
+    pub cpu_enabled: bool,
     /// Spy Name
     pub spy_name: String,
     /// Spy Version
@@ -64,6 +66,7 @@ impl PyroscopeConfig {
             application_name: application_name.as_ref().to_owned(),
             tags: HashMap::new(),
             sample_rate,
+            cpu_enabled: true,
             spy_name: spy_name.as_ref().to_owned(),
             spy_version: spy_version.as_ref().to_owned(),
             runtime_name: String::new(),
@@ -103,6 +106,13 @@ impl PyroscopeConfig {
         }
     }
 
+    pub fn cpu_enabled(self, cpu_enabled: bool) -> Self {
+        Self {
+            cpu_enabled,
+            ..self
+        }
+    }
+
     pub fn tenant_id(self, tenant_id: String) -> Self {
         Self {
             tenant_id: Some(tenant_id),
@@ -127,7 +137,7 @@ impl PyroscopeConfig {
 
 pub struct PyroscopeAgentBuilder {
     pub config: PyroscopeConfig,
-    pyspy_config: py_spy::config::Config,
+    pyspy_config: Option<py_spy::config::Config>,
     backend_config: BackendConfig,
     ruleset: ThreadTagsSet,
 }
@@ -135,7 +145,7 @@ pub struct PyroscopeAgentBuilder {
 impl PyroscopeAgentBuilder {
     pub fn new(
         config: PyroscopeConfig,
-        pyspy_config: py_spy::config::Config,
+        pyspy_config: Option<py_spy::config::Config>,
         backend_config: BackendConfig,
         ruleset: ThreadTagsSet,
     ) -> Self {
@@ -158,9 +168,13 @@ impl PyroscopeAgentBuilder {
         // todo!("implement")
         // }
 
-        let backend = Pyspy::new(self.pyspy_config, self.backend_config, self.ruleset.clone())?;
-
-        log::trace!(target: LOG_TAG, "Backend initialized");
+        let backend = self
+            .pyspy_config
+            .map(|config| Pyspy::new(config, self.backend_config, self.ruleset.clone()))
+            .transpose()?;
+        if backend.is_some() {
+            log::trace!(target: LOG_TAG, "Backend initialized");
+        }
 
         let session_manager = SessionManager::new(http_client);
         log::trace!(target: LOG_TAG, "SessionManager initialized");
@@ -205,7 +219,7 @@ pub struct PyroscopeAgent<S: PyroscopeAgentState> {
     /// Handle to the thread that runs the Pyroscope Agent
     handle: Option<JoinHandle<Result<()>>>,
     /// Profiler backend
-    pub backend: Pyspy,
+    pub backend: Option<Pyspy>,
     /// Configuration Object
     pub config: PyroscopeConfig,
     /// PyroscopeAgent State
@@ -233,9 +247,11 @@ impl<S: PyroscopeAgentState> PyroscopeAgent<S> {
     fn shutdown(mut self) {
         log::debug!(target: LOG_TAG, "PyroscopeAgent::drop()");
 
-        match self.backend.shutdown_thread() {
-            Ok(_) => log::debug!(target: LOG_TAG, "Backend shutdown"),
-            Err(e) => log::error!(target: LOG_TAG, "Backend shutdown error: {e}"),
+        if let Some(backend) = &mut self.backend {
+            match backend.shutdown_thread() {
+                Ok(_) => log::debug!(target: LOG_TAG, "Backend shutdown"),
+                Err(e) => log::error!(target: LOG_TAG, "Backend shutdown error: {e}"),
+            }
         }
 
         match self.session_manager.push(SessionSignal::Kill) {
@@ -261,7 +277,7 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
     pub fn start(mut self) -> Result<PyroscopeAgent<PyroscopeAgentRunning>> {
         log::debug!(target: LOG_TAG, "Starting");
 
-        let reporter = self.backend.reporter();
+        let reporter = self.backend.as_ref().map(Pyspy::reporter);
 
         let (tx, rx) = mpsc::channel();
         self.terminate_channel = Some(tx);
@@ -295,7 +311,7 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
     }
 
     fn snapshot(
-        reporter: &crate::pyspy_backend::Reporter,
+        reporter: &Option<crate::pyspy_backend::Reporter>,
         config: PyroscopeConfig,
         stx: &SyncSender<SessionSignal>,
         stop_watch: &mut StopWatch,
@@ -315,9 +331,10 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
         }
         log::trace!(target: LOG_TAG, "Sending session {:?}",  time_range);
 
-        let report = reporter.report()?;
-
-        batch.push(report);
+        if let Some(reporter) = reporter {
+            let report = reporter.report()?;
+            batch.push(report);
+        }
 
         // Send new Session to SessionManager
         stx.send(SessionSignal::Session(Box::new(Session::new(

--- a/scripts/tests/test_memory.py
+++ b/scripts/tests/test_memory.py
@@ -62,15 +62,12 @@ def main():
     canary = uuid.uuid4().hex
     logging.info('canary %s', canary)
 
-    try:
-        pyroscope.configure(
-            application_name=app_name,
-            cpu_enabled=False,
-            mem_enabled=False,
-        )
-    except ValueError:
-        pass
-    else:
+    if pyroscope.configure(
+        application_name=app_name,
+        enable_logging=True,
+        cpu_enabled=False,
+        mem_enabled=False,
+    ):
         raise AssertionError('configure accepted disabled CPU and memory profiling')
 
     pyroscope.configure(

--- a/scripts/tests/test_memory.py
+++ b/scripts/tests/test_memory.py
@@ -66,6 +66,7 @@ def main():
         application_name=app_name,
         server_address='http://localhost:4040',
         enable_logging=True,
+        cpu_enabled=False,
         mem_enabled=True,
         tags={
             'canary': canary,

--- a/scripts/tests/test_memory.py
+++ b/scripts/tests/test_memory.py
@@ -62,6 +62,17 @@ def main():
     canary = uuid.uuid4().hex
     logging.info('canary %s', canary)
 
+    try:
+        pyroscope.configure(
+            application_name=app_name,
+            cpu_enabled=False,
+            mem_enabled=False,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('configure accepted disabled CPU and memory profiling')
+
     pyroscope.configure(
         application_name=app_name,
         server_address='http://localhost:4040',


### PR DESCRIPTION
## Summary
- add a default-on `cpu_enabled` configuration option
- avoid starting the py-spy sampler and omit CPU reports when CPU profiling is disabled
- require at least one of CPU or memory profiling to be enabled
- exercise memory-only profiling with `cpu_enabled=False` and `mem_enabled=True`

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --locked`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --locked --all-targets -- -D warnings`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] Go integration packages compile
- [x] local Linux arm64 wheel against a Pyroscope container: alloc-space and in-use memory profiles present, CPU profile absent
- [ ] CI memory integration test confirms memory profiles are uploaded without CPU sampling