### PR TITLE
chore(ci): test native build configurations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,6 @@ flamegraph.svg
 perf.data
 perf.data.*
 /cpp/cmake-build-*/
+/docker/test.Dockerfile
 /python/pyroscope_io.egg-info/
+/python/pyroscope_python_extension/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,85 @@ jobs:
           PYTHON_IMAGE_SUFFIX: ${{ matrix.image-suffix }}
           PYROSCOPE_WHEEL_TARGET: ${{ matrix.wheel-target }}
 
+  python-linux-configuration-test:
+    name: Python Linux Configuration Test - ${{ matrix.configuration }}
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [debug, release, asan, tsan]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: stable
+          cache-dependency-path: integration-test/go.mod
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Reduce ASLR entropy for TSan
+        if: matrix.configuration == 'tsan'
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
+
+      - name: Build test image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --file docker/test.Dockerfile \
+            --build-arg BUILD_CONFIG=${{ matrix.configuration }} \
+            --cache-from type=gha,scope=python-native-${{ matrix.configuration }} \
+            --cache-to type=gha,mode=max,scope=python-native-${{ matrix.configuration }} \
+            --load \
+            --tag pyroscope-python-test:${{ matrix.configuration }} \
+            .
+
+      - name: Extract test wheel
+        run: |
+          set -euo pipefail
+          wheel_dir="${RUNNER_TEMP}/pyroscope-wheel-${{ matrix.configuration }}"
+          mkdir -p "${wheel_dir}"
+          container_id="$(docker create pyroscope-python-test:${{ matrix.configuration }})"
+          trap 'docker rm -f "${container_id}" >/dev/null' EXIT
+          docker cp "${container_id}:/wheels/." "${wheel_dir}/"
+          echo "PYROSCOPE_TEST_WHEEL_DIR=${wheel_dir}" >> "${GITHUB_ENV}"
+
+      - name: Run Rust unit tests
+        run: |
+          docker run --rm \
+            pyroscope-python-test:${{ matrix.configuration }} \
+            make test/unit/${{ matrix.configuration }} PYTHON=/usr/local/bin/python3
+
+      - name: Check extension linkage
+        run: |
+          docker run --rm \
+            pyroscope-python-test:${{ matrix.configuration }} \
+            sh -euc '
+              python3 -m pip install --no-index --find-links /wheels pyroscope-io
+              extension="$(python3 -c "import pyroscope._native as native; print(native.__file__)")"
+              if nm --defined-only "${extension}" | grep -Eq " (Py_Initialize|_PyRuntime)"; then
+                echo "CPython runtime symbols were bundled into ${extension}" >&2
+                exit 1
+              fi
+              case "${PYROSCOPE_SANITIZER:-}" in
+                address) nm -D --undefined-only "${extension}" | grep -q __asan_ ;;
+                thread) nm -D --undefined-only "${extension}" | grep -q __tsan_ ;;
+              esac
+            '
+
+      - name: Run integration tests
+        run: go test -v -timeout 40m -count=1 .
+        working-directory: integration-test
+        env:
+          PYTHON_IMAGE: pyroscope-python-test:${{ matrix.configuration }}
+          PYROSCOPE_WHEEL_DIR: ${{ env.PYROSCOPE_TEST_WHEEL_DIR }}
+          PYROSCOPE_WHEEL_PATTERN: "*.whl"
+          PYROSCOPE_WHEEL_TARGET: linux/amd64
+
   sdist-build:
     name: sdist
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 python/pyroscope/__pycache__/
+python/pyroscope_python_extension/
 python/pyroscope_io.egg-info/
 build/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,85 @@
