### PR TITLE
test: run integration tests natively on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,13 +182,17 @@ jobs:
         include:
           - target: x86_64-apple-darwin
             mk-arch: amd64
-            macos-version: "14"
+            runs-on: macos-15-intel
+            pyroscope-arch: amd64
+            pyroscope-sha256: ff380e029706f95262733d3b1225bf87059139176ae1ddcc17e93cd3d584c8a3
           - target: aarch64-apple-darwin
             mk-arch: arm64
-            macos-version: "14"
+            runs-on: macos-15
+            pyroscope-arch: arm64
+            pyroscope-sha256: 465f72bd963e7ad49e760af5fc174d73d9068b67f59da76196416a402fdf6827
 
     name: Python macOS - ${{ matrix.target }} - ${{ matrix.python-version }}
-    runs-on: macos-${{ matrix.macos-version }}
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -202,6 +206,10 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: stable
+          cache-dependency-path: integration-test/go.mod
 
       - run: python -m pip install build wheel
       - run: make mac/${{ matrix.mk-arch }}
@@ -214,6 +222,31 @@ jobs:
               unzip -p "$whl" '*.dist-info/WHEEL'
               unzip -p "$whl" '*.dist-info/WHEEL' | grep -qE 'Tag:.*macosx_11_0_' || { echo "ERROR: expected macosx_11_0 tag not found"; exit 1; }
           done
+
+      - name: Download Pyroscope
+        env:
+          PYROSCOPE_ARCH: ${{ matrix.pyroscope-arch }}
+          PYROSCOPE_SHA256: ${{ matrix.pyroscope-sha256 }}
+          PYROSCOPE_VERSION: "2.0.6"
+        run: |
+          set -euxo pipefail
+          archive="pyroscope_${PYROSCOPE_VERSION}_darwin_${PYROSCOPE_ARCH}.tar.gz"
+          url="https://github.com/grafana/pyroscope/releases/download/v${PYROSCOPE_VERSION}/${archive}"
+          mkdir -p "$RUNNER_TEMP/pyroscope"
+          curl --fail --location --silent --show-error --output "$RUNNER_TEMP/$archive" "$url"
+          echo "${PYROSCOPE_SHA256}  $RUNNER_TEMP/$archive" | shasum -a 256 --check
+          tar -xzf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP/pyroscope" pyroscope
+
+      - name: Run integration tests
+        run: make test
+        working-directory: integration-test
+        env:
+          PYROSCOPE_BINARY: ${{ runner.temp }}/pyroscope/pyroscope
+          PYROSCOPE_INTEGRATION_TEST_MODE: native
+          PYROSCOPE_PYTHON_BINARY: python
+          PYROSCOPE_WHEEL_DIR: ${{ github.workspace }}/dist
+          PYROSCOPE_WHEEL_TARGET: mac/${{ matrix.mk-arch }}
+          GO_TEST_TIMEOUT: 30m
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -3,10 +3,12 @@ ci-matrix:
 	@output="$$(go test -list . -json .)" && \
 		printf '%s\n' "$$output" | jq -sc '[.[] | select(.Action=="output") | .Output | rtrimstr("\n") | select(startswith("Test"))]'
 
+UNAME_SYSTEM := $(shell uname -s)
 UNAME_MACHINE := $(shell uname -m)
 WHEEL_ARCH := $(if $(filter arm64 aarch64,$(UNAME_MACHINE)),arm64,amd64)
-WHEEL_PLATFORM := $(if $(findstring alpine,$(PYTHON_IMAGE_SUFFIX)),musllinux,linux)
+WHEEL_PLATFORM := $(if $(filter Darwin,$(UNAME_SYSTEM)),mac,$(if $(findstring alpine,$(PYTHON_IMAGE_SUFFIX)),musllinux,linux))
 WHEEL_TARGET := $(or $(PYROSCOPE_WHEEL_TARGET),$(WHEEL_PLATFORM)/$(WHEEL_ARCH))
