### PR TITLE
test: run library tests under Miri

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -78,3 +78,30 @@ jobs:
           export Python3_EXECUTABLE=$(python3 -c 'import sys; print(sys.executable)')
           cargo test --locked --all-features
         working-directory: rust
+
+  miri:
+    name: cargo miri
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: nightly-2026-07-11
+          components: miri, rust-src
+
+      - name: Run library tests under Miri
+        env:
+          # LeakableMutex deliberately leaks inherited state when it resets.
+          MIRIFLAGS: -Zmiri-ignore-leaks
+        run: cargo miri test --locked --lib --no-default-features
+        working-directory: rust
+
+      - name: Explore fork-safety thread schedules under Miri
+        env:
+          MIRIFLAGS: -Zmiri-ignore-leaks -Zmiri-many-seeds=0..16
+        run: cargo miri test --locked --lib --no-default-features forksafety::tests -- --test-threads=1
+        working-directory: rust

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -94,14 +94,5 @@ jobs:
           components: miri, rust-src
 
       - name: Run library tests under Miri
-        env:
-          # LeakableMutex deliberately leaks inherited state when it resets.
-          MIRIFLAGS: -Zmiri-ignore-leaks
         run: cargo miri test --locked --lib --no-default-features
-        working-directory: rust
-
-      - name: Explore fork-safety thread schedules under Miri
-        env:
-          MIRIFLAGS: -Zmiri-ignore-leaks -Zmiri-many-seeds=0..16
-        run: cargo miri test --locked --lib --no-default-features forksafety::tests -- --test-threads=1
         working-directory: rust

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
@@ -44,6 +45,9 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 /// [`mutex`]: LeakableMutex::mutex
 pub struct LeakableMutex<T> {
     state: AtomicPtr<Mutex<T>>,
+    // AtomicPtr does not inherit T's Send/Sync bounds. Model ownership of the
+    // guarded value so LeakableMutex has the same auto-traits as Mutex<T>.
+    _marker: PhantomData<Mutex<T>>,
 }
 impl<T: Default> LeakableMutex<T> {
     /// Creates an empty (uninitialized) `LeakableMutex`.
@@ -53,6 +57,7 @@ impl<T: Default> LeakableMutex<T> {
     pub const fn new() -> Self {
         Self {
             state: AtomicPtr::new(std::ptr::null_mut()),
+            _marker: PhantomData,
         }
     }
 
@@ -103,5 +108,66 @@ impl<T: Default> LeakableMutex<T> {
 
     fn new_static() -> *mut Mutex<T> {
         Box::into_raw(Box::new(Mutex::new(T::default())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LeakableMutex;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn initializes_lazily_once() {
+        let state = LeakableMutex::<usize>::new();
+
+        assert_eq!(*state.mutex().lock().unwrap(), 0);
+        *state.mutex().lock().unwrap() = 42;
+        assert_eq!(*state.mutex().lock().unwrap(), 42);
+    }
+
+    #[test]
+    fn concurrent_initialization_uses_one_mutex() {
+        const THREADS: usize = 4;
+
+        let state = Arc::new(LeakableMutex::<usize>::new());
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+
+        for _ in 0..THREADS {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                *state.mutex().lock().unwrap() += 1;
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(*state.mutex().lock().unwrap(), THREADS);
+    }
+
+    #[test]
+    fn reset_preserves_old_reference_and_uses_fresh_default() {
+        let state = LeakableMutex::<usize>::new();
+        let old = state.mutex();
+        *old.lock().unwrap() = 42;
+
+        state.leak_and_reset();
+
+        let new = state.mutex();
+        assert!(!std::ptr::eq(old, new));
+        assert_eq!(*new.lock().unwrap(), 0);
+        assert_eq!(*old.lock().unwrap(), 42);
+    }
+
+    #[test]
+    fn is_send_and_sync_for_send_values() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<LeakableMutex<usize>>();
     }
 }

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
@@ -45,9 +44,6 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 /// [`mutex`]: LeakableMutex::mutex
 pub struct LeakableMutex<T> {
     state: AtomicPtr<Mutex<T>>,
-    // AtomicPtr does not inherit T's Send/Sync bounds. Model ownership of the
-    // guarded value so LeakableMutex has the same auto-traits as Mutex<T>.
-    _marker: PhantomData<Mutex<T>>,
 }
 impl<T: Default> LeakableMutex<T> {
     /// Creates an empty (uninitialized) `LeakableMutex`.
@@ -57,7 +53,6 @@ impl<T: Default> LeakableMutex<T> {
     pub const fn new() -> Self {
         Self {
             state: AtomicPtr::new(std::ptr::null_mut()),
-            _marker: PhantomData,
         }
     }
 
@@ -108,66 +103,5 @@ impl<T: Default> LeakableMutex<T> {
 
     fn new_static() -> *mut Mutex<T> {
         Box::into_raw(Box::new(Mutex::new(T::default())))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::LeakableMutex;
-    use std::sync::{Arc, Barrier};
-    use std::thread;
-
-    #[test]
-    fn initializes_lazily_once() {
-        let state = LeakableMutex::<usize>::new();
-
-        assert_eq!(*state.mutex().lock().unwrap(), 0);
-        *state.mutex().lock().unwrap() = 42;
-        assert_eq!(*state.mutex().lock().unwrap(), 42);
-    }
-
-    #[test]
-    fn concurrent_initialization_uses_one_mutex() {
-        const THREADS: usize = 4;
-
-        let state = Arc::new(LeakableMutex::<usize>::new());
-        let barrier = Arc::new(Barrier::new(THREADS));
-        let mut handles = Vec::with_capacity(THREADS);
-
-        for _ in 0..THREADS {
-            let state = Arc::clone(&state);
-            let barrier = Arc::clone(&barrier);
-            handles.push(thread::spawn(move || {
-                barrier.wait();
-                *state.mutex().lock().unwrap() += 1;
-            }));
-        }
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-
-        assert_eq!(*state.mutex().lock().unwrap(), THREADS);
-    }
-
-    #[test]
-    fn reset_preserves_old_reference_and_uses_fresh_default() {
-        let state = LeakableMutex::<usize>::new();
-        let old = state.mutex();
-        *old.lock().unwrap() = 42;
-
-        state.leak_and_reset();
-
-        let new = state.mutex();
-        assert!(!std::ptr::eq(old, new));
-        assert_eq!(*new.lock().unwrap(), 0);
-        assert_eq!(*old.lock().unwrap(), 42);
-    }
-
-    #[test]
-    fn is_send_and_sync_for_send_values() {
-        fn assert_send_sync<T: Send + Sync>() {}
-
-        assert_send_sync::<LeakableMutex<usize>>();
     }
 }


### PR DESCRIPTION
## Summary
- add a Linux x64 CI job using pinned nightly-2026-07-11 with Miri
- run the existing no-default-features Rust library tests under Miri
- keep leak detection enabled and leave the stable Rust jobs unchanged

## Test plan
- [x] `cargo +nightly-2026-07-11 miri test --locked --lib --no-default-features` (25 passed)