+.PHONY: build/debug build/release build/asan build/tsan
+.PHONY: test/unit/debug test/unit/release test/unit/asan test/unit/tsan
+
+PYTHON ?= python3
+RUST_NIGHTLY ?= nightly
+RUST_TARGET ?= $(shell rustc -vV | awk '/^host:/ { print $$2 }')
+
+.PHONY: build/debug
+build/debug:
+	SETUPTOOLS_RUST_CARGO_PROFILE=dev \
+		$(PYTHON) -m pip install -e . --no-build-isolation
+
+.PHONY: build/release
+build/release:
+	SETUPTOOLS_RUST_CARGO_PROFILE=release \
+		$(PYTHON) -m pip install -e . --no-build-isolation
+
+.PHONY: build/asan
+build/asan:
+	CC=clang CXX=clang++ \
+		RUSTUP_TOOLCHAIN=$(RUST_NIGHTLY) \
+		CARGO_BUILD_TARGET=$(RUST_TARGET) \
+		RUSTFLAGS="-Zsanitizer=address -Zexternal-clangrt -Cforce-frame-pointers=yes" \
+		PYROSCOPE_SANITIZER=address \
+		SETUPTOOLS_RUST_CARGO_PROFILE=dev \
+		$(PYTHON) -m pip install -e . --no-build-isolation
+
+.PHONY: build/tsan
+build/tsan:
+	CC=clang CXX=clang++ \
+		RUSTUP_TOOLCHAIN=$(RUST_NIGHTLY) \
+		CARGO_BUILD_TARGET=$(RUST_TARGET) \
+		RUSTFLAGS="-Zsanitizer=thread -Zexternal-clangrt -Cforce-frame-pointers=yes" \
+		PYROSCOPE_SANITIZER=thread \
+		SETUPTOOLS_RUST_CARGO_PROFILE=dev \
+		$(PYTHON) -m pip install -e . --no-build-isolation
+
+define run_unit_tests
+	cd rust && \
+		export Python3_ROOT_DIR="$$($(PYTHON) -c 'import pathlib, sys; print(pathlib.Path(sys.base_prefix).resolve())')" && \
+		export Python3_EXECUTABLE="$$($(PYTHON) -c 'import sys; print(sys.executable)')" && \
+		cargo test --locked $(1) --no-default-features && \
+		cargo test --locked $(1) --all-features
+endef
+
+# An explicit Cargo target makes PyO3 treat this as a cross build and omit
+# libpython. The extension must keep that behavior, but the cargo test
+# executable itself needs the development interpreter's embed link flags.
+define run_sanitized_unit_tests
+	cd rust && \
+		unset LD_LIBRARY_PATH && \
+		python_link_flags="" && \
+		for flag in $$($(PYTHON)-config --ldflags --embed); do \
+			python_link_flags="$$python_link_flags -Clink-arg=$$flag"; \
+		done && \
+		export CC=clang CXX=clang++ && \
+		export RUSTUP_TOOLCHAIN="$(RUST_NIGHTLY)" && \
+		export CARGO_BUILD_TARGET="$(RUST_TARGET)" && \
+		export RUSTFLAGS="-Zsanitizer=$(1) -Cforce-frame-pointers=yes $$python_link_flags" && \
+		export PYROSCOPE_SANITIZER="$(1)" && \
+		export Python3_ROOT_DIR="$$($(PYTHON) -c 'import pathlib, sys; print(pathlib.Path(sys.base_prefix).resolve())')" && \
+		export Python3_EXECUTABLE="$$($(PYTHON) -c 'import sys; print(sys.executable)')" && \
+		cargo test -Zbuild-std=std --target "$(RUST_TARGET)" --locked --no-default-features && \
+		cargo test -Zbuild-std=std --target "$(RUST_TARGET)" --locked --all-features
+endef
+
+.PHONY: test/unit/debug
+test/unit/debug:
+	$(call run_unit_tests,)
+
+.PHONY: test/unit/release
+test/unit/release:
+	$(call run_unit_tests,--release)
+
+.PHONY: test/unit/asan
+test/unit/asan:
+	$(call run_sanitized_unit_tests,address)
+
+.PHONY: test/unit/tsan
+test/unit/tsan:
+	$(call run_sanitized_unit_tests,thread)
+
 .PHONY: ffi/python/header
 ffi/python/header:
 	cd rust && cbindgen --config cbindgen.toml --output include/pyroscope_ffi.h

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -78,11 +78,10 @@ target_include_directories(
         ${CMAKE_CURRENT_SOURCE_DIR}/../rust/include
 )
 