+GO_TEST_TIMEOUT ?= 20m
 
 .PHONY: wheel
 wheel:
@@ -18,4 +20,8 @@ wheel:
 
 .PHONY: test/%
 test/%: wheel
-	go test -v -timeout 20m -count=1 -run '^$*$$' .
+	go test -v -timeout $(GO_TEST_TIMEOUT) -count=1 -run '^$*$$' .
+
+.PHONY: test
+test: wheel
+	go test -v -timeout $(GO_TEST_TIMEOUT) -count=1 .

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 
 	"pyroscope-python-integration-test/api/querier"
 	"pyroscope-python-integration-test/dockertest"
+	"pyroscope-python-integration-test/processtest"
 	"pyroscope-python-integration-test/pyroscope/model"
 	"pyroscope-python-integration-test/require"
 )
@@ -29,6 +31,60 @@ const (
 type profileConfig struct {
 	onCPU   bool
 	gilOnly bool
+}
+
+type workloadState struct {
+	running  bool
+	exitCode int
+}
+
+type testWorkload interface {
+	stop(*testing.T, time.Duration)
+	wait(*testing.T, time.Duration) int
+	logs(*testing.T) string
+	state() (workloadState, error)
+}
+
+type containerWorkload struct {
+	container *dockertest.Container
+}
+
+func (w *containerWorkload) stop(t *testing.T, timeout time.Duration) {
+	w.container.Stop(t, timeout)
+}
+
+func (w *containerWorkload) wait(t *testing.T, timeout time.Duration) int {
+	return w.container.Wait(t, timeout)
+}
+
+func (w *containerWorkload) logs(t *testing.T) string {
+	return w.container.Logs(t)
+}
+
+func (w *containerWorkload) state() (workloadState, error) {
+	state, err := w.container.State()
+	return workloadState{running: state.Running, exitCode: state.ExitCode}, err
+}
+
+type processWorkload struct {
+	process *processtest.Process
+}
+
+func (w *processWorkload) stop(t *testing.T, timeout time.Duration) {
+	w.process.Stop(t, timeout)
+}
+
+func (w *processWorkload) wait(t *testing.T, timeout time.Duration) int {
+	return w.process.Wait(t, timeout)
+}
+
+func (w *processWorkload) logs(_ *testing.T) string {
+	return w.process.Logs()
+}
+
+func (w *processWorkload) state() (workloadState, error) {
+	state := w.process.State()
+	return workloadState{running: state.Running, exitCode: state.ExitCode}, nil
 }
 
 func TestPythonProfilerOnCPUWithGILOnly(t *testing.T) {
@@ -56,16 +112,16 @@ func TestPythonNonCPUIntegrationSuites(t *testing.T) {
 func testPythonMemoryProfiler(t *testing.T) {
 	wheelDir := ensureWheel(t)
 
-	net := dockertest.CreateNetwork(t)
+	net := createNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("pyroscopers.python.test.memory.%d", time.Now().UnixNano())
 	canary := randomHex(t, 16)
-	workload := startPythonTestContainer(t, net, wheelDir, "memory_workload.py", map[string]string{
+	workload := startPythonTest(t, net, pyroscopeURL, wheelDir, "memory_workload.py", map[string]string{
 		"PYROSCOPE_APPLICATION_NAME": appName,
 		"CANARY":                     canary,
 	})
 	t.Cleanup(func() {
-		workload.Stop(t, 30*time.Second)
+		workload.stop(t, 30*time.Second)
 	})
 
 	labelSelector := fmt.Sprintf(`{service_name="%s",canary="%s"}`, appName, canary)
@@ -99,40 +155,40 @@ func testPythonMemoryProfiler(t *testing.T) {
 func testPythonConcurrentConfigureShutdown(t *testing.T) {
 	wheelDir := ensureWheel(t)
 
-	net := dockertest.CreateNetwork(t)
-	startPyroscope(t, net)
+	net := createNetwork(t)
+	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("pyroscopers.python.test.concurrency.%d", time.Now().UnixNano())
-	workload := startPythonTestContainer(t, net, wheelDir, "concurrency_workload.py", map[string]string{
+	workload := startPythonTest(t, net, pyroscopeURL, wheelDir, "concurrency_workload.py", map[string]string{
 		"PYROSCOPE_APPLICATION_NAME": appName,
 	})
 
-	requireContainerExit(t, workload, 0, 3*time.Minute)
+	requireWorkloadExit(t, workload, 0, 3*time.Minute)
 }
 
 func testPythonAtexitShutdown(t *testing.T) {
 	wheelDir := ensureWheel(t)
 
-	net := dockertest.CreateNetwork(t)
-	startPyroscope(t, net)
+	net := createNetwork(t)
+	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("pyroscopers.python.test.atexit.%d", time.Now().UnixNano())
-	workload := startPythonTestContainer(t, net, wheelDir, "atexit_workload.py", map[string]string{
+	workload := startPythonTest(t, net, pyroscopeURL, wheelDir, "atexit_workload.py", map[string]string{
 		"PYROSCOPE_APPLICATION_NAME": appName,
 	})
 
-	requireContainerExit(t, workload, 0, 2*time.Minute)
+	requireWorkloadExit(t, workload, 0, 2*time.Minute)
 }
 
 func testPythonProfilerConfiguration(t *testing.T, cfg profileConfig) {
 	t.Helper()
 	wheelDir := ensureWheel(t)
 
-	net := dockertest.CreateNetwork(t)
+	net := createNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("pyroscopers.python.test.%d", time.Now().UnixNano())
 	canary := randomHex(t, 16)
-	workload := startWorkload(t, net, appName, canary, cfg, wheelDir)
+	workload := startWorkload(t, net, pyroscopeURL, appName, canary, cfg, wheelDir)
 	t.Cleanup(func() {
-		workload.Stop(t, 30*time.Second)
+		workload.stop(t, 30*time.Second)
 	})
 
 	labelSelector := fmt.Sprintf(
@@ -146,14 +202,14 @@ func testPythonProfilerConfiguration(t *testing.T, cfg profileConfig) {
 	var workloadExited bool
 	var workloadExitCode int
 	require.Eventually(t, func() bool {
-		state, err := workload.State()
+		state, err := workload.state()
 		if err != nil {
-			t.Logf("failed to inspect workload container: %v", err)
+			t.Logf("failed to inspect workload: %v", err)
 			return false
 		}
-		if !state.Running {
+		if !state.running {
 			workloadExited = true
-			workloadExitCode = state.ExitCode
+			workloadExitCode = state.exitCode
 			return true
 		}
 
@@ -173,12 +229,34 @@ func testPythonProfilerConfiguration(t *testing.T, cfg profileConfig) {
 		return true
 	}, 3*time.Minute, 5*time.Second, "expected multihash samples for %s", cfg)
 	if workloadExited {
-		t.Fatalf("workload container exited before producing the expected profile (exit code %d)", workloadExitCode)
+		t.Fatalf("workload exited before producing the expected profile (exit code %d)", workloadExitCode)
 	}
+}
+
+func createNetwork(t *testing.T) *dockertest.Network {
+	t.Helper()
+	if nativeMode() {
+		return nil
+	}
+	return dockertest.CreateNetwork(t)
 }
 
 func startPyroscope(t *testing.T, net *dockertest.Network) string {
 	t.Helper()
+	if nativeMode() {
+		httpPort := availablePort(t)
+		endpoint := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+		processtest.Start(t, processtest.Request{
+			Name: envOrDefault("PYROSCOPE_BINARY", "pyroscope"),
+			Args: []string{
+				fmt.Sprintf("-server.http-listen-port=%d", httpPort),
+			},
+			Dir:     t.TempDir(),
+			WaitURL: endpoint + "/ready",
+			Timeout: 2 * time.Minute,
+		})
+		return endpoint
+	}
 	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:          envOrDefault("PYROSCOPE_IMAGE", "grafana/pyroscope"),
 		ExposedPorts:   []string{"4040/tcp"},
@@ -189,22 +267,26 @@ func startPyroscope(t *testing.T, net *dockertest.Network) string {
 	return fmt.Sprintf("http://%s", c.HostPort(t, "4040/tcp"))
 }
 
-func startWorkload(t *testing.T, net *dockertest.Network, appName, canary string, cfg profileConfig, wheelDir string) *dockertest.Container {
+func startWorkload(t *testing.T, net *dockertest.Network, pyroscopeURL, appName, canary string, cfg profileConfig, wheelDir string) testWorkload {
 	t.Helper()
-	return dockertest.StartContainer(t, dockertest.ContainerRequest{
+	env := map[string]string{
+		"PYTHONUNBUFFERED":              "1",
+		"PYTHONDONTWRITEBYTECODE":       "1",
+		"PYROSCOPE_APPLICATION_NAME":    appName,
+		"PYROSCOPE_SERVER_ADDRESS":      workloadServerAddress(pyroscopeURL),
+		"ONCPU":                         boolString(cfg.onCPU),
+		"GIL_ONLY":                      boolString(cfg.gilOnly),
+		"CANARY":                        canary,
+		"PIP_DISABLE_PIP_VERSION_CHECK": "1",
+	}
+	if nativeMode() {
+		return startNativePython(t, wheelDir, "workload.py", env)
+	}
+	return &containerWorkload{container: dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:    pythonImage(),
 		Platform: wheelDockerPlatform(),
 		Network:  net.Name,
-		Env: map[string]string{
-			"PYTHONUNBUFFERED":              "1",
-			"PYTHONDONTWRITEBYTECODE":       "1",
-			"PYROSCOPE_APPLICATION_NAME":    appName,
-			"PYROSCOPE_SERVER_ADDRESS":      "http://pyroscope:4040",
-			"ONCPU":                         boolString(cfg.onCPU),
-			"GIL_ONLY":                      boolString(cfg.gilOnly),
-			"CANARY":                        canary,
-			"PIP_DISABLE_PIP_VERSION_CHECK": "1",
-		},
+		Env:      env,
 		Volumes: []string{
 			repoRoot() + ":/pyroscope-python:ro",
 			wheelDir + ":/pyroscope-wheels:ro",
@@ -214,21 +296,24 @@ func startWorkload(t *testing.T, net *dockertest.Network, appName, canary string
 			"-c",
 			"python -m pip install --no-cache-dir --no-index --find-links /pyroscope-wheels pyroscope-io && python /pyroscope-python/integration-test/testdata/workload.py",
 		},
-	})
+	})}
 }
 
-func startPythonTestContainer(t *testing.T, net *dockertest.Network, wheelDir, script string, env map[string]string) *dockertest.Container {
+func startPythonTest(t *testing.T, net *dockertest.Network, pyroscopeURL, wheelDir, script string, env map[string]string) testWorkload {
 	t.Helper()
 	mergedEnv := map[string]string{
 		"PYTHONUNBUFFERED":              "1",
 		"PYTHONDONTWRITEBYTECODE":       "1",
-		"PYROSCOPE_SERVER_ADDRESS":      "http://pyroscope:4040",
+		"PYROSCOPE_SERVER_ADDRESS":      workloadServerAddress(pyroscopeURL),
 		"PIP_DISABLE_PIP_VERSION_CHECK": "1",
 	}
 	for k, v := range env {
 		mergedEnv[k] = v
 	}
-	return dockertest.StartContainer(t, dockertest.ContainerRequest{
+	if nativeMode() {
+		return startNativePython(t, wheelDir, script, mergedEnv)
+	}
+	return &containerWorkload{container: dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:    pythonImage(),
 		Platform: wheelDockerPlatform(),
 		Network:  net.Name,
@@ -245,14 +330,44 @@ func startPythonTestContainer(t *testing.T, net *dockertest.Network, wheelDir, s
 				script,
 			),
 		},
-	})
+	})}
 }
 
-func requireContainerExit(t *testing.T, container *dockertest.Container, expected int, timeout time.Duration) {
+func startNativePython(t *testing.T, wheelDir, script string, env map[string]string) testWorkload {
 	t.Helper()
-	code := container.Wait(t, timeout)
+	venv := filepath.Join(t.TempDir(), "venv")
+	python := envOrDefault("PYROSCOPE_PYTHON_BINARY", "python3")
+	processtest.Run(t, python, "-m", "venv", venv)
+	venvPython := filepath.Join(venv, "bin", "python")
+	processtest.Run(
+		t,
+		venvPython,
+		"-m", "pip", "install",
+		"--no-cache-dir",
+		"--no-index",
+		"--find-links", wheelDir,
+		"pyroscope-io",
+	)
+	return &processWorkload{process: processtest.Start(t, processtest.Request{
+		Name: venvPython,
+		Args: []string{filepath.Join(repoRoot(), "integration-test", "testdata", script)},
+		Dir:  repoRoot(),
+		Env:  env,
+	})}
+}
+
+func workloadServerAddress(pyroscopeURL string) string {
+	if nativeMode() {
+		return pyroscopeURL
+	}
+	return "http://pyroscope:4040"
+}
+
+func requireWorkloadExit(t *testing.T, workload testWorkload, expected int, timeout time.Duration) {
+	t.Helper()
+	code := workload.wait(t, timeout)
 	if code != expected {
-		t.Fatalf("container exited with %d, expected %d\nlogs:\n%s", code, expected, container.Logs(t))
+		t.Fatalf("workload exited with %d, expected %d\nlogs:\n%s", code, expected, workload.logs(t))
 	}
 }
 
@@ -322,15 +437,25 @@ func wheelDir() string {
 func wheelPattern() string {
 	target := wheelBuildTarget()
 	platform := "manylinux"
-	if strings.HasPrefix(target, "musllinux/") {
+	arch := wheelArch(target)
+	switch {
+	case strings.HasPrefix(target, "musllinux/"):
 		platform = "musllinux"
+	case strings.HasPrefix(target, "mac/"):
+		platform = "macosx_11_0"
+		if arch == "aarch64" {
+			arch = "arm64"
+		}
 	}
-	return fmt.Sprintf("*%s*%s*.whl", platform, wheelArch(target))
+	return fmt.Sprintf("*%s*%s*.whl", platform, arch)
 }
 
 func wheelBuildTarget() string {
 	if target := os.Getenv("PYROSCOPE_WHEEL_TARGET"); target != "" {
 		return target
+	}
+	if runtime.GOOS == "darwin" {
+		return "mac/" + makeArch()
 	}
 	target := "linux"
 	if strings.Contains(pythonImageSuffix(), "alpine") {
@@ -389,6 +514,20 @@ func absPath(path string) string {
 		panic(err)
 	}
 	return absolute
+}
+
+func nativeMode() bool {
+	return os.Getenv("PYROSCOPE_INTEGRATION_TEST_MODE") == "native"
+}
+
+func availablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a local port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
 }
 
 func randomHex(t *testing.T, n int) string {

--- a/integration-test/processtest/processtest.go
+++ b/integration-test/processtest/processtest.go
@@ -1,0 +1,185 @@
+package processtest
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+)
+
+type State struct {
+	Running  bool
+	ExitCode int
+}
+
+type Request struct {
+	Name    string
+	Args    []string
+	Dir     string
+	Env     map[string]string
+	WaitURL string
+	Timeout time.Duration
+}
+
+type Process struct {
+	cmd  *exec.Cmd
+	logs lockedBuffer
+	done chan struct{}
+
+	mu       sync.RWMutex
+	running  bool
+	exitCode int
+}
+
+type lockedBuffer struct {
+	mu sync.RWMutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.b.String()
+}
+
+func Start(t *testing.T, req Request) *Process {
+	t.Helper()
+	if req.Name == "" {
+		t.Fatal("processtest: process name is required")
+	}
+
+	cmd := exec.Command(req.Name, req.Args...)
+	cmd.Dir = req.Dir
+	cmd.Env = os.Environ()
+	for key, value := range req.Env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+
+	p := &Process{
+		cmd:      cmd,
+		done:     make(chan struct{}),
+		running:  true,
+		exitCode: -1,
+	}
+	cmd.Stdout = &p.logs
+	cmd.Stderr = &p.logs
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("processtest: start %s: %v", req.Name, err)
+	}
+
+	go func() {
+		err := cmd.Wait()
+		exitCode := 0
+		if err != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		}
+		p.mu.Lock()
+		p.running = false
+		p.exitCode = exitCode
+		p.mu.Unlock()
+		close(p.done)
+	}()
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("processtest: %s logs:\n%s", req.Name, p.Logs())
+		}
+		p.stop(10 * time.Second)
+	})
+
+	if req.WaitURL != "" {
+		timeout := req.Timeout
+		if timeout == 0 {
+			timeout = 2 * time.Minute
+		}
+		p.waitHTTP(t, req.WaitURL, timeout)
+	}
+	return p
+}
+
+func (p *Process) State() State {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return State{Running: p.running, ExitCode: p.exitCode}
+}
+
+func (p *Process) Stop(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	p.stop(timeout)
+}
+
+func (p *Process) stop(timeout time.Duration) {
+	if !p.State().Running {
+		return
+	}
+	_ = p.cmd.Process.Signal(os.Interrupt)
+	select {
+	case <-p.done:
+		return
+	case <-time.After(timeout):
+	}
+	_ = p.cmd.Process.Kill()
+	<-p.done
+}
+
+func (p *Process) Wait(t *testing.T, timeout time.Duration) int {
+	t.Helper()
+	select {
+	case <-p.done:
+		return p.State().ExitCode
+	case <-time.After(timeout):
+		p.stop(5 * time.Second)
+		t.Fatalf("processtest: process did not exit after %v\nlogs:\n%s", timeout, p.Logs())
+		return -1
+	}
+}
+
+func (p *Process) Logs() string {
+	return p.logs.String()
+}
+
+func (p *Process) waitHTTP(t *testing.T, endpoint string, timeout time.Duration) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !p.State().Running {
+			t.Fatalf(
+				"processtest: process exited before %s became ready (exit code %d)\nlogs:\n%s",
+				endpoint,
+				p.State().ExitCode,
+				p.Logs(),
+			)
+		}
+		resp, err := client.Get(endpoint)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+				return
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("processtest: %s was not ready after %v\nlogs:\n%s", endpoint, timeout, p.Logs())
+}
+
+func Run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	var output lockedBuffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("processtest: %s failed: %v\n%s", name, err, output.String())
+	}
+	return output.String()
+}


### PR DESCRIPTION
## Summary
- add a native process backend so the existing Go integration suite can run Pyroscope and Python workloads directly on macOS
- discover Darwin wheels and run the full suite for Python 3.10-3.14 on both Intel and ARM GitHub runners
- pin and checksum-verify the native Pyroscope test binary while preserving the existing Linux Docker path

## Test plan
- [x] Run the full native macOS ARM suite against Python 3.14
- [x] Run `go test -race -run '^$' ./...`
- [x] Run `go vet ./...`
- [x] Validate workflow YAML and wheel architecture/tags
- [ ] Confirm the complete Intel and ARM matrices in GitHub Actions