### PR TITLE
fix(forksafety): miri memory leaks in tests

### DIFF
--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -125,5 +125,11 @@ pub fn at_fork_after_in_child(_py: Python<'_>) {
     // Here we intentionally leak the whole running agent.
     // This runs post-fork in the child, the old agent must never be dropped there (its
     // stop() joins threads that don't survive fork)
+    #[cfg(not(miri))]
     STATE.leak_and_reset();
+    // The miri variant returns the abandoned allocation so tests can reclaim
+    // it. This hook is never exercised under Miri, and leaking is the whole
+    // point here, so discard it.
+    #[cfg(miri)]
+    let _ = STATE.leak_and_reset();
 }

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -79,6 +79,10 @@ where
 /// fork: after `leak_and_reset` it points at the abandoned parent-era mutex.
 /// Always re-fetch it via `STATE.mutex()` at the point of use.
 ///
+/// The accessors take `&'static self`, so the type is only usable from a
+/// `static` (or another never-dropped location such as a leaked allocation);
+/// non-static usage does not compile.
+///
 /// [`mutex`]: LeakableMutex::mutex
 pub struct LeakableMutex<T> {
     state: AtomicPtr<Mutex<T>>,
@@ -104,7 +108,11 @@ impl<T: Default> LeakableMutex<T> {
     /// Call this at every point of use instead of caching the returned
     /// reference, so that after [`leak_and_reset`](LeakableMutex::leak_and_reset)
     /// you observe the fresh mutex rather than the abandoned one.
-    pub fn mutex(&self) -> &Mutex<T> {
+    ///
+    /// Takes `&'static self`: this type is only meant to live in a `static`
+    /// (its leak-instead-of-drop contract assumes the instance itself is
+    /// never dropped), so non-static usage is rejected at compile time.
+    pub fn mutex(&'static self) -> &'static Mutex<T> {
         unsafe {
             let cur = self.state.load(Ordering::SeqCst);
             if !cur.is_null() {
@@ -139,8 +147,11 @@ impl<T: Default> LeakableMutex<T> {
     /// process is effectively single-threaded. Callers racing with this from
     /// other threads may still hold references to the old mutex, which stays
     /// valid (it is leaked, not freed), but their updates will be lost.
+    ///
+    /// Takes `&'static self` for the same reason as
+    /// [`mutex`](LeakableMutex::mutex).
     #[cfg(not(miri))]
-    pub fn leak_and_reset(&self) {
+    pub fn leak_and_reset(&'static self) {
         self.leak_and_reset_impl();
     }
 
@@ -150,7 +161,7 @@ impl<T: Default> LeakableMutex<T> {
     /// or `None` if the mutex was never initialized.
     #[cfg(miri)]
     #[must_use = "reclaim the returned allocation or Miri reports a leak"]
-    pub fn leak_and_reset(&self) -> Option<std::ptr::NonNull<Mutex<T>>> {
+    pub fn leak_and_reset(&'static self) -> Option<std::ptr::NonNull<Mutex<T>>> {
         std::ptr::NonNull::new(self.leak_and_reset_impl())
     }
 
@@ -163,23 +174,15 @@ impl<T: Default> LeakableMutex<T> {
     }
 }
 
-// Frees the current mutex and its contents (allocations abandoned by
-// `leak_and_reset` stay leaked). This must never run in a fork child on state
-// inherited from the parent: dropping `T` there could block on threads that
-// don't exist after fork — the exact hazard this type exists to avoid. In
-// practice it only runs for non-static instances (tests); the real instance
-// is a `static` and is never dropped.
-impl<T> Drop for LeakableMutex<T> {
-    fn drop(&mut self) {
-        let v = *self.state.get_mut();
-        if !v.is_null() {
-            unsafe {
-                drop(Box::from_raw(v));
-            }
-        }
-    }
-}
+// No `Drop` impl on purpose: `mutex` takes `&'static self`, so an instance
+// that could be dropped can never have allocated its inner mutex — there is
+// nothing to free. Dropping inherited state is the exact hazard this type
+// exists to avoid, so leaking on drop is the correct default anyway.
 
+// Each test declares its own `static` because the accessors take
+// `&'static self`. The mutex still reachable through a static at process
+// exit is not a leak for Miri (its leak checker is reachability-based);
+// only allocations abandoned by `leak_and_reset` need reclaiming.
 #[cfg(test)]
 mod tests {
     use super::LeakableMutex;
@@ -188,27 +191,26 @@ mod tests {
 
     #[test]
     fn initializes_lazily_once() {
-        let state = LeakableMutex::<usize>::new();
+        static STATE: LeakableMutex<usize> = LeakableMutex::new();
 
-        assert_eq!(*state.mutex().lock().unwrap(), 0);
-        *state.mutex().lock().unwrap() = 42;
-        assert_eq!(*state.mutex().lock().unwrap(), 42);
+        assert_eq!(*STATE.mutex().lock().unwrap(), 0);
+        *STATE.mutex().lock().unwrap() = 42;
+        assert_eq!(*STATE.mutex().lock().unwrap(), 42);
     }
 
     #[test]
     fn concurrent_initialization_uses_one_mutex() {
         const THREADS: usize = 4;
+        static STATE: LeakableMutex<usize> = LeakableMutex::new();
 
-        let state = Arc::new(LeakableMutex::<usize>::new());
         let barrier = Arc::new(Barrier::new(THREADS));
         let mut handles = Vec::with_capacity(THREADS);
 
         for _ in 0..THREADS {
-            let state = Arc::clone(&state);
             let barrier = Arc::clone(&barrier);
             handles.push(thread::spawn(move || {
                 barrier.wait();
-                *state.mutex().lock().unwrap() += 1;
+                *STATE.mutex().lock().unwrap() += 1;
             }));
         }
 
@@ -216,21 +218,22 @@ mod tests {
             handle.join().unwrap();
         }
 
-        assert_eq!(*state.mutex().lock().unwrap(), THREADS);
+        assert_eq!(*STATE.mutex().lock().unwrap(), THREADS);
     }
 
     #[test]
     fn reset_preserves_old_reference_and_uses_fresh_default() {
-        let state = LeakableMutex::<usize>::new();
-        let old = state.mutex();
+        static STATE: LeakableMutex<usize> = LeakableMutex::new();
+
+        let old = STATE.mutex();
         *old.lock().unwrap() = 42;
 
         #[cfg(miri)]
-        let leaked = state.leak_and_reset();
+        let leaked = STATE.leak_and_reset();
         #[cfg(not(miri))]
-        state.leak_and_reset();
+        STATE.leak_and_reset();
 
-        let new = state.mutex();
+        let new = STATE.mutex();
         assert!(!std::ptr::eq(old, new));
         assert_eq!(*new.lock().unwrap(), 0);
         assert_eq!(*old.lock().unwrap(), 42);

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -149,6 +149,7 @@ impl<T: Default> LeakableMutex<T> {
     /// allocation so tests can reclaim it and keep Miri's leak checker happy,
     /// or `None` if the mutex was never initialized.
     #[cfg(miri)]
+    #[must_use = "reclaim the returned allocation or Miri reports a leak"]
     pub fn leak_and_reset(&self) -> Option<std::ptr::NonNull<Mutex<T>>> {
         std::ptr::NonNull::new(self.leak_and_reset_impl())
     }
@@ -162,12 +163,18 @@ impl<T: Default> LeakableMutex<T> {
     }
 }
 
+// Frees the current mutex and its contents (allocations abandoned by
+// `leak_and_reset` stay leaked). This must never run in a fork child on state
+// inherited from the parent: dropping `T` there could block on threads that
+// don't exist after fork — the exact hazard this type exists to avoid. In
+// practice it only runs for non-static instances (tests); the real instance
+// is a `static` and is never dropped.
 impl<T> Drop for LeakableMutex<T> {
     fn drop(&mut self) {
         let v = *self.state.get_mut();
         if !v.is_null() {
             unsafe {
-                let _ = Box::from_raw(v);
+                drop(Box::from_raw(v));
             }
         }
     }

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -139,12 +139,34 @@ impl<T: Default> LeakableMutex<T> {
     /// process is effectively single-threaded. Callers racing with this from
     /// other threads may still hold references to the old mutex, which stays
     /// valid (it is leaked, not freed), but their updates will be lost.
+    /// For miri it returns the leaked pointer, for non-miri returns unit.
+    #[cfg(miri)]
+    pub fn leak_and_reset(&self) -> *mut Mutex<T> {
+        self.leak_and_reset_impl()
+    }
+
+    #[cfg(not(miri))]
     pub fn leak_and_reset(&self) {
-        self.state.store(Self::new_static(), Ordering::SeqCst)
+        self.leak_and_reset_impl();
+    }
+
+    fn leak_and_reset_impl(&self) -> *mut Mutex<T> {
+        self.state.swap(Self::new_static(), Ordering::SeqCst)
     }
 
     fn new_static() -> *mut Mutex<T> {
         Box::into_raw(Box::new(Mutex::new(T::default())))
+    }
+}
+
+impl<T> Drop for LeakableMutex<T> {
+    fn drop(&mut self) {
+        let v = self.state.load(Ordering::SeqCst);
+        if !v.is_null() {
+            unsafe {
+                let _ = Box::from_raw(v);
+            }
+        }
     }
 }
 
@@ -193,12 +215,19 @@ mod tests {
         let old = state.mutex();
         *old.lock().unwrap() = 42;
 
-        state.leak_and_reset();
+        let leaked = state.leak_and_reset();
 
         let new = state.mutex();
         assert!(!std::ptr::eq(old, new));
         assert_eq!(*new.lock().unwrap(), 0);
         assert_eq!(*old.lock().unwrap(), 42);
+
+        #[cfg(miri)]
+        unsafe {
+            let _ = Box::from_raw(leaked); // no leaks under miri
+        }
+        #[cfg(not(miri))]
+        let _ = leaked;
     }
 
     #[test]

--- a/rust/src/forksafety.rs
+++ b/rust/src/forksafety.rs
@@ -139,15 +139,18 @@ impl<T: Default> LeakableMutex<T> {
     /// process is effectively single-threaded. Callers racing with this from
     /// other threads may still hold references to the old mutex, which stays
     /// valid (it is leaked, not freed), but their updates will be lost.
-    /// For miri it returns the leaked pointer, for non-miri returns unit.
-    #[cfg(miri)]
-    pub fn leak_and_reset(&self) -> *mut Mutex<T> {
-        self.leak_and_reset_impl()
-    }
-
     #[cfg(not(miri))]
     pub fn leak_and_reset(&self) {
         self.leak_and_reset_impl();
+    }
+
+    /// Miri-only variant of `leak_and_reset` (see the `#[cfg(not(miri))]`
+    /// item for the full contract). It additionally returns the abandoned
+    /// allocation so tests can reclaim it and keep Miri's leak checker happy,
+    /// or `None` if the mutex was never initialized.
+    #[cfg(miri)]
+    pub fn leak_and_reset(&self) -> Option<std::ptr::NonNull<Mutex<T>>> {
+        std::ptr::NonNull::new(self.leak_and_reset_impl())
     }
 
     fn leak_and_reset_impl(&self) -> *mut Mutex<T> {
@@ -161,7 +164,7 @@ impl<T: Default> LeakableMutex<T> {
 
 impl<T> Drop for LeakableMutex<T> {
     fn drop(&mut self) {
-        let v = self.state.load(Ordering::SeqCst);
+        let v = *self.state.get_mut();
         if !v.is_null() {
             unsafe {
                 let _ = Box::from_raw(v);
@@ -215,7 +218,10 @@ mod tests {
         let old = state.mutex();
         *old.lock().unwrap() = 42;
 
+        #[cfg(miri)]
         let leaked = state.leak_and_reset();
+        #[cfg(not(miri))]
+        state.leak_and_reset();
 
         let new = state.mutex();
         assert!(!std::ptr::eq(old, new));
@@ -224,10 +230,8 @@ mod tests {
 
         #[cfg(miri)]
         unsafe {
-            let _ = Box::from_raw(leaked); // no leaks under miri
+            drop(Box::from_raw(leaked.unwrap().as_ptr())); // no leaks under miri
         }
-        #[cfg(not(miri))]
-        let _ = leaked;
     }
 
     #[test]


### PR DESCRIPTION
Miri tests are failing because there are two memory leaks:

1. An intentional leak during `leak_and_reset`. Fixed only for `cfg!(miri)`: under Miri, `leak_and_reset` returns the abandoned allocation as `#[must_use] Option<NonNull<Mutex<T>>>` so tests can reclaim it and keep Miri's leak checker happy. The non-Miri signature is unchanged.
2. A semi-unintentional leak when a `LeakableMutex` holding an allocation is dropped (previously only possible for the test-local instances). Fixed by making the accessors (`mutex`, `leak_and_reset`) take `&'static self`, so the type is only usable from a `static` and an instance that could be dropped can never have allocated its inner mutex. This enforces the "used in a static, never dropped" invariant at compile time instead of by convention, and makes a `Drop` impl unnecessary. Tests now declare a `static` per test; memory still reachable through those statics at exit is not reported by Miri's reachability-based leak checker, so only the allocation abandoned by `leak_and_reset` needs explicit reclaiming.

Note: these are purely code hygiene changes. In our code the `LeakableMutex` is used in a static and never dropped; production call sites are unchanged apart from the `cfg(miri)` discard in the post-fork hook.