-# Link libraries Python3::Python target might not exist in all build environments (e.g., manylinux) Python modules
-# should use -undefined dynamic_lookup on macOS and not link to libpython on Linux
-if (TARGET Python3::Python AND NOT APPLE)
-    target_link_libraries(${FULL_EXTENSION_NAME} PRIVATE Python3::Python)
-endif ()
+# Python extension modules resolve CPython symbols from the running
+# interpreter. Do not link Python3::Python here: when it is a static library,
+# BundleStaticLibrary.cmake would merge libpython.a into the extension along
+# with Abseil, producing a second copy of the CPython runtime.
 
 # Compile against absl::flat_hash_map (brings in include dirs and records absl as a link
 # dependency). Since this is a STATIC library, the absl object code is not archived in here;

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,0 +1,139 @@
+# syntax=docker/dockerfile:1.23@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG CPYTHON_VERSION=3.13.14
+ARG CPYTHON_SHA256=5ae535a36af0ebca6fca176ecb8197f5db9c1cb8c8f0cd12cdf1787046db1f41
+ARG RUST_VERSION=1.96.0
+ARG RUST_NIGHTLY=nightly-2026-06-15
+ARG RUST_TARGET=x86_64-unknown-linux-gnu
+ARG BUILD_CONFIG=debug
+
+FROM python:3.13-slim-trixie AS toolchain
+
+ARG RUST_VERSION
+ARG RUST_NIGHTLY
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        binutils \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        git \
+        libbz2-dev \
+        libclang-rt-dev \
+        libffi-dev \
+        liblzma-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        pkg-config \
+        tk-dev \
+        uuid-dev \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -fsS https://sh.rustup.rs -o /tmp/rustup-init.sh \
+    && sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain "${RUST_VERSION}" \
+    && rm /tmp/rustup-init.sh \
+    && /root/.cargo/bin/rustup toolchain install "${RUST_NIGHTLY}" --profile minimal --component rust-src
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+FROM toolchain AS cpython-source
+
+ARG CPYTHON_VERSION
+ARG CPYTHON_SHA256
+
+RUN curl --proto '=https' --tlsv1.2 -fsS \
+        "https://www.python.org/ftp/python/${CPYTHON_VERSION}/Python-${CPYTHON_VERSION}.tgz" \
+        -o /tmp/cpython.tgz \
+    && echo "${CPYTHON_SHA256}  /tmp/cpython.tgz" | sha256sum --check - \
+    && mkdir -p /opt/cpython-source \
+    && tar -xzf /tmp/cpython.tgz --strip-components=1 -C /opt/cpython-source \
+    && rm /tmp/cpython.tgz
+
+FROM cpython-source AS cpython-asan
+
+ENV ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:allocator_may_return_null=1:handle_segv=0"
+ENV PYTHONMALLOC=malloc
+
+RUN cd /opt/cpython-source \
+    && CC=clang CXX=clang++ ./configure \
+        --prefix=/opt/cpython \
+        --enable-shared \
+        --with-address-sanitizer \
+        --with-ensurepip=install \
+    && make -j"$(nproc)" \
+    && make install
+
+RUN ln -s /opt/cpython/bin/python3 /opt/cpython/bin/python
+
+ENV LD_LIBRARY_PATH="/opt/cpython/lib"
+ENV PATH="/opt/cpython/bin:${PATH}"
+
+FROM cpython-source AS cpython-tsan
+
+ENV TSAN_OPTIONS="halt_on_error=1:exitcode=66:handle_segv=0:suppressions=/opt/cpython-source/Tools/tsan/suppressions.txt"
+
+RUN cd /opt/cpython-source \
+    && CC=clang CXX=clang++ ./configure \
+        --prefix=/opt/cpython \
+        --enable-shared \
+        --disable-ipv6 \
+        --with-thread-sanitizer \
+        --with-ensurepip=install \
+    && make -j"$(nproc)" \
+    && make install
+
+RUN ln -s /opt/cpython/bin/python3 /opt/cpython/bin/python
+
+ENV LD_LIBRARY_PATH="/opt/cpython/lib"
+ENV PATH="/opt/cpython/bin:${PATH}"
+
+FROM toolchain AS configured-debug
+ENV SETUPTOOLS_RUST_CARGO_PROFILE=dev
+
+FROM toolchain AS configured-release
+ENV SETUPTOOLS_RUST_CARGO_PROFILE=release
+
+FROM cpython-asan AS configured-asan
+ARG RUST_NIGHTLY
+ARG RUST_TARGET
+ENV CC=clang
+ENV CXX=clang++
+ENV CARGO_BUILD_TARGET="${RUST_TARGET}"
+ENV PYROSCOPE_SANITIZER=address
+ENV RUSTFLAGS="-Zsanitizer=address -Zexternal-clangrt -Cforce-frame-pointers=yes"
+ENV RUST_NIGHTLY="${RUST_NIGHTLY}"
+ENV RUSTUP_TOOLCHAIN="${RUST_NIGHTLY}"
+ENV SETUPTOOLS_RUST_CARGO_PROFILE=dev
+
+FROM cpython-tsan AS configured-tsan
+ARG RUST_NIGHTLY
+ARG RUST_TARGET
+ENV CC=clang
+ENV CXX=clang++
+ENV CARGO_BUILD_TARGET="${RUST_TARGET}"
+ENV PYROSCOPE_SANITIZER=thread
+ENV RUSTFLAGS="-Zsanitizer=thread -Zexternal-clangrt -Cforce-frame-pointers=yes"
+ENV RUST_NIGHTLY="${RUST_NIGHTLY}"
+ENV RUSTUP_TOOLCHAIN="${RUST_NIGHTLY}"
+ENV SETUPTOOLS_RUST_CARGO_PROFILE=dev
+
+FROM configured-${BUILD_CONFIG} AS test
+
+WORKDIR /pyroscope-python
+COPY . .
+
+RUN python3 -m pip install --no-cache-dir \
+        build \
+        "setuptools==83.0.0" \
+        "setuptools-rust==1.12.0" \
+        wheel \
+    && mkdir -p /wheels \
+    && python3 -m build --wheel --no-isolation --outdir /wheels
+
+CMD ["python3"]

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -1,0 +1,140 @@
+# Native build configurations and sanitizers
+
+The native extension is tested in four configurations on Linux x86_64:
+
+- `debug`: Cargo dev profile and CMake Debug
+- `release`: Cargo release profile and CMake Release
+- `asan`: debug profile instrumented with AddressSanitizer
+- `tsan`: debug profile instrumented with ThreadSanitizer
+
+Sanitized builds are test artifacts and must never be published. The regular
+wheel compatibility matrix remains responsible for release-wheel coverage
+across supported Python versions, architectures, and libc implementations.
+
+## Why sanitized CPython is required
+
+The Rust extension, C++ memory profiler, Abseil, and CPython must use one
+sanitizer runtime:
+
+- TSan needs CPython instrumentation to observe synchronization performed by
+  the interpreter.
+- ASan needs CPython instrumentation and `PYTHONMALLOC=malloc` to observe
+  allocations that would otherwise stay inside pymalloc arenas.
+- The extension is built with Rust's `-Zexternal-clangrt`, so its sanitizer
+  symbols resolve from the runtime loaded by CPython at process startup.
+
+The extension intentionally does not link `libpython`. Linking a static
+sanitized `libpython.a` would bundle a second CPython runtime into the
+extension and invalidate the test.
+
+TSan's standard `--with-thread-sanitizer` configure option requires CPython
+3.13 or newer. CI uses a pinned CPython 3.13 release for both sanitizers.
+
+## Local native builds
+
+Debug and release builds can use a regular Python environment:
+
+```sh
+python3 -m pip install build setuptools setuptools-rust wheel
+make build/debug
+make test/unit/debug
+
+make build/release
+make test/unit/release
+```
+
+Sanitizer builds require Linux x86_64, Clang, CMake, and a nightly Rust
+toolchain with `rust-src`. Build CPython with the matching sanitizer and
+prefer a shared `libpython`, which makes the Clang runtime available to loaded
+extensions:
+
+```sh
+# AddressSanitizer
+CC=clang CXX=clang++ ./configure \
+  --prefix="$HOME/cpython-asan" \
+  --enable-shared \
+  --with-address-sanitizer
+make -j"$(nproc)"
+make install
+
+# ThreadSanitizer (CPython 3.13+)
+CC=clang CXX=clang++ ./configure \
+  --prefix="$HOME/cpython-tsan" \
+  --enable-shared \
+  --with-thread-sanitizer
+make -j"$(nproc)"
+make install
+```
+
+Create a virtual environment from that interpreter, install the Python build
+requirements, and select the same Rust nightly used by the build:
+
+```sh
+rustup toolchain install nightly --profile minimal --component rust-src
+
+export LD_LIBRARY_PATH="$HOME/cpython-asan/lib"
+~/cpython-asan/bin/python3 -m venv ~/venv-asan
+. ~/venv-asan/bin/activate
+python -m pip install build setuptools setuptools-rust wheel
+make build/asan
+make test/unit/asan PYTHON=/usr/bin/python3
+```
+
+Use `build/tsan` with the TSan interpreter, then run `test/unit/tsan` with a
+normal development Python through the `PYTHON` override shown above. Override
+`RUST_NIGHTLY` and `RUST_TARGET` when a non-default nightly or target is
+required.
+
+The unit-test sanitizer executable owns Rust's sanitizer runtime, so unit tests
+should use a normal development Python through `PYTHON=/path/to/python3`.
+The extension itself must be imported only by the matching sanitized Python.
+
+## Runtime options
+
+Recommended fail-fast settings are:
+
+```sh
+ASAN_OPTIONS="detect_leaks=0:halt_on_error=1:allocator_may_return_null=1:handle_segv=0"
+PYTHONMALLOC=malloc
+
+TSAN_OPTIONS="halt_on_error=1:exitcode=66:handle_segv=0:suppressions=/path/to/cpython/Tools/tsan/suppressions.txt"
+```
+
+Leak detection is disabled because CPython retains interpreter-level
+allocations at shutdown. Do not blanket-suppress reports containing CPython
+frames: races and memory errors crossing the extension/interpreter boundary
+are relevant.
+
+On Linux hosts with high ASLR entropy, TSan may fail to reserve its shadow
+address range. Match CPython CI before running TSan:
+
+```sh
+sudo sysctl -w vm.mmap_rnd_bits=28
+```
+
+## Reproducing the CI image
+
+The parameterized test image builds the correct interpreter, extension wheel,
+and toolchains:
+
+```sh
+docker buildx build \
+  --platform linux/amd64 \
+  --file docker/test.Dockerfile \
+  --build-arg BUILD_CONFIG=asan \
+  --load \
+  --tag pyroscope-python-test:asan \
+  .
+
+docker run --rm pyroscope-python-test:asan \
+  make test/unit/asan PYTHON=/usr/local/bin/python3
+```
+
+Valid `BUILD_CONFIG` values are `debug`, `release`, `asan`, and `tsan`. The CI
+workflow extracts `/wheels`, checks that CPython symbols were not bundled,
+verifies sanitizer references, and runs the complete Go integration suite
+using the same image.
+
+The focused sanitizer matrix is Linux x86_64 only. macOS and Linux arm64 are
+deferred until the initial lanes are stable; this is a current CI scope
+decision, not a claim that LLVM sanitizers cannot support those platforms.

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -320,6 +320,9 @@ func wheelDir() string {
 }
 
 func wheelPattern() string {
+	if pattern := os.Getenv("PYROSCOPE_WHEEL_PATTERN"); pattern != "" {
+		return pattern
+	}
 	target := wheelBuildTarget()
 	platform := "manylinux"
 	if strings.HasPrefix(target, "musllinux/") {

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -44,6 +44,28 @@ fn main() {
     cfg.define("Python3_EXECUTABLE", &python_executable);
     cfg.define("Python3_FIND_STRATEGY", "LOCATION");
 
+    println!("cargo:rerun-if-env-changed=PYROSCOPE_SANITIZER");
+    if let Ok(sanitizer) = env::var("PYROSCOPE_SANITIZER") {
+        let flag = match sanitizer.as_str() {
+            "address" => "-fsanitize=address",
+            "thread" => "-fsanitize=thread",
+            _ => panic!(
+                "PYROSCOPE_SANITIZER must be unset, 'address', or 'thread', got {sanitizer:?}"
+            ),
+        };
+
+        // Keep sanitizer configurations in distinct CMake trees. The cmake
+        // crate otherwise keys only on Cargo's profile, allowing stale native
+        // objects to be reused when switching sanitizers.
+        let out_dir =
+            PathBuf::from(env::var_os("OUT_DIR").unwrap()).join(format!("sanitizer-{sanitizer}"));
+        cfg.out_dir(out_dir);
+        cfg.cflag(flag);
+        cfg.cflag("-fno-omit-frame-pointer");
+        cfg.cxxflag(flag);
+        cfg.cxxflag("-fno-omit-frame-pointer");
+    }
+
     let dst = cfg.build();
 
     println!("cargo:rustc-link-search=native={}", dst.display());

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,24 @@ env.update({
     "Python3_EXECUTABLE": sys.executable,
 })
 
+sanitizer = os.environ.get("PYROSCOPE_SANITIZER")
+if sanitizer not in (None, "address", "thread"):
+    raise RuntimeError(
+        "PYROSCOPE_SANITIZER must be unset, 'address', or 'thread'"
+    )
+
+cargo_args = []
+if sanitizer:
+    if not os.environ.get("CARGO_BUILD_TARGET"):
+        raise RuntimeError(
+            "CARGO_BUILD_TARGET must be set for sanitizer builds so Rust "
+            "build scripts and host tools are not instrumented"
+        )
+    # Instrument std as well as the extension. This avoids false positives in
+    # synchronization primitives and requires nightly plus the rust-src
+    # component.
+    cargo_args.append("-Zbuild-std=std")
+
 features = []
 if sysconfig.get_config_var("Py_GIL_DISABLED") != 1:
     features.append("memory")
@@ -31,6 +49,7 @@ setup(
             "pyroscope._native",
             path="rust/Cargo.toml",
             binding=Binding.PyO3,
+            args=cargo_args,
             cargo_manifest_args=["--locked"],
             features=features,
             env=env,


### PR DESCRIPTION
## Summary
- add explicit debug, release, ASan, and TSan build/unit-test targets plus a reusable CPython 3.13 test image
- run Rust unit and Go integration coverage across the native configuration matrix while retaining the existing release-wheel compatibility matrix
- prevent static `libpython` bundling, verify sanitizer linkage in CI, and document local sanitizer workflows

## Test plan
- [x] Rust unit suites for debug, release, ASan, and TSan
- [x] debug, ASan, and TSan integration workloads
- [x] sanitizer wheel import and native symbol linkage checks
- [x] Go compilation, Rust formatting, workflow YAML validation, and Make target expansion