### PR TITLE
feat: alternative CPU profiler vendored from dd-trace-py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,17 @@ include rust/Cargo.lock
 include rust/build.rs
 recursive-include rust/src/ *.rs
 include rust/include/pyroscope_ffi.h
-include cpp/CMakeLists.txt
-include cpp/BundleStaticLibrary.cmake
+# Native profiler sources. cpp/cpu/ holds the vendored alternative CPU
+# profiler, in its own CMake project; see cpp/cpu/*/VENDOR.md.
+recursive-include cpp/ CMakeLists.txt
 recursive-include cpp/ *.h
-recursive-include cpp/ *.cpp
 recursive-include cpp/ *.hpp
+recursive-include cpp/ *.c
+recursive-include cpp/ *.cc
+recursive-include cpp/ *.cpp
+recursive-include cpp/ *.cmake
+
+# Upstream licences and provenance for the vendored trees. These must ship with
+# the source distribution to satisfy the vendored code's licence terms.
+recursive-include cpp/ LICENSE
+recursive-include cpp/ VENDOR.md

--- a/cpp/cpu/PyroscopeCpu.h
+++ b/cpp/cpu/PyroscopeCpu.h
@@ -1,0 +1,130 @@
+//
+// Pyroscope sink shim for vendored CPU profilers.
+//
+// This is the CPU analogue of cpp/Pyroscope.h (which replaced Datadog's
+// ddup_interface for the memalloc profiler). A vendored CPU profiler renders
+// its samples through this class instead of through its upstream sink
+// (Datadog's ddup_* / libdd_wrapper), so it feeds the same Rust encoder and
+// uploader everything else in this extension uses.
+//
+// It lives one level above the individual profiler directories so a second
+// vendored sampler can share it without duplicating the C ABI glue.
+//
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+extern "C" {
+#include "pyroscope_ffi.h"
+}
+
+namespace Pyroscope
+{
+    /* Accumulates one stack trace and hands it to the Rust sink.
+     *
+     * IMPORTANT: export_sample() crosses into Rust, where it allocates and
+     * takes a lock. It must NEVER be called from a signal handler. The
+     * vendored echion sampler already has the right shape for this -- its
+     * signal handler only does siglongjmp recovery for safe_memcpy, and all
+     * rendering happens on the ordinary sampling thread. Preserve that.
+     *
+     * Reuse one instance across samples and call clear() between them; the
+     * frame vector keeps its capacity so the sampling loop does not allocate
+     * per sample.
+     */
+    class CpuSample
+    {
+        std::vector<FFICpuFrame> frames;
+        size_t max_nframes;
+        uint64_t thread_id{0};
+        std::string_view thread_name{};
+        uint32_t pid{0};
+        uint64_t cpu_nanos{0};
+        uint64_t dropped_frames{0};
+
+    public:
+        explicit CpuSample(const size_t max_nframes) : max_nframes{max_nframes}
+        {
+            frames.reserve(max_nframes);
+        }
+
+        /* Frames must be pushed leaf-first, matching py-spy's ordering. */
+        void push_frame(const std::string_view function_name,
+                        const std::string_view file_name,
+                        const int line)
+        {
+            if (frames.size() >= max_nframes)
+            {
+                dropped_frames++;
+                return;
+            }
+            frames.emplace_back(
+                FFICpuFrame{
+                    .function_name = string_view(function_name),
+                    .file_name = string_view(file_name),
+                    .line = line,
+                }
+            );
+        }
+
+        void set_thread(const uint64_t tid, const std::string_view name)
+        {
+            thread_id = tid;
+            thread_name = name;
+        }
+
+        void set_pid(const uint32_t p) { pid = p; }
+
+        /* CPU nanoseconds this sample accounts for.
+         *
+         * Must be real CPU time, not wall time. A wall-clock sampler that
+         * walks every Python thread sees one sample per thread per tick; if
+         * each were credited a full sampling period of CPU, the profile would
+         * claim several times more CPU than the process actually consumed and
+         * would count blocked threads as busy. A sampler whose timer fires
+         * once per period of CPU would pass ticks * period here. */
+        void set_cpu_nanos(const uint64_t ns) { cpu_nanos = ns; }
+
+        bool empty() const { return frames.empty(); }
+
+        void clear()
+        {
+            frames.clear();
+            thread_id = 0;
+            thread_name = {};
+            pid = 0;
+            cpu_nanos = 0;
+            dropped_frames = 0;
+        }
+
+        void export_sample() const
+        {
+            /* A sample with no CPU time is not a CPU sample. Filtering here
+             * rather than in Rust keeps zero-valued entries out of the sink's
+             * aggregation map entirely. */
+            if (frames.empty() || cpu_nanos == 0)
+            {
+                return;
+            }
+            pyroscope_cpu_push_sample(FFICpuSample{
+                .frames = frames.data(),
+                .len = frames.size(),
+                .pid = pid,
+                .thread_id = thread_id,
+                .thread_name = string_view(thread_name),
+                .cpu_nanos = cpu_nanos,
+            });
+        }
+
+    private:
+        static FFIStringView string_view(const std::string_view s)
+        {
+            return FFIStringView{
+                .data = s.data(),
+                .len = s.length(),
+            };
+        }
+    };
+}

--- a/cpp/cpu/ddtrace_stack/CMakeLists.txt
+++ b/cpp/cpu/ddtrace_stack/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.19)
+
+# Vendored CPU profiler: dd-trace-py's `stack` sampler (echion-based wall-clock
+# sampler). See VENDOR.md for the upstream release and the list of local
+# modifications.
+#
+# No part of dd_wrapper / libdatadog is vendored; see shim/ and
+# src/pyroscope_renderer.cpp.
+project(pyroscope_cpu_ddtrace)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_compile_options(-fPIC -fvisibility=hidden -pthread -Wall -Wextra)
+
+# Deliberately NOT defining _POSIX_C_SOURCE here (unlike cpp/CMakeLists.txt).
+# Upstream dd-trace-py does not define it, and on macOS it selects the strict
+# POSIX namespace, which hides BSD extensions the vendored code uses --
+# echion/danger.cc calls getpagesize().
+
+# Required by the vendored sources, mirroring dd-trace-py's own
+# stack/CMakeLists.txt. Without PL_LINUX / PL_DARWIN, echion's danger.h
+# compiles out its platform memory-copy primitives (copy_type, proc_ref_t,
+# safe_memcpy_return_t) and everything downstream fails to resolve.
+#
+# UNWIND_NATIVE_DISABLE: we profile Python frames only. Native unwinding would
+# pull in libunwind and change what is being measured.
+add_compile_definitions(UNWIND_NATIVE_DISABLE)
+
+if (APPLE)
+    # rust/build.rs does not build this project on macOS today (thread
+    # auto-registration is Linux-only; see the TODO(macos) in
+    # src/echion/threads.cc). The branch is kept so the tree still configures
+    # if someone builds it by hand while working on that.
+    add_compile_definitions(_DARWIN_C_SOURCE PL_DARWIN)
+else ()
+    add_compile_definitions(PL_LINUX)
+endif ()
+
+find_package(Python3 COMPONENTS Interpreter Development)
+if (NOT Python3_INCLUDE_DIRS)
+    message(FATAL_ERROR "Python3_INCLUDE_DIRS not found")
+endif ()
+message(STATUS "pyroscope_cpu_ddtrace: Python3_VERSION ${Python3_VERSION}")
+
+file(GLOB ECHION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/echion/*.cc)
+
+set(SOURCE_FILES
+        ${ECHION_SOURCES}
+        src/sampler.cpp
+        src/thread_span_links.cpp
+        src/origin_task_links.cpp
+        src/pyroscope_renderer.cpp
+        src/pyroscope_entry.cpp)
+
+set(TARGET_NAME pyroscope_cpu_ddtrace)
+add_library(${TARGET_NAME} STATIC ${SOURCE_FILES})
+
+# No bundling step (unlike cpp/CMakeLists.txt, which has to merge Abseil):
+# this project has no transitive static dependencies, so the archive cmake
+# produces is already complete.
+target_include_directories(
+        ${TARGET_NAME}
+        PRIVATE ${Python3_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/util
+        ${CMAKE_CURRENT_SOURCE_DIR}/echion
+        ${CMAKE_CURRENT_SOURCE_DIR}/shim
+        ${CMAKE_CURRENT_SOURCE_DIR}/..          # PyroscopeCpu.h
+        # profiling_helpers/ is NOT vendored twice: src/echion/frame.cc includes
+        # <profiling_helpers/frame_accessors.h>, and cpp/profiling_helpers/ (used
+        # by the memalloc profiler) is byte-identical to the upstream copy. One
+        # definition on disk, so the two archives cannot drift into an ODR
+        # violation on those `namespace DataDog` inline functions.
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../rust/include  # pyroscope_ffi.h
+)
+
+# Python modules should use -undefined dynamic_lookup on macOS and not link to
+# libpython on Linux, matching cpp/CMakeLists.txt.
+if (TARGET Python3::Python AND NOT APPLE)
+    target_link_libraries(${TARGET_NAME} PRIVATE Python3::Python)
+endif ()
+
+install(TARGETS ${TARGET_NAME}
+        ARCHIVE DESTINATION .
+        LIBRARY DESTINATION .)

--- a/cpp/cpu/ddtrace_stack/LICENSE
+++ b/cpp/cpu/ddtrace_stack/LICENSE
@@ -1,0 +1,40 @@
+# Licenses for the vendored sources in this directory
+
+## dd-trace-py
+
+Everything here except `echion/` and `src/echion/` originates from
+https://github.com/DataDog/dd-trace-py.
+
+This work is dual-licensed under Apache 2.0 or BSD3.
+You may select, at your option, one of the above-listed licenses.
+
+`SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause`
+
+## echion
+
+`echion/` and `src/echion/` originate from https://github.com/P403n1x87/echion
+via dd-trace-py's vendored copy, and are released under MIT:
+
+`SPDX-License-Identifier: MIT`
+
+MIT License
+
+Copyright (c) 2023 Gabriele N. Tornetta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cpp/cpu/ddtrace_stack/VENDOR.md
+++ b/cpp/cpu/ddtrace_stack/VENDOR.md
@@ -1,0 +1,184 @@
+# Vendored: dd-trace-py `stack` (echion sampler)
+
+| | |
+|---|---|
+| Upstream | https://github.com/DataDog/dd-trace-py |
+| Release | `v4.14.0` (commit `ef8651166784671cc6d5f82803c8ea38a0239557`) |
+| Path | `ddtrace/internal/datadog/profiling/stack/` |
+| License | Apache-2.0 OR BSD-3-Clause; `echion/` and `src/echion/` are MIT (see `LICENSE`) |
+
+A wall-clock sampler: a dedicated thread wakes on an interval and walks every
+Python thread, reading frames out of process memory with a fault-tolerant copy
+primitive. Upstream called this `stack_v2` before 4.14.0.
+
+**Linux, CPython 3.11+ only** -- see the thread auto-registration patch below.
+The tree compiles on macOS and on 3.10, it just cannot discover threads there.
+
+Driven from Rust over the C ABI in `src/pyroscope_entry.cpp`; see
+`rust/src/cpu/native.rs`.
+
+## No libdatadog
+
+Upstream renders samples through `StackRenderer` -> `ddup_*` ->
+`libdd_wrapper.so` -> Rust **libdatadog**, which owns pprof encoding and
+upload. **None of that chain is vendored.** Specifically dropped:
+
+- the entire `dd_wrapper/` tree,
+- `src/stack_renderer.cpp` and `include/stack_renderer.hpp`, replaced by
+  `src/pyroscope_renderer.cpp` + our own `include/stack_renderer.hpp`, which
+  render into `Pyroscope::CpuSample` (`../PyroscopeCpu.h`) and push over the C
+  ABI in `rust/include/pyroscope_ffi.h`.
+
+`libdd_wrapper.so` is a pre-built binary artifact and is not buildable from
+source here; taking it would also mean two pprof encoders and two uploaders in
+one process.
+
+`shim/dd_wrapper/include/` holds small replacements for the few headers the
+retained code still includes -- see the header comments in each. Only
+`constants.hpp`, `defer.hpp` and `scope.hpp` are genuine upstream files (pure
+utility code, no libdatadog dependency); `sample.hpp`, `profiler_stats.hpp`
+and `profiler_state.hpp` are Pyroscope no-op shims. Keeping them as shims is
+what lets `src/sampler.cpp` and `src/echion/stacks.cc` stay byte-identical to
+upstream.
+
+Check after building that no real dd_wrapper header leaked in:
+
+```
+nm --defined-only -g libpyroscope_cpu_ddtrace.a | grep -E 'ddog_|libdatadog'   # empty
+nm -u _native.abi3.so | grep ddog_                                            # empty
+```
+
+## Other things dropped
+
+- All `*.py` / `*.pyi`.
+- `src/stack.cpp` -- the CPython extension-module glue (`PyMethodDef`
+  `stack_start`/`stack_stop`/`register_thread`/`link_span`/...). Replaced by
+  `src/pyroscope_entry.cpp`, a plain C ABI.
+- Span linking, greenlet tracking, asyncio task attribution and
+  `sys.monitoring` native-call tracking. All are Datadog product features
+  driven from the Python layer, and none affects CPU sampling.
+  `src/thread_span_links.cpp` and `src/origin_task_links.cpp` are still
+  compiled because `src/sampler.cpp` references them; with nothing populating
+  them they are inert.
+- `fuzz/` and `test/`.
+- `profiling_helpers/`, which `src/echion/frame.cc` includes, is **not**
+  vendored again: `cpp/profiling_helpers/` (used by the memalloc profiler) is
+  byte-identical to this release's copy, and `CMakeLists.txt` puts `cpp/` on
+  the include path. One definition on disk means the two archives cannot drift
+  into an ODR violation on those `namespace DataDog` inline functions.
+
+## Local modifications
+
+Marked in-file with `Pyroscope patch:` comments.
+
+1. **`src/echion/threads.cc`, `for_each_thread()`** -- auto-register threads on
+   discovery, and refresh entries whose thread has been replaced.
+
+   Upstream depends on the Python `threading` patch calling
+   `stack_thread_register()` for every thread. That call does two things:
+   creates the `ThreadInfo`, and *overwrites* any existing entry under the same
+   key. Both halves matter, and without the Python layer both have to happen
+   here.
+
+   - Without the insert, `thread_info_map` stays empty and the loop's
+     `continue` silently skips **every** thread -- the profiler yields nothing.
+   - Without the overwrite, recycled `pthread_t` values are mis-attributed. The
+     map is keyed by `pthread_t`, which the C library reuses after a thread
+     exits; a new thread inheriting a dead one's key would keep the dead
+     thread's `cpu_clock_id` (derived from the old kernel TID), so
+     `update_cpu_time()` reads a clock that no longer exists and the CPU delta
+     stays zero for that thread's whole life. A thread-churning workload
+     reported **5% of the CPU it actually used** before this was handled. The
+     kernel TID (`PyThreadState::native_thread_id`) is the discriminator.
+
+   Cost: no Python-level thread name (not reachable off-GIL from here), so this
+   profiler reports no `thread_name` tag. Entries for dead threads are never
+   evicted, which is fine because `pthread_t` reuse bounds the map at roughly
+   the peak concurrent thread count rather than the total ever created.
+
+   The patched path is compiled only for `PL_LINUX && PY_VERSION_HEX >= 3.11`.
+   `PyThreadState::native_thread_id` does not exist before CPython 3.11, and
+   only Linux can derive a usable per-thread CPU clock from it. Everywhere else
+   the tree still compiles (the lookup miss falls through to upstream's
+   `continue`) but yields nothing, so `CpuProfiler::check_supported` in
+   `rust/src/cpu/mod.rs` refuses to start it rather than report a blank profile:
+   non-Linux is rejected because `rust/build.rs` does not build the archive
+   there, CPython 3.10 by an explicit version check.
+
+   **TODO(macos):** `ThreadInfo::create()` on Darwin calls
+   `pthread_mach_thread_np()` on a `pthread_t` copied out of a concurrently
+   changing interpreter list, which is undefined for a stale value. The likely
+   fix is to use `native_id` directly (CPython sets `native_thread_id` from
+   `pthread_mach_thread_np(pthread_self())` on macOS, so it is already the mach
+   port) and let `update_cpu_time()`'s `thread_info()` call fail cleanly for a
+   dead port -- needs verifying against CPython 3.11-3.14 first.
+
+2. **`src/echion/vm.cc`, `echion/echion/vm.h`** -- dropped
+   `__attribute__((constructor))` from `init_safe_copy()` and renamed it to
+   `pyroscope_init_safe_copy()`.
+
+   Upstream runs it at `dlopen`, i.e. on `import pyroscope`, installing
+   process-wide SIGSEGV/SIGBUS handlers and a 1 MiB alt stack whether or not
+   this profiler is ever selected. `src/pyroscope_entry.cpp` calls it
+   explicitly (under a `std::once_flag`) when the sampler starts instead.
+
+   Deliberately never uninstalled on stop: the handler chains to the previous
+   disposition for anything it does not own, so leaving it installed is benign,
+   whereas tearing it down while `fast_copy_active` stays true would leave
+   `safe_memcpy` without its recovery path on a subsequent restart
+   (`Sampler::sampling_thread` only reinstalls under its own `std::once_flag`).
+
+3. **`src/sampler.cpp`, `stack_atfork_child()`** -- do not restart the sampler
+   in the fork child.
+
+   Upstream calls `Sampler::restart_after_fork()` there. Pyroscope's fork
+   policy is the opposite: `rust/src/lib.rs::at_fork_after_in_child` stops
+   profiling and deliberately leaks the agent, because the agent's threads did
+   not survive the fork. An auto-restarted sampler would keep pushing samples
+   into a Rust sink that no uploader is draining.
+
+   The cleanup itself is kept, and kept on `pthread_atfork` rather than moved
+   to Rust: it re-inits echion's mutexes and maps with placement new, and
+   `pthread_atfork` also covers a raw `fork(2)` from C, which
+   `os.register_at_fork` would miss. Because that handler already ran the
+   cleanup, `pyroscope_cpu_ddtrace_postfork_child()` must not call
+   `Sampler::postfork_child()` again.
+
+## Sample weighting
+
+This is a **wall-clock** sampler: it wakes on an interval and walks every
+Python thread, producing one stack per thread per tick whether or not that
+thread ran. `src/pyroscope_renderer.cpp` therefore weights each sample by the
+per-thread CPU delta echion supplies via `render_cpu_time()`, and drops samples
+from threads that consumed no CPU. `rust/src/cpu/mod.rs` tags the batch
+`ReportData::ReportsCpuNanos` so `encode::pprof` writes those nanoseconds
+verbatim instead of multiplying by the sampling period.
+
+Weighting by the sampling period instead (one tick = one period of CPU, which
+is correct for py-spy with `gil_only`) inflates the profile by roughly the
+thread count and counts blocked threads as busy: 13.6s of "CPU" was measured
+for a process that used 3.7s.
+
+## Configuration notes
+
+- `Sampler::set_interval()` takes **fractional seconds**, not microseconds.
+- The stack depth cap lives in echion's `max_frames` global (`echion/config.h`),
+  not on `Sampler`.
+- Adaptive sampling is deliberately **disabled** in `pyroscope_entry.cpp`. It
+  varies the interval to hit a CPU-overhead target, which would make the sample
+  rate the user asked for a suggestion rather than a setting and quietly trade
+  samples for overhead under load.
+- `UNWIND_NATIVE_DISABLE` and `PL_LINUX`/`PL_DARWIN` compile definitions are
+  required, mirroring upstream's `stack/CMakeLists.txt`. Without `PL_*`,
+  `echion/danger.h` compiles out its platform memory-copy primitives and the
+  whole tree fails to resolve.
+- `_POSIX_C_SOURCE` is deliberately **not** defined (unlike
+  `cpp/CMakeLists.txt`): on macOS it selects the strict POSIX namespace, which
+  hides BSD extensions the vendored code uses -- `echion/danger.cc` calls
+  `getpagesize()`.
+
+## Re-vendoring
+
+`scripts/check-cpu-profilers-multiversion.sh` compiles this tree against
+CPython 3.10-3.14 in about a minute; run it after any update, because that is
+where version-specific CPython internals break.

--- a/cpp/cpu/ddtrace_stack/echion/echion/cache.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/cache.h
@@ -1,0 +1,81 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <functional>
+#include <list>
+#include <memory>
+#include <unordered_map>
+
+#include <echion/errors.h>
+
+#define CACHE_MAX_ENTRIES 2048
+
+template<typename K, typename V>
+class LRUCache
+{
+  public:
+    LRUCache(size_t capacity)
+      : capacity(capacity)
+    {
+    }
+
+    Result<std::reference_wrapper<V>> lookup(const K& k);
+
+    void store(const K& k, std::unique_ptr<V> v);
+
+    void clear()
+    {
+        items.clear();
+        index.clear();
+    }
+
+    void postfork_child()
+    {
+        // At fork, the sampling thread may have been modifying the list
+        // mid-operation (e.g., splice in lookup, emplace in store). Traversing
+        // the list to free nodes (as std::list::clear does) can crash on corrupted
+        // pointers. Use placement new to construct fresh empty containers,
+        // abandoning the old data (intentional one-time leak).
+        new (&items) std::list<std::pair<K, std::unique_ptr<V>>>();
+        new (&index) std::unordered_map<K, typename std::list<std::pair<K, std::unique_ptr<V>>>::iterator>();
+    }
+
+  private:
+    size_t capacity;
+    std::list<std::pair<K, std::unique_ptr<V>>> items;
+    std::unordered_map<K, typename std::list<std::pair<K, std::unique_ptr<V>>>::iterator> index;
+};
+
+template<typename K, typename V>
+void
+LRUCache<K, V>::store(const K& k, std::unique_ptr<V> v)
+{
+    // Check if cache is full
+    if (items.size() >= capacity) {
+        index.erase(items.back().first);
+        items.pop_back();
+    }
+
+    // Insert the new item at front of the list
+    items.emplace_front(k, std::move(v));
+
+    // Insert in the map
+    index[k] = items.begin();
+}
+
+template<typename K, typename V>
+Result<std::reference_wrapper<V>>
+LRUCache<K, V>::lookup(const K& k)
+{
+    auto itr = index.find(k);
+    if (itr == index.end())
+        return ErrorKind::LookupError;
+
+    // Move to the front of the list
+    items.splice(items.begin(), items, itr->second);
+
+    return std::reference_wrapper<V>(*(itr->second->second.get()));
+}

--- a/cpp/cpu/ddtrace_stack/echion/echion/config.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/config.h
@@ -1,0 +1,8 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+// Maximum number of frames to unwind
+inline unsigned int max_frames = 2048;

--- a/cpp/cpu/ddtrace_stack/echion/echion/cpython/tasks.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/cpython/tasks.h
@@ -1,0 +1,445 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+#include <cpython/genobject.h>
+
+#if PY_VERSION_HEX >= 0x030e0000
+#include <cstddef>
+#include <internal/pycore_frame.h>
+#include <internal/pycore_interpframe.h>
+#include <internal/pycore_interpframe_structs.h>
+#include <internal/pycore_llist.h>
+#include <internal/pycore_stackref.h>
+#include <opcode.h>
+#elif PY_VERSION_HEX >= 0x030d0000
+#include <opcode.h>
+#else
+#include <cstddef>
+#include <internal/pycore_frame.h>
+#include <internal/pycore_opcode.h>
+#endif // PY_VERSION_HEX >= 0x030d0000
+#else
+#include <genobject.h>
+#include <opcode.h>
+#endif
+
+#include <memory>
+
+#include <echion/vm.h>
+
+constexpr ssize_t MAX_STACK_SIZE = 1 << 20; // 1 MiB
+
+extern "C"
+{
+
+    typedef enum
+    {
+        STATE_PENDING,
+        STATE_CANCELLED,
+        STATE_FINISHED
+    } fut_state;
+
+#if PY_VERSION_HEX >= 0x030e0000
+// Python 3.14+: New fields added (awaited_by, is_task, awaited_by_is_set)
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_exception_tb;                                                                                   \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    PyObject* prefix##_cancel_msg;                                                                                     \
+    PyObject* prefix##_cancelled_exc;                                                                                  \
+    PyObject* prefix##_awaited_by;                                                                                     \
+    fut_state prefix##_state;                                                                                          \
+    /* Used by profilers to make traversing the stack from an external                                                 \
+       process faster. */                                                                                              \
+    char prefix##_is_task;                                                                                             \
+    char prefix##_awaited_by_is_set;                                                                                   \
+    /* These bitfields need to be at the end of the struct                                                             \
+       so that these and bitfields from TaskObj are contiguous.                                                        \
+    */                                                                                                                 \
+    unsigned prefix##_log_tb : 1;                                                                                      \
+    unsigned prefix##_blocking : 1;
+
+#elif PY_VERSION_HEX >= 0x030d0000
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_exception_tb;                                                                                   \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    PyObject* prefix##_cancel_msg;                                                                                     \
+    PyObject* prefix##_cancelled_exc;                                                                                  \
+    fut_state prefix##_state;                                                                                          \
+    /* These bitfields need to be at the end of the struct                                                             \
+       so that these and bitfields from TaskObj are contiguous.                                                        \
+    */                                                                                                                 \
+    unsigned prefix##_log_tb : 1;                                                                                      \
+    unsigned prefix##_blocking : 1;
+
+#elif PY_VERSION_HEX >= 0x030b0000
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_exception_tb;                                                                                   \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    PyObject* prefix##_cancel_msg;                                                                                     \
+    fut_state prefix##_state;                                                                                          \
+    int prefix##_log_tb;                                                                                               \
+    int prefix##_blocking;                                                                                             \
+    PyObject* dict;                                                                                                    \
+    PyObject* prefix##_weakreflist;                                                                                    \
+    PyObject* prefix##_cancelled_exc;
+
+#elif PY_VERSION_HEX >= 0x030a0000
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_exception_tb;                                                                                   \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    PyObject* prefix##_cancel_msg;                                                                                     \
+    fut_state prefix##_state;                                                                                          \
+    int prefix##_log_tb;                                                                                               \
+    int prefix##_blocking;                                                                                             \
+    PyObject* dict;                                                                                                    \
+    PyObject* prefix##_weakreflist;                                                                                    \
+    _PyErr_StackItem prefix##_cancelled_exc_state;
+
+#elif PY_VERSION_HEX >= 0x03090000
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    PyObject* prefix##_cancel_msg;                                                                                     \
+    fut_state prefix##_state;                                                                                          \
+    int prefix##_log_tb;                                                                                               \
+    int prefix##_blocking;                                                                                             \
+    PyObject* dict;                                                                                                    \
+    PyObject* prefix##_weakreflist;                                                                                    \
+    _PyErr_StackItem prefix##_cancelled_exc_state;
+
+#else
+#define FutureObj_HEAD(prefix)                                                                                         \
+    PyObject_HEAD PyObject* prefix##_loop;                                                                             \
+    PyObject* prefix##_callback0;                                                                                      \
+    PyObject* prefix##_context0;                                                                                       \
+    PyObject* prefix##_callbacks;                                                                                      \
+    PyObject* prefix##_exception;                                                                                      \
+    PyObject* prefix##_result;                                                                                         \
+    PyObject* prefix##_source_tb;                                                                                      \
+    fut_state prefix##_state;                                                                                          \
+    int prefix##_log_tb;                                                                                               \
+    int prefix##_blocking;                                                                                             \
+    PyObject* dict;                                                                                                    \
+    PyObject* prefix##_weakreflist;
+#endif
+
+    typedef struct
+    {
+        FutureObj_HEAD(future)
+    } FutureObj;
+
+#if PY_VERSION_HEX >= 0x030e0000
+    // Python 3.14+: TaskObj includes task_node for linked-list storage
+    typedef struct
+    {
+        FutureObj_HEAD(task) unsigned task_must_cancel : 1;
+        unsigned task_log_destroy_pending : 1;
+        int task_num_cancels_requested;
+        PyObject* task_fut_waiter;
+        PyObject* task_coro;
+        PyObject* task_name;
+        PyObject* task_context;
+        struct llist_node task_node;
+#ifdef Py_GIL_DISABLED
+        // thread id of the thread where this task was created
+        uintptr_t task_tid;
+#endif
+    } TaskObj;
+#elif PY_VERSION_HEX >= 0x030d0000
+    typedef struct
+    {
+        FutureObj_HEAD(task) unsigned task_must_cancel : 1;
+        unsigned task_log_destroy_pending : 1;
+        int task_num_cancels_requested;
+        PyObject* task_fut_waiter;
+        PyObject* task_coro;
+        PyObject* task_name;
+        PyObject* task_context;
+    } TaskObj;
+
+#elif PY_VERSION_HEX >= 0x030a0000
+    typedef struct
+    {
+        FutureObj_HEAD(task) PyObject* task_fut_waiter;
+        PyObject* task_coro;
+        PyObject* task_name;
+        PyObject* task_context;
+        int task_must_cancel;
+        int task_log_destroy_pending;
+        int task_num_cancels_requested;
+    } TaskObj;
+
+#else
+    typedef struct
+    {
+        FutureObj_HEAD(task) PyObject* task_fut_waiter;
+        PyObject* task_coro;
+        PyObject* task_name;
+        PyObject* task_context;
+        int task_must_cancel;
+        int task_log_destroy_pending;
+    } TaskObj;
+#endif
+
+    // ---- cr_await ----
+
+#if PY_VERSION_HEX >= 0x030c0000
+#define RESUME_QUICK INSTRUMENTED_RESUME
+#endif
+
+#if PY_VERSION_HEX >= 0x030e0000
+    // Python 3.14+: Use stackpointer and _PyStackRef
+
+    inline PyObject* PyGen_yf(PyGenObject* gen, PyObject* frame_addr)
+    {
+        if (gen->gi_frame_state != FRAME_SUSPENDED_YIELD_FROM) {
+            return nullptr;
+        }
+
+        _PyInterpreterFrame frame;
+        if (copy_type(frame_addr, frame)) {
+            return nullptr;
+        }
+
+        // CPython asserts the following:
+        // assert(f->stackpointer >  f->localsplus + _PyFrame_GetCode(f)->co_nlocalsplus);
+        // assert(!PyStackRef_IsNull(f->stackpointer[-1]));
+
+        // Though we have to pay the price of copying the code object, we need
+        // to do this to catch the case where the stack is empty, as accessing
+        // frame.stackpointer[-1] would be an undefined behavior.
+        // This is necessary as frame.stacktop is removed in 3.14.
+        PyCodeObject code;
+        auto code_addr = reinterpret_cast<PyCodeObject*>(BITS_TO_PTR_MASKED(frame.f_executable));
+        if (copy_type(code_addr, code)) {
+            return nullptr;
+        }
+
+        uintptr_t frame_addr_uint = reinterpret_cast<uintptr_t>(frame_addr);
+        uintptr_t localsplus_addr = frame_addr_uint + offsetof(_PyInterpreterFrame, localsplus);
+        // This computes f->localsplus + code.co_nlocalsplus.
+        uintptr_t stackbase_addr = localsplus_addr + code.co_nlocalsplus * sizeof(_PyStackRef);
+
+        uintptr_t stackpointer_addr = reinterpret_cast<uintptr_t>(frame.stackpointer);
+        // We want stackpointer_addr to be greater than the stackbase_addr,
+        // that is, the stack is not empty.
+        if (stackpointer_addr <= stackbase_addr) {
+            return nullptr;
+        }
+
+        // We can also calculate stacktop and check that it is within a reasonable range.
+        // Similar to 3.13's stacktop check below.
+        int stacktop = (int)((stackpointer_addr - stackbase_addr) / sizeof(_PyStackRef));
+
+        if (stacktop < 1 || stacktop > MAX_STACK_SIZE) {
+            return nullptr;
+        }
+
+        // Read the top of stack directly from remote memory
+        // This is equivalent to CPython's frame.stackpointer[-1].
+        _PyStackRef top_ref;
+        if (copy_type(reinterpret_cast<void*>(stackpointer_addr - sizeof(_PyStackRef)), top_ref)) {
+            return nullptr;
+        }
+
+        // Extract PyObject* from _PyStackRef.bits
+        // Per Python 3.14 release notes (gh-123923): clear LSB to recover PyObject* pointer
+        return BITS_TO_PTR_MASKED(top_ref);
+    }
+
+#elif PY_VERSION_HEX >= 0x030d0000
+
+    inline PyObject* PyGen_yf(PyGenObject* gen, PyObject* frame_addr)
+    {
+        if (gen->gi_frame_state != FRAME_SUSPENDED_YIELD_FROM) {
+            return nullptr;
+        }
+
+        _PyInterpreterFrame frame;
+        if (copy_type(frame_addr, frame)) {
+            return nullptr;
+        }
+
+        if (frame.stacktop < 1 || frame.stacktop > MAX_STACK_SIZE) {
+            return nullptr;
+        }
+
+        auto localsplus = std::make_unique<PyObject*[]>(frame.stacktop);
+
+        // Calculate the remote address of the localsplus array
+        auto remote_localsplus = reinterpret_cast<PyObject**>(reinterpret_cast<uintptr_t>(frame_addr) +
+                                                              offsetof(_PyInterpreterFrame, localsplus));
+        if (copy_generic(remote_localsplus, localsplus.get(), frame.stacktop * sizeof(PyObject*))) {
+            return nullptr;
+        }
+
+        return localsplus[frame.stacktop - 1];
+    }
+
+#elif PY_VERSION_HEX >= 0x030b0000
+
+    inline PyObject* PyGen_yf(PyGenObject* gen, PyObject* frame_addr)
+    {
+        PyObject* yf = NULL;
+
+        if (gen->gi_frame_state < FRAME_CLEARED) {
+            if (gen->gi_frame_state == FRAME_CREATED)
+                return NULL;
+
+            _PyInterpreterFrame frame;
+            if (copy_type(frame_addr, frame))
+                return NULL;
+
+            _Py_CODEUNIT next;
+#if PY_VERSION_HEX >= 0x030d0000
+            if (copy_type(frame.instr_ptr, next))
+#else
+            if (copy_type(frame.prev_instr + 1, next))
+#endif
+                return NULL;
+            if (!(_Py_OPCODE(next) == RESUME || _Py_OPCODE(next) == RESUME_QUICK) || _Py_OPARG(next) < 2)
+                return NULL;
+
+            if (frame.stacktop < 1 || frame.stacktop > MAX_STACK_SIZE)
+                return NULL;
+
+            auto localsplus = std::make_unique<PyObject*[]>(frame.stacktop);
+            // Calculate the remote address of the localsplus array
+            auto localsplus_addr = reinterpret_cast<uintptr_t>(frame_addr) + offsetof(_PyInterpreterFrame, localsplus);
+            auto remote_localsplus = reinterpret_cast<PyObject**>(localsplus_addr);
+            if (copy_generic(remote_localsplus, localsplus.get(), frame.stacktop * sizeof(PyObject*))) {
+                return NULL;
+            }
+
+            yf = localsplus[frame.stacktop - 1];
+        }
+
+        return yf;
+    }
+
+#elif PY_VERSION_HEX >= 0x030a0000
+    inline PyObject* PyGen_yf(PyGenObject* Py_UNUSED(gen), PyObject* frame_addr)
+    {
+        PyObject* yf = NULL;
+        PyFrameObject* f = (PyFrameObject*)frame_addr;
+
+        if (f) {
+            PyFrameObject frame;
+            if (copy_type(f, frame))
+                return NULL;
+
+            if (frame.f_lasti < 0)
+                return NULL;
+
+            PyCodeObject code;
+            if (copy_type(frame.f_code, code))
+                return NULL;
+
+            Py_ssize_t s = 0;
+            auto c = pybytes_to_bytes_and_size(code.co_code, &s);
+            if (c == nullptr)
+                return NULL;
+
+            Py_ssize_t idx = (frame.f_lasti + 1) * sizeof(_Py_CODEUNIT);
+            if (idx < 0 || idx >= s)
+                return NULL;
+
+            if (c[idx] != YIELD_FROM)
+                return NULL;
+
+            ssize_t nvalues = frame.f_stackdepth;
+            if (nvalues < 1 || nvalues > MAX_STACK_SIZE)
+                return NULL;
+
+            auto stack = std::make_unique<PyObject*[]>(nvalues);
+
+            if (copy_generic(frame.f_valuestack, stack.get(), nvalues * sizeof(PyObject*)))
+                return NULL;
+
+            yf = stack[nvalues - 1];
+        }
+
+        return yf;
+    }
+
+#else
+    inline PyObject* PyGen_yf(PyGenObject* Py_UNUSED(gen), PyObject* frame_addr)
+    {
+        PyObject* yf = NULL;
+        PyFrameObject* f = (PyFrameObject*)frame_addr;
+
+        if (frame_addr == NULL)
+            return NULL;
+
+        PyFrameObject frame;
+        if (copy_type(f, frame))
+            return NULL;
+
+        if (frame.f_stacktop) {
+            if (frame.f_lasti < 0)
+                return NULL;
+
+            PyCodeObject code;
+            if (copy_type(frame.f_code, code))
+                return NULL;
+
+            Py_ssize_t s = 0;
+            auto c = pybytes_to_bytes_and_size(code.co_code, &s);
+            if (c == nullptr)
+                return NULL;
+
+            Py_ssize_t idx = frame.f_lasti + sizeof(_Py_CODEUNIT);
+            if (idx < 0 || idx >= s)
+                return NULL;
+
+            if (c[idx] != YIELD_FROM)
+                return NULL;
+
+            auto stacktop = std::make_unique<PyObject*>();
+            if (copy_generic(frame.f_stacktop - 1, stacktop.get(), sizeof(PyObject*)))
+                return NULL;
+
+            yf = *stacktop;
+        }
+
+        return yf;
+    }
+#endif
+}

--- a/cpp/cpu/ddtrace_stack/echion/echion/danger.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/danger.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <cassert>
+#include <csignal>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#if defined PL_DARWIN
+#include <pthread.h>
+
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach/machine/kern_return.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#endif
+
+int
+init_segv_catcher();
+
+void
+uninstall_segv_handler();
+
+// Returns true only if our signal handler owns both SIGSEGV and SIGBUS; false on any error.
+bool
+segv_handler_installed();
+
+#if defined PL_LINUX
+ssize_t
+safe_memcpy_wrapper(pid_t,
+                    const struct iovec* __dstvec,
+                    unsigned long int __dstiovcnt,
+                    const struct iovec* __srcvec,
+                    unsigned long int __srciovcnt,
+                    unsigned long int);
+#elif defined PL_DARWIN
+kern_return_t
+safe_memcpy_wrapper(vm_map_read_t target_task,
+                    mach_vm_address_t address,
+                    mach_vm_size_t size,
+                    mach_vm_address_t data,
+                    mach_vm_size_t* outsize);
+#endif
+
+struct ThreadAltStack
+{
+  private:
+    inline static constexpr size_t kAltStackSize = 1 << 20; // 1 MiB
+
+  public:
+    void* mem = nullptr;
+    size_t size = 0;
+    bool ready = false;
+    bool owns_mapping = false;
+
+    int ensure_installed()
+    {
+        if (ready) {
+            return 0;
+        }
+
+        // An alternate signal stack is already installed on this thread, by the
+        // application, CPython's faulthandler, or libdatadog's crashtracker (which by
+        // default creates and owns its own larger alt stack because CPython's default is
+        // too small). Adopt it rather than replacing it, and record that we do not own
+        // the mapping: the destructor must never disable or free an alt stack we did not
+        // allocate, or we would break the owner's fault handling (e.g. crashtracker).
+        stack_t cur{};
+        if (sigaltstack(nullptr, &cur) == 0 && !(cur.ss_flags & SS_DISABLE)) {
+            ready = true;
+            owns_mapping = false;
+            return 0;
+        }
+
+        void* stack_mem = mmap(nullptr, kAltStackSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (stack_mem == MAP_FAILED) {
+            std::cerr << "Failed to allocate alt stack. Memory copying may not work. "
+                      << "Error: " << strerror(errno) << std::endl;
+            return -1;
+        }
+
+        stack_t ss{};
+        ss.ss_sp = stack_mem;
+        ss.ss_size = kAltStackSize;
+        ss.ss_flags = 0;
+        if (sigaltstack(&ss, nullptr) != 0) {
+            std::cerr << "Failed to set alt stack. Memory copying may not work. "
+                      << "Error: " << strerror(errno) << std::endl;
+            munmap(stack_mem, kAltStackSize);
+            return -1;
+        }
+
+        this->mem = stack_mem;
+        this->size = kAltStackSize;
+        this->ready = true;
+        this->owns_mapping = true;
+
+        return 0;
+    }
+
+    ~ThreadAltStack()
+    {
+        // Do not disable an alternate signal stack that this ThreadAltStack did not allocate.
+        if (!ready || !owns_mapping || mem == nullptr) {
+            return;
+        }
+
+        // Only disable the alt stack if the one currently installed on this thread is still
+        // the one we installed. Another component (for example crashtracker) may have replaced
+        // this thread's alt stack after us; disabling in that case would strip the replacement
+        // owner's alt stack and break its fault handling. We free our own mapping regardless.
+        stack_t cur{};
+        if (sigaltstack(nullptr, &cur) == 0 && cur.ss_sp == mem && !(cur.ss_flags & SS_DISABLE)) {
+            stack_t disable{};
+            disable.ss_flags = SS_DISABLE;
+            (void)sigaltstack(&disable, nullptr);
+        }
+        munmap(mem, size);
+    }
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/echion_sampler.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/echion_sampler.h
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <echion/cache.h>
+#include <echion/frame.h>
+#include <echion/strings.h>
+#include <echion/threads.h>
+
+#include "stack_renderer.hpp"
+
+// Forward declaration
+class Frame;
+
+class EchionSampler
+{
+    // Thread Info map (Thread ID -> ThreadInfo)
+    std::unordered_map<uintptr_t, ThreadInfo::Ptr> thread_info_map_;
+    std::mutex thread_info_map_lock_;
+
+    // Task Link maps (Task -> Task relationships)
+    std::unordered_map<PyObject*, PyObject*> task_link_map_;
+    std::unordered_map<PyObject*, PyObject*> weak_task_link_map_;
+    std::mutex task_link_map_lock_;
+
+    // Greenlet maps
+    std::unordered_map<GreenletInfo::ID, GreenletInfo::Ptr> greenlet_info_map_;
+    std::unordered_map<GreenletInfo::ID, GreenletInfo::ID> greenlet_parent_map_;
+    std::unordered_map<uintptr_t, GreenletInfo::ID> greenlet_thread_map_;
+    std::mutex greenlet_info_map_lock_;
+
+    // Asyncio state
+    PyObject* asyncio_scheduled_tasks_ = nullptr;
+    PyObject* asyncio_eager_tasks_ = nullptr;
+
+    // Task unwinding state
+    std::optional<Frame::Key> asyncio_frame_cache_key_;
+    std::optional<Frame::Key> uvloop_frame_cache_key_;
+    std::unordered_set<PyObject*> previous_task_objects_;
+
+    // Sampling-thread scratch buffer. Only the single sampling thread
+    // (Sampler::sampling_thread) touches this. unwind_frame clears it on
+    // entry; reusing the hash table across calls eliminates per-call
+    // allocator churn.
+    std::unordered_set<PyObject*> seen_frames_scratch_;
+
+    // Accumulated asyncio task count across sampled threads in the current sampling cycle.
+    // When thread subsampling is enabled (_DD_PROFILING_STACK_MAX_THREADS), this only
+    // reflects tasks from the sampled subset, not all threads in the process.
+    // Only accessed from the sampling thread, so no lock/atomic is needed.
+    size_t asyncio_task_count_ = 0;
+
+    // Caches
+    StringTable string_table_;
+    LRUCache<uintptr_t, Frame> frame_cache_;
+
+    // Stack renderer for outputting samples
+    Datadog::StackRenderer renderer_;
+
+  public:
+    EchionSampler(size_t frame_cache_capacity = 1024)
+      : frame_cache_(frame_cache_capacity)
+    {
+    }
+    ~EchionSampler() = default;
+
+    Datadog::StackRenderer& renderer() { return renderer_; }
+
+    std::unordered_map<uintptr_t, ThreadInfo::Ptr>& thread_info_map() { return thread_info_map_; }
+    std::mutex& thread_info_map_lock() { return thread_info_map_lock_; }
+
+    std::unordered_map<PyObject*, PyObject*>& task_link_map() { return task_link_map_; }
+    std::unordered_map<PyObject*, PyObject*>& weak_task_link_map() { return weak_task_link_map_; }
+    std::mutex& task_link_map_lock() { return task_link_map_lock_; }
+
+    std::unordered_map<GreenletInfo::ID, GreenletInfo::Ptr>& greenlet_info_map() { return greenlet_info_map_; }
+    std::unordered_map<GreenletInfo::ID, GreenletInfo::ID>& greenlet_parent_map() { return greenlet_parent_map_; }
+    std::unordered_map<uintptr_t, GreenletInfo::ID>& greenlet_thread_map() { return greenlet_thread_map_; }
+    std::mutex& greenlet_info_map_lock() { return greenlet_info_map_lock_; }
+
+    PyObject* asyncio_scheduled_tasks() const { return asyncio_scheduled_tasks_; }
+    PyObject* asyncio_eager_tasks() const { return asyncio_eager_tasks_; }
+
+    void init_asyncio(PyObject* scheduled_tasks, PyObject* eager_tasks)
+    {
+        asyncio_scheduled_tasks_ = scheduled_tasks;
+        asyncio_eager_tasks_ = (eager_tasks != Py_None) ? eager_tasks : nullptr;
+    }
+
+    std::optional<Frame::Key>& asyncio_frame_cache_key() { return asyncio_frame_cache_key_; }
+    std::optional<Frame::Key>& uvloop_frame_cache_key() { return uvloop_frame_cache_key_; }
+    std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
+
+    std::unordered_set<PyObject*>& seen_frames_scratch() { return seen_frames_scratch_; }
+
+    void reset_asyncio_task_count() { asyncio_task_count_ = 0; }
+    void add_asyncio_task_count(size_t count) { asyncio_task_count_ += count; }
+    size_t asyncio_task_count() const { return asyncio_task_count_; }
+
+    // Accessor for StringTable operations
+    StringTable& string_table() { return string_table_; }
+    const StringTable& string_table() const { return string_table_; }
+
+    // Accessor for frame cache operations
+    LRUCache<uintptr_t, Frame>& frame_cache() { return frame_cache_; }
+
+    void postfork_child()
+    {
+        // Re-init mutexes (placement new to avoid UB)
+        new (&thread_info_map_lock_) std::mutex;
+        new (&task_link_map_lock_) std::mutex;
+        new (&greenlet_info_map_lock_) std::mutex;
+
+        // Reset string_table mutex
+        string_table_.postfork_child();
+
+        // Reset frame cache. Use postfork_child (placement new) instead of std::list::clear
+        // because the Sampling Thread may have been modifying the cache when fork
+        // took its snapshot. Traversing a corrupted list to free nodes would crash.
+        frame_cache_.postfork_child();
+
+        // Also use placement new for all containers touched by the sampling thread.
+        // Using placement new means the existing containers are abandoned and
+        // their memory leaked in the child and we may lose some data (e.g. relationships
+        // between asyncio Tasks).
+        // However, this is the only way to safely continue working after fork.
+        new (&thread_info_map_) std::unordered_map<uintptr_t, ThreadInfo::Ptr>();
+        new (&task_link_map_) std::unordered_map<PyObject*, PyObject*>();
+        new (&weak_task_link_map_) std::unordered_map<PyObject*, PyObject*>();
+        new (&greenlet_info_map_) std::unordered_map<GreenletInfo::ID, GreenletInfo::Ptr>();
+        new (&greenlet_parent_map_) std::unordered_map<GreenletInfo::ID, GreenletInfo::ID>();
+        new (&greenlet_thread_map_) std::unordered_map<uintptr_t, GreenletInfo::ID>();
+        new (&previous_task_objects_) std::unordered_set<PyObject*>();
+
+        asyncio_frame_cache_key_.reset();
+        uvloop_frame_cache_key_.reset();
+        asyncio_task_count_ = 0;
+
+        new (&seen_frames_scratch_) std::unordered_set<PyObject*>();
+
+        // Clear renderer caches to avoid using stale interned IDs from the
+        // parent's Profiles Dictionary
+        renderer_.postfork_child();
+    }
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/errors.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/errors.h
@@ -1,0 +1,192 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+enum class ErrorKind
+{
+    Undefined,
+    LookupError,
+    FrameError,
+    MirrorError,
+    PyLongError,
+    PyUnicodeError,
+    StackChunkError,
+    GenInfoError,
+    TaskInfoError,
+    TaskInfoGeneratorError,
+    ThreadInfoError,
+    CpuTimeError,
+    LocationError,
+};
+
+template<typename T>
+class [[nodiscard]] Result
+{
+  public:
+    // Factories
+    static Result ok(const T& v) { return Result(v); }
+    static Result ok(T&& v) { return Result(std::move(v)); }
+    static Result error(ErrorKind e) noexcept { return Result(e); }
+
+    // Constructors
+    Result(const T& v) noexcept(std::is_nothrow_copy_constructible<T>::value)
+      : success_(true)
+    {
+        ::new (static_cast<void*>(std::addressof(value_))) T(v);
+    }
+
+    Result(T&& v) noexcept(std::is_nothrow_move_constructible<T>::value)
+      : success_(true)
+    {
+        ::new (static_cast<void*>(std::addressof(value_))) T(std::move(v));
+    }
+
+    Result(ErrorKind e) noexcept
+      : success_(false)
+    {
+        error_ = e;
+    }
+
+    // Destructor
+    ~Result() { reset(); }
+
+    // Copy ctor
+    Result(const Result& other) noexcept(std::is_nothrow_copy_constructible<T>::value)
+      : success_(other.success_)
+    {
+        if (success_) {
+            ::new (static_cast<void*>(std::addressof(value_))) T(other.value_);
+        } else {
+            error_ = other.error_;
+        }
+    }
+
+    // Move ctor
+    Result(Result&& other) noexcept(std::is_nothrow_move_constructible<T>::value)
+      : success_(other.success_)
+    {
+        if (success_) {
+            ::new (static_cast<void*>(std::addressof(value_))) T(std::move(other.value_));
+        } else {
+            error_ = other.error_;
+        }
+    }
+
+    // Copy assignment
+    Result& operator=(const Result& other) noexcept(std::is_nothrow_copy_constructible<T>::value &&
+                                                    std::is_nothrow_copy_assignable<T>::value)
+    {
+        if (this == &other)
+            return *this;
+
+        if (success_ && other.success_) {
+            value_ = other.value_;
+        } else if (success_ && !other.success_) {
+            value_.~T();
+            success_ = false;
+            error_ = other.error_;
+        } else if (!success_ && other.success_) {
+            ::new (static_cast<void*>(std::addressof(value_))) T(other.value_);
+            success_ = true;
+        } else { // both errors
+            error_ = other.error_;
+        }
+        return *this;
+    }
+
+    // Move assignment
+    Result& operator=(Result&& other) noexcept(std::is_nothrow_move_constructible<T>::value &&
+                                               std::is_nothrow_move_assignable<T>::value)
+    {
+        if (this == &other)
+            return *this;
+
+        if (success_ && other.success_) {
+            value_ = std::move(other.value_);
+        } else if (success_ && !other.success_) {
+            value_.~T();
+            success_ = false;
+            error_ = other.error_;
+        } else if (!success_ && other.success_) {
+            ::new (static_cast<void*>(std::addressof(value_))) T(std::move(other.value_));
+            success_ = true;
+        } else { // both errors
+            error_ = other.error_;
+        }
+        return *this;
+    }
+
+    // Observers
+    explicit operator bool() const noexcept { return success_; }
+
+    T& operator*() & { return value_; }
+    const T& operator*() const& { return value_; }
+    T&& operator*() && { return std::move(value_); }
+
+    T* operator->() { return std::addressof(value_); }
+    const T* operator->() const { return std::addressof(value_); }
+
+    bool has_value() const noexcept { return success_; }
+
+    // If in error, returns default_value
+    template<typename U>
+    T value_or(U&& default_value) const
+    {
+        return success_ ? value_ : static_cast<T>(std::forward<U>(default_value));
+    }
+
+    // Returns ErrorKind::Undefined when holding a value
+    ErrorKind error() const noexcept { return success_ ? ErrorKind::Undefined : error_; }
+
+  private:
+    // Active member is tracked by success_
+    union
+    {
+        ErrorKind error_;
+        T value_;
+    };
+    bool success_;
+
+    void reset() noexcept
+    {
+        if (success_) {
+            value_.~T();
+        }
+    }
+};
+
+// Specialization for void
+template<>
+class [[nodiscard]] Result<void>
+{
+  public:
+    static Result ok() noexcept { return Result(true, ErrorKind::Undefined); }
+    static Result error(ErrorKind e) noexcept { return Result(false, e); }
+    Result(ErrorKind e) noexcept
+      : success_(false)
+      , error_(e)
+    {
+    }
+
+    explicit operator bool() const noexcept { return success_; }
+    bool has_value() const noexcept { return success_; }
+
+    // Returns ErrorKind::Undefined when success
+    ErrorKind error() const noexcept { return success_ ? ErrorKind::Undefined : error_; }
+
+  private:
+    bool success_;
+    ErrorKind error_;
+
+    explicit Result(bool s, ErrorKind e) noexcept
+      : success_(s)
+      , error_(e)
+    {
+    }
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/frame.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/frame.h
@@ -1,0 +1,93 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif
+#include <frameobject.h>
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_interpframe_structs.h>
+#elif PY_VERSION_HEX >= 0x030b0000
+#include <internal/pycore_frame.h>
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
+#include <echion/cache.h>
+#if PY_VERSION_HEX >= 0x030b0000
+#include <echion/stack_chunk.h>
+#endif // PY_VERSION_HEX >= 0x030b0000
+#include <echion/strings.h>
+#include <echion/vm.h>
+
+// Forward declaration
+class EchionSampler;
+
+// ----------------------------------------------------------------------------
+class Frame
+{
+  public:
+    using Ref = std::reference_wrapper<Frame>;
+    using Ptr = std::unique_ptr<Frame>;
+    using Key = uintptr_t;
+
+    // ------------------------------------------------------------------------
+    Key cache_key = 0;
+    StringTable::Key filename = 0;
+    StringTable::Key name = 0;
+
+    unsigned line = 0;
+    uintptr_t code_object = 0; // PyCodeObject address, matches Python's id(code)
+    int lasti = -1;            // Last bytecode offset in _Py_CODEUNIT units
+    int first_lineno = 0;      // co_firstlineno, used to detect code object address reuse
+
+    // ------------------------------------------------------------------------
+    Frame(StringTable::Key filename, StringTable::Key name)
+      : filename(filename)
+      , name(name)
+    {
+    }
+    Frame(StringTable::Key name)
+      : name(name) {};
+    [[nodiscard]] static Result<Frame::Ptr> create(EchionSampler& echion, PyCodeObject* code, int lasti);
+
+#if PY_VERSION_HEX >= 0x030b0000
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(EchionSampler& echion,
+                                                                    _PyInterpreterFrame* frame_addr,
+                                                                    _PyInterpreterFrame** prev_addr);
+#else
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> read(EchionSampler& echion,
+                                                                    PyObject* frame_addr,
+                                                                    PyObject** prev_addr);
+#endif
+
+    [[nodiscard]] static Result<std::reference_wrapper<Frame>> get(EchionSampler& echion,
+                                                                   PyCodeObject* code_addr,
+                                                                   int lasti);
+    static Frame& get(EchionSampler& echion, StringTable::Key name);
+
+  private:
+    [[nodiscard]] Result<void> inline infer_location(PyCodeObject* code, int instr_offset);
+    // co_firstlineno is included in the key to prevent stale cache hits when Python
+    // reuses a freed PyCodeObject's memory address for a new code object. Without it,
+    // the profiler can return a cached <module> frame for a function frame.
+    static inline Key key(PyCodeObject* code, int lasti, int firstlineno);
+};
+
+inline auto INVALID_FRAME = Frame(StringTable::INVALID);
+inline auto UNKNOWN_FRAME = Frame(StringTable::UNKNOWN);
+inline auto C_FRAME = Frame(StringTable::C_FRAME);

--- a/cpp/cpu/ddtrace_stack/echion/echion/greenlets.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/greenlets.h
@@ -1,0 +1,58 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2025 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_frame.h>
+#endif
+
+#include <echion/stacks.h>
+#include <echion/task_name.h>
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#define FRAME_NOT_SET Py_False // Sentinel for frame cell
+
+class EchionSampler;
+
+class GreenletInfo
+{
+  public:
+    typedef std::unique_ptr<GreenletInfo> Ptr;
+    typedef std::reference_wrapper<GreenletInfo> Ref;
+    typedef uintptr_t ID;
+
+    ID greenlet_id = 0;
+    TaskName name;
+    PyObject* frame = NULL;
+
+    GreenletInfo(ID id, PyObject* frame, TaskName name)
+      : greenlet_id(id)
+      , name(std::move(name))
+      , frame(frame)
+    {
+    }
+
+    void unwind(EchionSampler& echion, PyObject*, PyThreadState*, FrameStack&);
+};
+
+// Lightweight snapshot of a greenlet's state for unwinding outside the lock.
+// Frame pointers may become stale after the lock is released (e.g. if the
+// greenlet finishes and the PyFrameObject is freed).  GreenletInfo::unwind()
+// reads through them using copy_type(), which safely handles invalid addresses.
+struct GreenletSnapshot
+{
+    GreenletInfo::ID greenlet_id;
+    TaskName name;
+    PyObject* frame; // potentially-stale address, read via copy_type in unwind
+    // Parent chain: (parent_name, parent_frame) pairs in order from immediate parent up
+    std::vector<std::pair<TaskName, PyObject*>> parent_chain;
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/interp.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/interp.h
@@ -1,0 +1,33 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x03090000
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+#include <internal/pycore_interp.h>
+#endif
+
+#include <functional>
+
+#include <echion/state.h>
+#include <echion/vm.h>
+
+class InterpreterInfo
+{
+  public:
+    int64_t id = 0;
+    void* tstate_head = NULL;
+    void* next = NULL;
+};
+
+void
+for_each_interp(_PyRuntimeState* runtime, const std::function<void(InterpreterInfo& interp)>& callback);

--- a/cpp/cpu/ddtrace_stack/echion/echion/long.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/long.h
@@ -1,0 +1,38 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+#pragma once
+
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+
+#if PY_VERSION_HEX >= 0x030c0000
+#include <internal/pycore_long.h>
+
+// Note: Even if use the right PYLONG_BITS_IN_DIGIT that is specified in the
+// Python we use to build echion, it can be different from the Python that is
+// used to run the program.
+#if PYLONG_BITS_IN_DIGIT == 30
+typedef uint32_t digit;
+#elif PYLONG_BITS_IN_DIGIT == 15
+typedef unsigned short digit;
+#else
+#error "Unsupported PYLONG_BITS_IN_DIGIT"
+#endif // PYLONG_BITS_IN_DIGIT
+#endif // PY_VERSION_HEX >= 0x030c0000
+
+#include <echion/errors.h>
+#include <echion/vm.h>
+
+constexpr Py_ssize_t MAX_DIGITS = 128;
+
+#if PY_VERSION_HEX >= 0x030c0000
+
+[[nodiscard]] Result<long long>
+pylong_to_llong(PyObject* long_addr);
+
+#endif

--- a/cpp/cpu/ddtrace_stack/echion/echion/mirrors.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/mirrors.h
@@ -1,0 +1,88 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <memory>
+#include <unordered_set>
+
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
+#include <dictobject.h>
+#include <setobject.h>
+
+#include <echion/errors.h>
+#include <echion/vm.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+#include <internal/pycore_dict.h>
+#else
+typedef struct
+{
+    Py_hash_t me_hash;
+    PyObject* me_key;
+    PyObject* me_value; /* This field is only meaningful for combined tables */
+} PyDictKeyEntry;
+
+typedef Py_ssize_t (*dict_lookup_func)(PyDictObject* mp, PyObject* key, Py_hash_t hash, PyObject** value_addr);
+
+/* See dictobject.c for actual layout of DictKeysObject */
+typedef struct _dictkeysobject
+{
+    Py_ssize_t dk_refcnt;
+
+    /* Size of the hash table (dk_indices). It must be a power of 2. */
+    Py_ssize_t dk_size;
+
+    dict_lookup_func dk_lookup;
+
+    /* Number of usable entries in dk_entries. */
+    Py_ssize_t dk_usable;
+
+    /* Number of used entries in dk_entries. */
+    Py_ssize_t dk_nentries;
+
+    char dk_indices[]; /* char is required to avoid strict aliasing. */
+
+} PyDictKeysObject;
+
+typedef PyObject* PyDictValues;
+#endif
+
+constexpr ssize_t MAX_MIRROR_SIZE = 1 << 20; // 1 MiB
+constexpr ssize_t MAX_MIRROR_ITEMS = MAX_MIRROR_SIZE / sizeof(setentry);
+
+class MirrorObject
+{
+  protected:
+    MirrorObject(std::unique_ptr<char[]> data)
+      : data(std::move(data))
+    {
+    }
+
+    std::unique_ptr<char[]> data = nullptr;
+};
+
+// ----------------------------------------------------------------------------
+class MirrorSet : public MirrorObject
+{
+  public:
+    [[nodiscard]] static Result<MirrorSet> create(PyObject*);
+    [[nodiscard]] Result<std::unordered_set<PyObject*>> as_unordered_set();
+
+  private:
+    MirrorSet(size_t size, PySetObject set, std::unique_ptr<char[]> data)
+      : MirrorObject(std::move(data))
+      , size(size)
+      , set(set)
+    {
+    }
+
+    size_t size;
+    PySetObject set;
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/stack_chunk.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/stack_chunk.h
@@ -1,0 +1,56 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+#include <internal/pycore_frame.h>
+#include <internal/pycore_pystate.h>
+
+#include <memory>
+#include <vector>
+
+#include <echion/errors.h>
+#include <echion/vm.h>
+
+const constexpr size_t MAX_CHUNK_SIZE = 256 * 1024; // 256KB
+
+// ----------------------------------------------------------------------------
+class StackChunk
+{
+  public:
+    StackChunk() {}
+
+    [[nodiscard]] Result<void> update(_PyStackChunk* chunk_addr);
+    void* resolve(void* frame_addr);
+    bool is_valid() const;
+
+  private:
+    [[nodiscard]] Result<void> update_with_depth(_PyStackChunk* chunk_addr, size_t depth);
+
+    static constexpr size_t kMaxChunkDepth = 64;
+    void* origin = NULL;
+    std::vector<char> data;
+    size_t data_capacity = 0;
+
+    // copied_size stores the actual number of bytes copied by StackChunk::update.
+    // This MUST be used for bounds checking in StackChunk::resolve, NOT chunk->size from the copied data,
+    // because a race condition can cause chunk->size to be larger than what was actually copied.
+    size_t copied_size = 0;
+    std::unique_ptr<StackChunk> previous = nullptr;
+};
+
+// ----------------------------------------------------------------------------
+
+inline std::unique_ptr<StackChunk> stack_chunk = nullptr;
+
+#endif // PY_VERSION_HEX >= 0x030b0000

--- a/cpp/cpu/ddtrace_stack/echion/echion/stacks.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/stacks.h
@@ -1,0 +1,79 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <echion/config.h>
+#include <echion/frame.h>
+#include <echion/task_name.h>
+#if PY_VERSION_HEX >= 0x030b0000
+#include "echion/stack_chunk.h"
+#endif // PY_VERSION_HEX >= 0x030b0000
+#include <echion/errors.h>
+
+class EchionSampler;
+
+// ----------------------------------------------------------------------------
+// FrameStack owns the Frames so that they stay valid across cache evictions
+// (asyncio unwind_tasks precomputes per-task stacks via Frame::get, which can
+// evict entries still referenced from an earlier thread-stack capture).
+class FrameStack : public std::vector<Frame>
+{
+  public:
+    using Key = Frame::Key;
+
+    void render(EchionSampler& echion);
+};
+
+// Forward declaration
+class EchionSampler;
+
+// ----------------------------------------------------------------------------
+// Primary entry point. The caller supplies the cycle-detection set; callers on
+// the sampling thread should pass EchionSampler::seen_frames_scratch() so the
+// hash table's capacity is reused across calls instead of reallocated per call.
+// `seen_frames` is cleared on entry.
+size_t
+unwind_frame(EchionSampler& echion,
+             PyObject* frame_addr,
+             FrameStack& stack,
+             std::unordered_set<PyObject*>& seen_frames,
+             size_t max_depth = max_frames);
+
+// Convenience variant that owns a local scratch set, for callers that have no
+// reusable scratch to share (fuzz harnesses and other callers outside the
+// sampling thread). Prefer the primary overload above on the sampling thread.
+size_t
+unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth = max_frames);
+
+// ----------------------------------------------------------------------------
+void
+unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack);
+
+// ----------------------------------------------------------------------------
+class StackInfo
+{
+  public:
+    TaskName task_name;
+    // Numeric task identifier emitted as the "task id" label.
+    // Must match _task.task_object_address() (lock profiler) so the backend can
+    // correlate stack and lock samples on the timeline.
+    uint64_t task_id;
+    bool on_cpu;
+    FrameStack stack;
+
+    StackInfo(TaskName task_name, bool on_cpu, uint64_t task_id)
+      : task_name(std::move(task_name))
+      , task_id(task_id)
+      , on_cpu(on_cpu)
+    {
+    }
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/state.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/state.h
@@ -1,0 +1,22 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif
+
+#if defined __GNUC__ && defined HAVE_STD_ATOMIC
+#undef HAVE_STD_ATOMIC
+#endif
+#include <internal/pycore_pystate.h>
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_runtime.h>
+#endif

--- a/cpp/cpu/ddtrace_stack/echion/echion/strings.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/strings.h
@@ -1,0 +1,108 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define Py_BUILD_CORE
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <unicodeobject.h>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include <echion/errors.h>
+#include <echion/vm.h>
+
+constexpr ssize_t MAX_STRING_SIZE = 1 << 20; // 1 MiB
+
+// ----------------------------------------------------------------------------
+std::unique_ptr<unsigned char[]>
+pybytes_to_bytes_and_size(PyObject* bytes_addr, Py_ssize_t* size);
+
+// ----------------------------------------------------------------------------
+Result<std::string>
+pyunicode_to_utf8(PyObject* str_addr);
+
+// ----------------------------------------------------------------------------
+// NOTE: StringTag is used to salt the upper bits of string table keys.
+// This prevents collisions when Python reuses memory addresses for different
+// types of strings (e.g., a filename getting deallocated and the same address
+// being reused for a code object's name). Without tags, we'd return stale
+// cached values for the wrong string type.
+enum class StringTag : uint8_t
+{
+    Unknown = 0,  // Default/untagged (for backwards compatibility)
+    FileName = 1, // co_filename from code objects
+    FuncName = 2, // co_name / co_qualname from code objects
+};
+
+class StringTable
+{
+  public:
+    using Key = uintptr_t;
+    using Map = std::unordered_map<Key, std::string>;
+
+    // Tag is stored in the upper 8 bits of the key (bits 56-63).
+    // On x86_64, only 48 bits are used for virtual addresses, so this is safe.
+    // On other architectures with larger address spaces, collisions are still
+    // unlikely and the worst case is just a cache miss (re-read the string).
+    static constexpr int TAG_SHIFT = 56;
+    static constexpr Key TAG_MASK = static_cast<Key>(0xFF) << TAG_SHIFT;
+
+    [[nodiscard]] static constexpr Key make_tagged_key(uintptr_t addr, StringTag tag)
+    {
+        return (addr & ~TAG_MASK) | (static_cast<Key>(tag) << TAG_SHIFT);
+    }
+
+    [[nodiscard]] static constexpr StringTag extract_tag(Key key)
+    {
+        return static_cast<StringTag>((key & TAG_MASK) >> TAG_SHIFT);
+    }
+
+    static constexpr Key INVALID = 1;
+    static constexpr Key UNKNOWN = 2;
+    static constexpr Key C_FRAME = 3;
+
+    // Python string object
+    [[nodiscard]] Result<Key> key(PyObject* s, StringTag tag = StringTag::Unknown);
+
+    [[nodiscard]] Result<std::reference_wrapper<const std::string>> lookup(Key key) const;
+
+    [[nodiscard]] inline size_t size() const
+    {
+        const std::lock_guard<std::mutex> lock(table_lock);
+        return table_.size();
+    }
+
+    StringTable()
+    {
+        table_.emplace(0, "");
+        table_.emplace(INVALID, "<invalid>");
+        table_.emplace(UNKNOWN, "<unknown>");
+    }
+
+    void postfork_child()
+    {
+        // NB placement-new to re-init and leak the mutex because doing anything else is UB
+        new (&table_lock) std::mutex();
+        // table_ may be in a mid-emplace state if fork raced with
+        // StringTable::key. Its inherited bucket/node pointers may be inconsistent,
+        // so calling clear would traverse the same corrupted linked-list state.
+        // Use placement-new to reconstruct the map without inspecting its contents.
+        new (&table_) Map();
+        // Restore sentinel entries expected by the rest of the code.
+        table_.emplace(0, "");
+        table_.emplace(INVALID, "<invalid>");
+        table_.emplace(UNKNOWN, "<unknown>");
+    }
+
+  private:
+    Map table_;
+    mutable std::mutex table_lock;
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/task_name.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/task_name.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+class TaskName
+{
+  public:
+    [[nodiscard]] static TaskName from_literal(std::string value) { return TaskName(std::move(value)); }
+
+    [[nodiscard]] static TaskName from_asyncio_task_id(std::uint64_t id) { return TaskName(AsyncioTaskId{ id }); }
+
+    [[nodiscard]] static TaskName from_greenlet_id(std::uint64_t id) { return TaskName(GreenletId{ id }); }
+
+    [[nodiscard]] static TaskName from_gevent_name(std::string_view name)
+    {
+        auto maybe_id = parse_prefixed_uint(name, "Greenlet-");
+        if (maybe_id) {
+            return from_greenlet_id(*maybe_id);
+        }
+        return from_literal(std::string(name));
+    }
+
+    // The string_view passed to callback is valid only for the callback duration.
+    template<typename Callback>
+    void visit_string(Callback&& callback) const
+    {
+        std::visit(
+          [&](const auto& v) {
+              using T = std::decay_t<decltype(v)>;
+              if constexpr (std::is_same_v<T, std::string>) {
+                  callback(std::string_view(v));
+              } else if constexpr (std::is_same_v<T, AsyncioTaskId>) {
+                  visit_prefixed_number("Task-", v.value, callback);
+              } else if constexpr (std::is_same_v<T, GreenletId>) {
+                  visit_prefixed_number("Greenlet-", v.value, callback);
+              }
+          },
+          storage_);
+    }
+
+  private:
+    struct AsyncioTaskId
+    {
+        std::uint64_t value;
+    };
+    struct GreenletId
+    {
+        std::uint64_t value;
+    };
+
+    using Storage = std::variant<std::string, AsyncioTaskId, GreenletId>;
+
+    explicit TaskName(std::string s)
+      : storage_(std::move(s))
+    {
+    }
+    explicit TaskName(AsyncioTaskId id)
+      : storage_(id)
+    {
+    }
+    explicit TaskName(GreenletId id)
+      : storage_(id)
+    {
+    }
+
+    template<std::size_t PrefixSize, typename Callback>
+    static void visit_prefixed_number(const char (&prefix)[PrefixSize], std::uint64_t value, Callback&& callback)
+    {
+        constexpr std::size_t prefix_size = PrefixSize - 1;
+        constexpr std::size_t max_digits = std::numeric_limits<std::uint64_t>::digits10 + 1;
+        std::array<char, prefix_size + max_digits> buffer{};
+
+        auto digits_begin = std::copy_n(prefix, prefix_size, buffer.begin());
+
+        auto [ptr, ec] = std::to_chars(std::to_address(digits_begin), buffer.data() + buffer.size(), value);
+        if (ec != std::errc{}) {
+            callback(std::string_view("<unknown>"));
+            return;
+        }
+
+        callback(std::string_view(buffer.data(), static_cast<std::size_t>(ptr - buffer.data())));
+    }
+
+    [[nodiscard]] static std::optional<std::uint64_t> parse_prefixed_uint(std::string_view value,
+                                                                          std::string_view prefix)
+    {
+        if (value.size() <= prefix.size() || value.compare(0, prefix.size(), prefix) != 0) {
+            return std::nullopt;
+        }
+
+        const char* suffix_begin = value.data() + prefix.size();
+        const char* suffix_end = value.data() + value.size();
+        std::uint64_t result = 0;
+        auto [ptr, ec] = std::from_chars(suffix_begin, suffix_end, result);
+        if (ec != std::errc{} || ptr != suffix_end) {
+            return std::nullopt;
+        }
+
+        return result;
+    }
+
+    Storage storage_;
+};

--- a/cpp/cpu/ddtrace_stack/echion/echion/tasks.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/tasks.h
@@ -1,0 +1,157 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#define Py_BUILD_CORE
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <frameobject.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+#include <cpython/genobject.h>
+
+#include <cstddef>
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_frame.h>
+#include <opcode.h>
+#elif PY_VERSION_HEX >= 0x030d0000
+#include <opcode.h>
+#else
+#include <internal/pycore_frame.h>
+#include <internal/pycore_opcode.h>
+#endif // PY_VERSION_HEX >= 0x030d0000
+#else
+#include <genobject.h>
+#include <opcode.h>
+#endif // PY_VERSION_HEX >= 0x30b0000
+
+#include <memory>
+#include <utility>
+
+#include <echion/config.h>
+#include <echion/errors.h>
+#include <echion/frame.h>
+#include <echion/mirrors.h>
+#include <echion/stacks.h>
+#include <echion/state.h>
+#include <echion/task_name.h>
+#include <echion/timing.h>
+
+#include <echion/cpython/tasks.h>
+
+class EchionSampler;
+
+// Max number of recursive calls GenInfo::GenInfo and TaskInfo::TaskInfo can do
+// before raising an error.
+const constexpr size_t MAX_RECURSION_DEPTH = 250;
+
+// This is a private type in CPython, so we need to define it here
+// in order to be able to use it in our code.
+// We cannot put it into namespace {} because the 'PyAsyncGenASend' name would then be ambiguous.
+// The extern "C" is not required but here to avoid any ambiguity.
+extern "C"
+{
+
+    typedef struct PyAsyncGenASend
+    {
+        PyObject_HEAD PyAsyncGenObject* ags_gen;
+    } PyAsyncGenASend;
+
+#ifndef PyAsyncGenASend_CheckExact
+#if PY_VERSION_HEX >= 0x03090000
+// Py_IS_TYPE is only available since Python 3.9
+#define PyAsyncGenASend_CheckExact(obj) (Py_IS_TYPE(obj, &_PyAsyncGenASend_Type))
+#else // PY_VERSION_HEX >= 0x03090000
+#define PyAsyncGenASend_CheckExact(obj) (Py_TYPE(obj) == &_PyAsyncGenASend_Type)
+#endif // PY_VERSION_HEX < 0x03090000
+#endif // defined PyAsyncGenASend_CheckExact
+}
+
+class GenInfo
+{
+  public:
+    using Ptr = std::unique_ptr<GenInfo>;
+
+  private:
+    [[nodiscard]] static Result<GenInfo::Ptr> create_impl(PyObject* gen_addr);
+
+  public:
+    // The address of the Task PyObject* the GenInfo represents
+    PyObject* origin = nullptr;
+
+    // The address of the Frame PyObject* the GenInfo represents
+    PyObject* frame = nullptr;
+
+    // The coroutine awaited by this coroutine, if any
+    GenInfo::Ptr await = nullptr;
+
+    // Whether the coroutine, or the coroutine it awaits, is currently running (on CPU)
+    bool is_running = false;
+
+    [[nodiscard]] static Result<GenInfo::Ptr> create(PyObject* gen_addr);
+    GenInfo(PyObject* origin, PyObject* frame, GenInfo::Ptr await, bool is_running)
+      : origin(origin)
+      , frame(frame)
+      , await(std::move(await))
+      , is_running(is_running)
+    {
+    }
+};
+
+// ----------------------------------------------------------------------------
+
+class TaskInfo
+{
+  public:
+    using Ptr = std::unique_ptr<TaskInfo>;
+    using Ref = std::reference_wrapper<TaskInfo>;
+
+  private:
+    [[nodiscard]] static Result<TaskInfo::Ptr> create_impl(EchionSampler& echion, TaskObj*, size_t recursion_depth);
+
+  public:
+    // The address of the Task PyObject* the TaskInfo represents
+    PyObject* origin = nullptr;
+
+    // The address of the asyncio Event Loop PyObject* the Task is running on
+    PyObject* loop = nullptr;
+
+    // The name of the Task
+    TaskName name;
+
+    // Whether the Task's coroutine (or a coroutine it awaits, transitively) is currently running (on CPU).
+    // This will not be true if the Task is currently awaiting another Task, and this other Task is on CPU.
+    bool is_on_cpu = false;
+
+    // The coroutine wrapped by the Task, i.e. the coroutine passed to asyncio.create_task
+    // or equivalent (e.g. asyncio.run, etc.)
+    GenInfo::Ptr coro = nullptr;
+
+    // The Task that the current Task is awaiting, if any.
+    // Note that this will not be set if the current Task's coroutine is awaiting another coroutine,
+    // only if it is awaiting another Task.
+    TaskInfo::Ptr waiter = nullptr;
+
+    [[nodiscard]] static Result<TaskInfo::Ptr> create(EchionSampler& echion, TaskObj*);
+    TaskInfo(PyObject* origin, PyObject* loop, GenInfo::Ptr coro, TaskName name, TaskInfo::Ptr waiter)
+      : origin(origin)
+      , loop(loop)
+      , name(std::move(name))
+      , is_on_cpu(coro && coro->is_running)
+      , coro(std::move(coro))
+      , waiter(std::move(waiter))
+    {
+    }
+
+    size_t unwind(EchionSampler& echion, FrameStack&, bool using_uvloop);
+};
+
+// Checks whether a Frame is the uvloop.run coroutine wrapper.
+// When uvloop.run is used, the top-level Task contains a wrapper coroutine
+// named "run.<locals>.wrapper" that just validates the loop type and awaits the user's main
+// coroutine. We skip this frame to keep the stack clean and consistent with regular asyncio.
+bool
+is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& frame);

--- a/cpp/cpu/ddtrace_stack/echion/echion/threads.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/threads.h
@@ -1,0 +1,139 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+// Py_BUILD_CORE must be defined before Python.h to avoid conflicting
+// declarations between public and internal headers (e.g., PyObject_GC_IsFinalized)
+#define Py_BUILD_CORE
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_tstate.h>
+#endif
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <unordered_map>
+
+#if defined PL_LINUX
+#include <ctime>
+#elif defined PL_DARWIN
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+#include <echion/errors.h>
+#include <echion/greenlets.h>
+#include <echion/interp.h>
+#include <echion/stacks.h>
+#include <echion/tasks.h>
+#include <echion/timing.h>
+
+class EchionSampler;
+
+class ThreadInfo
+{
+  public:
+    using Ptr = std::unique_ptr<ThreadInfo>;
+
+    uintptr_t thread_id;
+    unsigned long native_id;
+    FrameStack python_stack;
+    std::vector<std::unique_ptr<StackInfo>> current_tasks;
+    std::vector<std::unique_ptr<StackInfo>> current_greenlets;
+
+    std::string name;
+
+#if defined PL_LINUX
+    clockid_t cpu_clock_id;
+#elif defined PL_DARWIN
+    mach_port_t mach_port;
+#endif
+    microsecond_t cpu_time = 0;
+
+    uintptr_t asyncio_loop = 0;
+    uintptr_t tstate_addr = 0; // Remote address of PyThreadState for accessing asyncio_tasks_head
+    bool using_uvloop = false; // Whether this thread is using uvloop instead of asyncio
+
+    [[nodiscard]] Result<void> update_cpu_time();
+
+    [[nodiscard]] Result<void> sample(EchionSampler&, PyThreadState*, microsecond_t);
+    void unwind(EchionSampler&, PyThreadState*);
+
+    // ------------------------------------------------------------------------
+#if defined PL_LINUX
+    ThreadInfo(uintptr_t thread_id, unsigned long native_id, const char* name, clockid_t cpu_clock_id)
+      : thread_id(thread_id)
+      , native_id(native_id)
+      , name(name)
+      , cpu_clock_id(cpu_clock_id)
+    {
+    }
+#elif defined PL_DARWIN
+    ThreadInfo(uintptr_t thread_id, unsigned long native_id, const char* name, mach_port_t mach_port)
+      : thread_id(thread_id)
+      , native_id(native_id)
+      , name(name)
+      , mach_port(mach_port)
+    {
+    }
+#endif
+
+    [[nodiscard]] static Result<std::unique_ptr<ThreadInfo>> create(uintptr_t thread_id,
+                                                                    unsigned long native_id,
+                                                                    const char* name)
+    {
+#if defined PL_LINUX
+        // pthread_getcpuclockid() dereferences pthread_t, but Python's thread_id can be
+        // a gevent greenlet ID or a stale value. Derive the Linux per-thread clock from
+        // the kernel TID instead. clock_gettime() safely rejects an invalid TID with EINVAL.
+        constexpr uint64_t CPUCLOCK_SCHED = 2;
+        constexpr uint64_t CPUCLOCK_PERTHREAD_MASK = 4;
+        auto cpu_clock_id =
+          static_cast<clockid_t>((~static_cast<uint64_t>(native_id) << 3) | (CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK));
+
+        auto result = std::make_unique<ThreadInfo>(thread_id, native_id, name, cpu_clock_id);
+#elif defined PL_DARWIN
+        mach_port_t mach_port;
+        // pthread_mach_thread_np does not return a status code; the behaviour is undefined
+        // if thread_id is invalid.
+        mach_port = pthread_mach_thread_np((pthread_t)thread_id);
+
+        auto result = std::make_unique<ThreadInfo>(thread_id, native_id, name, mach_port);
+#endif
+
+        auto update_cpu_time_success = result->update_cpu_time();
+        if (!update_cpu_time_success) {
+            return ErrorKind::ThreadInfoError;
+        }
+
+        return result;
+    };
+
+  private:
+    void reset_cycle_state() noexcept;
+    void render_unwound_stacks(EchionSampler&);
+    [[nodiscard]] Result<void> unwind_tasks(EchionSampler&, PyThreadState*);
+    void unwind_greenlets(EchionSampler&, PyThreadState*, unsigned long);
+    [[nodiscard]] Result<std::vector<TaskInfo::Ptr>> get_all_tasks(EchionSampler&, PyThreadState* tstate);
+#if PY_VERSION_HEX >= 0x030e0000
+    [[nodiscard]] Result<void> get_tasks_from_thread_linked_list(EchionSampler& echion,
+                                                                 std::vector<TaskInfo::Ptr>& tasks);
+    [[nodiscard]] Result<void> get_tasks_from_interpreter_linked_list(EchionSampler& echion,
+                                                                      PyThreadState* tstate,
+                                                                      std::vector<TaskInfo::Ptr>& tasks);
+    [[nodiscard]] Result<void> get_tasks_from_linked_list(EchionSampler& echion,
+                                                          uintptr_t head_addr,
+                                                          std::vector<TaskInfo::Ptr>& tasks);
+#endif
+};
+
+// ----------------------------------------------------------------------------
+
+using PyThreadStateCallback = std::function<void(PyThreadState*, ThreadInfo&)>;
+
+void
+for_each_thread(EchionSampler& echion, InterpreterInfo& interp, const PyThreadStateCallback& callback);

--- a/cpp/cpu/ddtrace_stack/echion/echion/timing.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/timing.h
@@ -1,0 +1,12 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <cstdint>
+
+typedef int64_t microsecond_t;
+
+#define TS_TO_MICROSECOND(ts) ((ts).tv_sec * 1e6 + (ts).tv_nsec / 1e3)
+#define TV_TO_MICROSECOND(tv) ((tv).seconds * 1e6 + (tv).microseconds)

--- a/cpp/cpu/ddtrace_stack/echion/echion/vm.h
+++ b/cpp/cpu/ddtrace_stack/echion/echion/vm.h
@@ -1,0 +1,145 @@
+// This file is part of "echion" which is released under MIT.
+//
+// Copyright (c) 2023 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+
+#pragma once
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+
+#include <echion/danger.h>
+
+#if defined PL_LINUX
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+typedef pid_t proc_ref_t;
+
+ssize_t
+process_vm_readv(pid_t,
+                 const struct iovec*,
+                 unsigned long liovcnt,
+                 const struct iovec* remote_iov,
+                 unsigned long riovcnt,
+                 unsigned long flags);
+
+#define copy_type(addr, dest) (copy_memory(pid, addr, sizeof(dest), &dest))
+#define copy_type_p(addr, dest) (copy_memory(pid, addr, sizeof(*dest), dest))
+#define copy_generic(addr, dest, size)                                                                                 \
+    (copy_memory(pid, reinterpret_cast<const void*>(addr), size, reinterpret_cast<void*>(dest)))
+
+#elif defined PL_DARWIN
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <mach/machine/kern_return.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+typedef mach_port_t proc_ref_t;
+
+#define copy_type(addr, dest) (copy_memory(mach_task_self(), addr, sizeof(dest), &dest))
+#define copy_type_p(addr, dest) (copy_memory(mach_task_self(), addr, sizeof(*dest), dest))
+#define copy_generic(addr, dest, size) (copy_memory(mach_task_self(), (void*)(addr), size, (void*)(dest)))
+
+inline kern_return_t (*safe_copy)(vm_map_read_t,
+                                  mach_vm_address_t,
+                                  mach_vm_size_t,
+                                  mach_vm_address_t,
+                                  mach_vm_size_t*) = mach_vm_read_overwrite;
+
+#endif
+
+// Whether safe_copy is currently set to the memcpy-based wrapper.
+inline bool fast_copy_active = false;
+
+// User opted out via _DD_PROFILING_STACK_FAST_COPY or set_fast_copy(false).
+inline bool fast_copy_user_disabled = false;
+
+// Sticky: fell back to syscall copy (init failure, foreign handler, warmup miss).
+inline bool fast_copy_syscall_fallback = false;
+
+inline void
+mark_fast_copy_syscall_fallback()
+{
+    fast_copy_syscall_fallback = true;
+}
+
+// Set at init; survives toggling fast_copy_active.
+inline bool safe_memcpy_initialized = false;
+
+#if defined PL_LINUX
+// Whether the process_vm_readv probe succeeded at constructor time.
+inline bool process_vm_readv_available = false;
+
+// True when neither safe_memcpy nor process_vm_readv could be initialized.
+inline bool failed_safe_copy = false;
+
+inline ssize_t (*safe_copy)(pid_t,
+                            const struct iovec*,
+                            unsigned long,
+                            const struct iovec*,
+                            unsigned long,
+                            unsigned long) = process_vm_readv;
+#endif // PL_LINUX
+
+/**
+ * Initialize the safe copy operation on macOS
+ *
+ * Tries safe_memcpy first (unless disabled via env var), falls back to
+ * mach_vm_read_overwrite.
+ * Called explicitly from src/pyroscope_entry.cpp when the sampler starts.
+ */
+// Pyroscope patch: dropped `__attribute__((constructor))` and renamed
+// init_safe_copy -> pyroscope_init_safe_copy.
+//
+// Upstream runs this at dlopen, i.e. on `import pyroscope`, which installs
+// process-wide SIGSEGV/SIGBUS handlers and a 1 MiB alt stack whether or not
+// this profiler is ever selected -- an unacceptable side effect for users who
+// only ever run py-spy. src/pyroscope_entry.cpp calls it explicitly (under a
+// std::once_flag) when the sampler is started instead. See ../VENDOR.md.
+void
+pyroscope_init_safe_copy();
+
+// Switch the active copy method at runtime.  Must be called before the
+// sampling thread is started.
+// Returns true on success, false if the requested method (and its fallback) are unavailable
+// (in which case failed_safe_copy is set and stack profiling should be disabled).
+bool
+set_fast_copy_enabled(bool enabled);
+
+/**
+ * Copy a chunk of memory from a portion of the virtual memory of another
+ * process.
+ * @param proc_ref_t  the process reference (platform-dependent)
+ * @param void *      the remote address
+ * @param ssize_t     the number of bytes to read
+ * @param void *      the destination buffer, expected to be at least as large
+ *                    as the number of bytes to read.
+ *
+ * @return  zero on success, otherwise non-zero.
+ */
+#if defined(ECHION_FUZZING)
+// Let the fuzzing harness control the copy_memory behavior, so we can simulate "garbage" reads.
+extern "C" int
+echion_fuzz_copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void* buf);
+
+inline int
+copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void* buf)
+{
+    return echion_fuzz_copy_memory(proc_ref, addr, len, buf);
+}
+#else
+// Implementation in vm.cc
+int
+copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void* buf);
+#endif
+
+inline pid_t pid = 0;
+
+// Number of copy_memory errors since last drain (thread-safe, incremented from the sampling thread)
+inline std::atomic<size_t> g_copy_memory_error_count{ 0 };
+
+void
+_set_pid(pid_t _pid);

--- a/cpp/cpu/ddtrace_stack/include/constants.hpp
+++ b/cpp/cpu/ddtrace_stack/include/constants.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "dd_wrapper/include/constants.hpp"
+
+// Default sampling frequency in microseconds.  This will almost certainly be overridden by dynamic sampling.
+constexpr unsigned int g_default_sampling_period_us = 10000;     // 100 Hz
+constexpr unsigned int g_min_sampling_period_us = 100;           // 10000 Hz
+constexpr unsigned int g_max_sampling_period_us = 1000000;       // 1 seconds
+constexpr unsigned int g_adaptive_sampling_interval_us = 250000; // 250 ms
+constexpr double g_default_sampling_period_s = g_default_sampling_period_us / 1e6;
+constexpr double g_target_overhead = 0.01; // 1% overhead
+
+// Maximum number of threads to sample per cycle. When the number of threads exceeds this,
+// reservoir sampling (Algorithm R) is used to select a uniform random subset.
+// 0 means no limit (sample all threads).
+constexpr unsigned int g_default_max_threads_per_sample = 25;
+
+// Echion maintains a cache of frames--the size of this cache is specified up-front.
+constexpr unsigned int g_default_echion_frame_cache_size = 1024;

--- a/cpp/cpu/ddtrace_stack/include/origin_task_links.hpp
+++ b/cpp/cpu/ddtrace_stack/include/origin_task_links.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <optional>
+#include <stdint.h>
+#include <string>
+#include <unordered_map>
+
+namespace Datadog {
+
+// Identity of the asyncio task that submitted work to a ThreadPoolExecutor.
+// task_id is the task object's address (id(task) in Python)
+struct OriginTask
+{
+    uint64_t task_id;
+    std::string task_name;
+
+    OriginTask(uint64_t _task_id, std::string _task_name)
+      : task_id(_task_id)
+      , task_name(std::move(_task_name))
+    {
+    }
+
+    // for testing
+    bool operator==(const OriginTask& other) const { return task_id == other.task_id && task_name == other.task_name; }
+};
+
+// Per-(worker)-thread registry of the asyncio task that offloaded the work
+// currently running on that thread. Populated by the futures integration for
+// the duration of an executor job and accessed by stack renderer.
+//
+// Lifecycle matches the stack sampler: enable() after Sampler::start() succeeds,
+// disable_and_reset() before Sampler::stop(). While disabled, link/unlink/get
+// are no-ops so the default-on futures patch is cheap when profiling is off.
+class OriginTaskLinks
+{
+  public:
+    static OriginTaskLinks& get_instance()
+    {
+        static OriginTaskLinks instance;
+        return instance;
+    }
+
+    OriginTaskLinks(OriginTaskLinks const&) = delete;
+    OriginTaskLinks& operator=(OriginTaskLinks const&) = delete;
+
+    void enable();
+    void disable_and_reset();
+    bool is_enabled() const { return enabled_.load(std::memory_order_acquire); }
+
+    void link_origin_task(uint64_t thread_id, uint64_t task_id, std::string task_name);
+    const std::optional<OriginTask> get_origin_task(uint64_t thread_id);
+    void unlink_origin_task(uint64_t thread_id);
+
+    static void postfork_child();
+
+  private:
+    std::atomic<bool> enabled_{ false };
+    std::mutex mtx;
+    std::unordered_map<uint64_t, OriginTask> thread_id_to_origin_task;
+
+    // Private Constructor/Destructor
+    OriginTaskLinks() = default;
+    ~OriginTaskLinks() = default;
+};
+
+}

--- a/cpp/cpu/ddtrace_stack/include/python_headers.hpp
+++ b/cpp/cpu/ddtrace_stack/include/python_headers.hpp
@@ -1,0 +1,7 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif

--- a/cpp/cpu/ddtrace_stack/include/sampler.hpp
+++ b/cpp/cpu/ddtrace_stack/include/sampler.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <vector>
+
+#include "constants.hpp"
+
+#include "echion/task_name.h"
+#include "echion/timing.h"
+
+#include <Python.h>
+
+class EchionSampler;
+
+namespace Datadog {
+
+enum class PauseResult : std::uint8_t
+{
+    Paused,     // sampler was running and is now paused
+    NotRunning, // sampler was not running (nothing to pause)
+    Timeout,    // sampler is running but did not pause within the timeout
+};
+
+class Sampler
+{
+    // This class manages the initialization of echion as well as the sampling thread.
+    // The underlying echion instance it manages keeps much of its state globally, so this class is a singleton in order
+    // to keep it aligned with the echion state.
+    std::unique_ptr<EchionSampler> echion;
+
+    // The sampling interval is atomic because it needs to be safely propagated to the sampling thread
+    std::atomic<microsecond_t> sample_interval_us{ g_default_sampling_period_us };
+
+    // This is not a running total of the number of launched threads; it is a sequence for the
+    // transactions upon the sampling threads (usually starts + stops). This allows threads to be
+    // stopped or started in a straightforward manner without finer-grained control (locks)
+    std::atomic<uint64_t> thread_seq_num{ 0 };
+
+    // Thread exit synchronization - allows stop() to wait for the sampling thread to exit.
+    // The mutex + condition variable pair is used to avoid the "lost wake-up" race condition
+    // where stop() could miss the notification and hang forever (or until timeout).
+    std::atomic<bool> thread_running{ false };
+    // Whether the sampler is currently active. Unlike thread_running (which tracks
+    // the thread's actual lifecycle) this is set synchronously in start/stop, so
+    // it is not subject to the sampling-thread startup race.
+    // It becomes false in stop and also when the sampling thread aborts on an
+    // unexpected exception, since the sampler is then no longer active.
+    // prefork reads this to decide whether to restart the sampler after fork,
+    // ensuring a sampler that stopped due to an error is not silently restarted.
+    std::atomic<bool> sampler_active_{ false };
+    std::mutex thread_exit_mutex;
+    std::condition_variable thread_exit_cv;
+
+    // Pause synchronization — allows the faulthandler wrapper to temporarily
+    // suspend sampling so signal handlers can be safely swapped without racing
+    // with in-flight safe_memcpy calls.
+    std::atomic<bool> pause_requested_{ false };
+    std::atomic<bool> paused_{ false };
+    std::mutex pause_mutex_;
+    std::condition_variable pause_cv_;
+
+    // This is a singleton, so no public constructor
+    Sampler();
+
+    // One-time setup of echion
+    void one_time_setup();
+
+    // Internal perf counters
+    uint64_t process_count = 0;
+    uint64_t sampler_thread_count = 0;
+
+    bool do_adaptive_sampling = true;
+    double target_overhead = g_target_overhead;
+    microsecond_t max_sampling_period_us = g_max_sampling_period_us;
+    unsigned int max_threads_per_sample = g_default_max_threads_per_sample;
+    std::minstd_rand rng{ std::random_device{}() };
+    std::vector<PyThreadState> thread_candidates;
+    void adapt_sampling_interval();
+
+    // Captures one sampling cycle across all threads (or a reservoir-sampled subset thereof
+    // when max_threads_per_sample is set).
+    void capture_samples(microsecond_t wall_time_us);
+
+    // Rolling window for p_stable: ring buffer of process_delta values (us CPU per adapt window).
+    // p_stable is the p-th percentile of this buffer, giving a stable estimate of app CPU usage
+    // that doesn't collapse to zero during brief idle periods.
+    std::vector<double> process_delta_window;
+    size_t process_delta_window_head = 0;
+
+    // Baseline CPU budget (us per adapt window) corresponding to an absolute floor overhead.
+    // Derived from baseline_core_pct at configuration time; keeps the profiler sampling even
+    // when app CPU is near 0.
+    double baseline_cpu_us_per_adapt_window = 0.0;
+
+    // Percentile (0..1) used for p_stable; configurable, default p95.
+    double p_stable_percentile_frac = 0.95;
+
+    // Fast-copy startup warmup in seconds.
+    double fast_copy_warmup_seconds = 15.0;
+
+    // Rolling window duration in seconds; controls the ring buffer capacity.
+    uint32_t p_stable_window_s = 600;
+
+    // Tracks whether the sampler was running when prefork was called,
+    // so that postfork_parent/restart_after_fork can restore it.
+    bool was_running_at_fork_{ false };
+
+    void atfork_child();
+    friend void stack_atfork_prepare();
+    friend void stack_atfork_parent();
+    friend void stack_atfork_child();
+
+  public:
+    // Singleton instance
+    static Sampler& get();
+
+    // Accessor for EchionSampler
+    EchionSampler& get_echion() { return *echion; }
+
+    bool start();
+    void stop();
+    PauseResult pause();
+    void resume();
+    void register_thread(uint64_t id, uint64_t native_id, const char* name);
+    void unregister_thread(uint64_t id);
+    void track_asyncio_loop(uintptr_t thread_id, PyObject* loop);
+    void init_asyncio(PyObject* _asyncio_scheduled_tasks, PyObject* _asyncio_eager_tasks);
+    void link_tasks(PyObject* parent, PyObject* child);
+    void weak_link_tasks(PyObject* parent, PyObject* child);
+    void sampling_thread(const uint64_t seq_num);
+    void track_greenlet(uintptr_t greenlet_id, TaskName name, PyObject* frame);
+    void untrack_greenlet(uintptr_t greenlet_id);
+    void link_greenlets(uintptr_t parent, uintptr_t child);
+    void update_greenlet_frame(uintptr_t greenlet_id, PyObject* frame);
+    void set_uvloop_mode(uintptr_t thread_id, bool value);
+
+    // The Python side dynamically adjusts the sampling rate based on overhead, so we need to be able to update our
+    // own intervals accordingly.  Rather than a preemptive measure, we assume the rate is ~fairly stable and just
+    // update the next rate with the latest interval. This is not perfect because the adjustment is based on
+    // self-time, and we're not currently accounting for the echion self-time.
+    void set_interval(double new_interval);
+    bool is_running() const { return thread_running.load(); }
+    void set_adaptive_sampling(bool value) { do_adaptive_sampling = value; }
+    void set_target_overhead(double value) { target_overhead = value; }
+    void set_max_sampling_period(microsecond_t max_interval_us)
+    {
+        max_sampling_period_us = std::max(max_interval_us, static_cast<microsecond_t>(g_min_sampling_period_us));
+    }
+    void set_max_threads_per_sample(unsigned int value) { max_threads_per_sample = value; }
+
+    // Set the absolute overhead floor as "core percent" units (1 = 0.01 core = 10 mcores).
+    // Converted to us of CPU budget per adaptation window.
+    void set_baseline_core_pct(double value)
+    {
+        baseline_cpu_us_per_adapt_window = value * 0.01 * g_adaptive_sampling_interval_us;
+    }
+
+    // Set the rolling window duration (seconds) over which p_stable is computed.
+    void set_p_stable_window_s(uint32_t value) { p_stable_window_s = value; }
+
+    // Set the percentile (0–100) used to compute p_stable from the rolling window.
+    void set_p_stable_percentile(double percentile) { p_stable_percentile_frac = percentile / 100.0; }
+
+    void set_fast_copy_warmup_seconds(double value) { fast_copy_warmup_seconds = value; }
+
+    // Delegates to the StackRenderer to clear its caches after fork
+    void postfork_child();
+
+    // Record whether the Sampler was running before fork
+    void prefork();
+
+    // Restart the sampling thread in the parent after fork
+    void postfork_parent();
+
+    // Restart the sampler after fork if it was running.
+    // Returns true if start() was invoked and succeeded.
+    bool restart_after_fork();
+};
+
+void
+seed_fast_copy_profiler_stats();
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/include/stack_renderer.hpp
+++ b/cpp/cpu/ddtrace_stack/include/stack_renderer.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+// Pyroscope replacement for dd-trace-py's include/stack_renderer.hpp.
+//
+// Upstream's StackRenderer renders into Datadog::Sample -> ddup_* ->
+// libdd_wrapper.so -> Rust libdatadog, which owns pprof encoding and upload.
+// None of that chain is vendored here: Pyroscope has its own encoder and
+// uploader, and shipping a second one would mean two pprof encoders and two
+// uploaders in the same process.
+//
+// This class keeps the exact method surface echion calls (EchionSampler holds
+// a StackRenderer by value and src/echion/*.cc call it directly), but renders
+// into Pyroscope::CpuSample, which pushes to the Rust sink over the C ABI in
+// rust/include/pyroscope_ffi.h. It is the same seam the memalloc port used
+// when it replaced Datadog's ddup_interface with cpp/Pyroscope.h.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "python_headers.hpp"
+
+#include "echion/frame.h"
+#include "echion/timing.h"
+
+#include "PyroscopeCpu.h"
+
+namespace Datadog {
+
+enum class MetricType : std::uint8_t
+{
+    Time,
+    Memory
+};
+
+struct ThreadState
+{
+    // Current thread info. One instance per StackRenderer is enough because the
+    // renderer visits threads one at a time.
+    uintptr_t id = 0;
+    unsigned long native_id = 0;
+    std::string name;
+    microsecond_t wall_time_ns = 0;
+    microsecond_t cpu_time_ns = 0;
+    int64_t now_time_ns = 0;
+};
+
+class StackRenderer
+{
+    // The sample currently being built, or "no sample in flight" when
+    // sample_active is false. Reused across samples so the sampling thread does
+    // not allocate per stack.
+    Pyroscope::CpuSample sample;
+    bool sample_active = false;
+    ThreadState thread_state = {};
+    uint32_t pid = 0;
+
+  public:
+    StackRenderer();
+
+    void render_thread_begin(PyThreadState* tstate,
+                             std::string_view name,
+                             microsecond_t wall_time_us,
+                             uintptr_t thread_id,
+                             unsigned long native_id);
+    void render_task_begin(std::string_view task_name, bool on_cpu, uint64_t task_id);
+    void render_frame(Frame& frame);
+    void render_cpu_time(microsecond_t cpu_time_us);
+    void render_native_frame(const std::string& name, const std::string& module);
+    void render_stack_end();
+
+    // Drop a partially-built sample without flushing it.
+    void abort_sample();
+
+    // Reset in-flight state after a fork.
+    void postfork_child();
+};
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/include/thread_span_links.hpp
+++ b/cpp/cpu/ddtrace_stack/include/thread_span_links.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdint.h>
+#include <string>
+#include <unordered_map>
+
+namespace Datadog {
+
+struct Span
+{
+    uint64_t span_id;
+    uint64_t local_root_span_id;
+    std::string span_type;
+
+    Span(uint64_t _span_id, uint64_t _local_root_span_id, std::string _span_type)
+      : span_id(_span_id)
+      , local_root_span_id(_local_root_span_id)
+      , span_type(std::move(_span_type))
+    {
+    }
+
+    // for testing
+    bool operator==(const Span& other) const
+    {
+        return span_id == other.span_id && local_root_span_id == other.local_root_span_id &&
+               span_type == other.span_type;
+    }
+};
+
+class ThreadSpanLinks
+{
+  public:
+    static ThreadSpanLinks& get_instance()
+    {
+        static ThreadSpanLinks instance;
+        return instance;
+    }
+
+    // Delete Copy constructor and assignment operator to prevent copies
+    ThreadSpanLinks(ThreadSpanLinks const&) = delete;
+    ThreadSpanLinks& operator=(ThreadSpanLinks const&) = delete;
+
+    void link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_root_span_id, std::string span_type);
+    const std::optional<Span> get_active_span_from_thread_id(uint64_t thread_id);
+    void unlink_span(uint64_t thread_id);
+    void unlink_span(uint64_t thread_id, uint64_t expected_span_id);
+    void reset();
+
+    static void postfork_child();
+
+  private:
+    std::mutex mtx;
+    std::unordered_map<uint64_t, std::unique_ptr<Span>> thread_id_to_span;
+
+    // Private Constructor/Destructor
+    ThreadSpanLinks() = default;
+    ~ThreadSpanLinks() = default;
+};
+
+}

--- a/cpp/cpu/ddtrace_stack/include/util/cast_to_pyfunc.hpp
+++ b/cpp/cpu/ddtrace_stack/include/util/cast_to_pyfunc.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <Python.h>
+
+// Abiding by the contract required in the Python interface requires abandoning certain checks in one's main project.
+// Rather than abandoning discipline, we can include this header in a way that bypasses these checks.
+inline static PyCFunction
+cast_to_pycfunction(PyObject* (*func)(PyObject*, PyObject*, PyObject*))
+{
+    // Direct C-style cast
+    return (PyCFunction)(func);
+}

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/constants.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/constants.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+// Default value for the max frames; this number will always be overridden by whatever the default
+// is for ddtrace/settings/profiling.py:ProfilingConfig.max_frames, but should conform
+constexpr unsigned int g_default_max_nframes = 64;
+
+// Maximum number of locations admissible in the Profiling backend. Reserve one location for the
+// synthetic "<N frames omitted>" frame emitted when a stack is truncated.
+// Keep in sync with BACKEND_MAX_LOCATIONS and MAX_FRAMES in ddtrace/internal/settings/profiling.py.
+constexpr unsigned int g_backend_max_nlocations = 600;
+constexpr unsigned int g_backend_max_nframes = g_backend_max_nlocations - 1;
+
+// Default value for the max number of samples to keep in the StaticSamplePool
+constexpr size_t g_default_sample_pool_capacity = 4;
+
+// Default name of the runtime.  This will almost certainly get overridden by the caller, but we set it here
+// as a reasonable default just in case.
+constexpr std::string_view g_runtime_name = "CPython";
+
+// Name of the language we support
+constexpr std::string_view g_language_name = "python";
+
+// Name of the library
+constexpr std::string_view g_library_name = "dd-trace-py";
+
+// Keep this in sync with ddtrace/settings/profiling.py:ProfilingConfig.api_timeout_ms
+constexpr uint64_t g_default_max_timeout_ms = 10'000; // 10 seconds

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/defer.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/defer.hpp
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include "scope.hpp"
+
+namespace details {
+
+struct DeferDummy
+{};
+
+template<class F>
+scope_exit<F>
+operator*(DeferDummy /*unused*/, F&& f)
+{
+    return scope_exit<F>{ std::forward<F>(f) };
+}
+
+} // namespace details
+
+template<class F>
+scope_exit<F>
+make_defer(F&& f)
+{
+    return scope_exit<F>{ std::forward<F>(f) };
+}
+
+// Allows to execute a deferred operation early (before scope end)
+template<typename F>
+void
+exec_defer(scope_exit<F>&& scope_object)
+{
+    const scope_exit<F> local{ std::move(scope_object) };
+    (void)local;
+}
+
+#define DEFER_(LINE) zz_defer##LINE
+#define DEFER(LINE) DEFER_(LINE)
+#define defer [[maybe_unused]] const auto& DEFER(__COUNTER__) = ::details::DeferDummy{}* [&]()

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/profiler_state.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/profiler_state.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+// Pyroscope shim for dd_wrapper/include/profiler_state.hpp.
+//
+// Upstream's ProfilerState is almost entirely libdatadog state (exporter
+// config, ddog_prof_* interned string caches, upload cancellation tokens).
+// None of that is vendored. The only member the code we keep actually touches
+// is native_call_registry, used by src/echion/stacks.cc to inject native frames
+// discovered via sys.monitoring CALL events.
+//
+// That registry is populated exclusively from the Python layer
+// (start_native_monitoring in upstream's src/stack.cpp), which we do not
+// vendor, so it is always empty and lookup() always misses. Keeping the shim
+// rather than editing stacks.cc lets that file stay byte-identical to upstream.
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
+#include "constants.hpp"
+
+namespace Datadog {
+
+struct NativeCallEntry
+{
+    std::string name;
+    std::string module;
+};
+
+class NativeCallRegistry
+{
+  public:
+    std::optional<std::reference_wrapper<NativeCallEntry>> lookup(uintptr_t /*code_ptr*/,
+                                                                  int /*offset_bytes*/,
+                                                                  int /*first_lineno*/)
+    {
+        // Always a miss: native call tracking needs the Python layer we drop.
+        return std::nullopt;
+    }
+};
+
+class ProfilerState
+{
+  public:
+    static ProfilerState& get()
+    {
+        static ProfilerState instance;
+        return instance;
+    }
+
+    NativeCallRegistry native_call_registry{};
+
+    // Sample configuration echion consults for stack depth limits.
+    unsigned int max_nframes{ g_default_max_nframes };
+
+  private:
+    ProfilerState() = default;
+};
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/profiler_stats.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/profiler_stats.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+// Pyroscope shim for dd_wrapper/include/profiler_stats.hpp.
+//
+// Upstream accumulates profiler telemetry into a ProfilerStats object that is
+// uploaded to Datadog alongside the profile via libdatadog. Pyroscope has no
+// equivalent channel and deliberately vendors no part of libdatadog, so every
+// setter here is a no-op.
+//
+// Keeping the full method surface (rather than deleting the call sites) is what
+// lets src/sampler.cpp stay byte-identical to upstream, which is what makes
+// re-vendoring cheap. See ../../../VENDOR.md.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace Datadog {
+
+class ProfilerStats
+{
+  public:
+    // Templated so the shim does not have to track upstream's exact parameter
+    // types; every one of these discards its argument.
+    template<typename T> void set_fast_copy_memory_user_disabled(T) {}
+    template<typename T> void set_fast_copy_memory_capable(T) {}
+    template<typename T> void set_fast_copy_memory_syscall_fallback(T) {}
+    template<typename T> void set_fast_copy_memory_enabled(T) {}
+    template<typename T> void set_sampling_interval_us(T) {}
+    template<typename T> void set_string_table_count(T) {}
+    template<typename T> void set_asyncio_task_count(T) {}
+    template<typename T> void set_greenlet_count(T) {}
+    template<typename T> void add_copy_memory_error_count(T) {}
+    template<typename T> void add_sample_capture_cpu_time_us(T) {}
+    void increment_sample_count() {}
+    void increment_sampling_event_count() {}
+};
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/sample.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/sample.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+// Pyroscope shim for dd_wrapper/include/sample.hpp.
+//
+// Upstream's Sample is the entry point into libdatadog's pprof builder and
+// uploader. Pyroscope renders through its own StackRenderer into
+// Pyroscope::CpuSample instead (see ../../../include/stack_renderer.hpp), so
+// the only thing still needed from this header is the
+// profile_borrow()/stats() handle that src/sampler.cpp uses for telemetry --
+// all no-ops here.
+//
+// Deliberately does NOT include libdatadog_helpers.hpp (which is what declares
+// the ddog_* types upstream); see ../../../VENDOR.md.
+
+#include "profiler_stats.hpp"
+
+namespace Datadog {
+
+class Sample
+{
+  public:
+    // Mirrors upstream's RAII borrow handle. The borrow is meaningless without
+    // libdatadog, so this just hands back a process-wide no-op stats object.
+    // Returned by value: src/sampler.cpp stores it as `auto borrow = ...`.
+    class ProfileBorrow
+    {
+      public:
+        ProfilerStats& stats() { return stats_; }
+
+      private:
+        // Shared by every borrow; nothing reads it back.
+        inline static ProfilerStats stats_{};
+    };
+
+    static ProfileBorrow profile_borrow() { return {}; }
+};
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/scope.hpp
+++ b/cpp/cpu/ddtrace_stack/shim/dd_wrapper/include/scope.hpp
@@ -1,0 +1,428 @@
+/*
+ * MIT License
+
+Copyright (c) 2016/2017 Eric Niebler, slightly adapted by Peter Sommerlad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+#pragma once
+
+#if __has_include(<experimental/scope>)
+
+#include <experimental/scope>
+
+#if __cpp_lib_experimental_scope >= 201902
+// if available use the STL implementation
+#define USE_STD_EXPERIMENTAL_RESOURCE
+#endif
+#endif
+
+#ifdef USE_STD_EXPERIMENTAL_RESOURCE
+using std::experimental::make_unique_resource_checked;
+using std::experimental::scope_exit;
+using std::experimental::scope_fail;
+using std::experimental::scope_success;
+using std::experimental::unique_resource;
+#else
+
+#include <exception> // for std::uncaught_exceptions
+#include <functional>
+#include <limits> // for maxint
+#include <type_traits>
+#include <utility>
+
+// modeled slightly after Andrescu's talk and article(s)
+
+// contribution by (c) Eric Niebler 2016, adapted by (c) 2017 Peter Sommerlad
+namespace detail {
+namespace hidden {
+
+// should this helper be standardized? // write testcase where recognizable.
+template<typename T>
+constexpr std::conditional_t<std::is_nothrow_move_assignable_v<T>, T&&, T const&>
+move_assign_if_noexcept(T& x) noexcept
+{
+    return std::move(x);
+}
+
+template<class T>
+constexpr typename std::
+  conditional<!std::is_nothrow_move_constructible_v<T> && std::is_copy_constructible_v<T>, const T&, T&&>::type
+  move_if_noexcept(T& x) noexcept;
+
+} // namespace hidden
+
+template<typename T>
+class box
+{
+    [[no_unique_address]] T value;
+    explicit box(T const& t) noexcept(noexcept(T(t)))
+      : value(t)
+    {
+    }
+    explicit box(T&& t) noexcept(noexcept(T(std::move_if_noexcept(t))))
+      : value(std::move_if_noexcept(t))
+    {
+    }
+
+  public:
+    template<typename TT, typename GG>
+        requires std::is_constructible_v<T, TT>
+    explicit box(TT&& t, GG&& guard) noexcept(noexcept(box(static_cast<T&&>(t))))
+      : box(std::forward<TT>(t))
+    {
+        guard.release();
+    }
+    box() = default;
+
+    T& get() noexcept { return value; }
+    T const& get() const noexcept { return value; }
+    T&& move() noexcept { return std::move(value); }
+    void reset(T const& t) noexcept(noexcept(value = t)) { value = t; }
+    void reset(T&& t) noexcept(noexcept(value = hidden::move_assign_if_noexcept(t)))
+    {
+        value = hidden::move_assign_if_noexcept(t);
+    }
+};
+
+template<typename T>
+class box<T&>
+{
+    std::reference_wrapper<T> value;
+
+  public:
+    template<typename TT, typename GG>
+        requires std::is_convertible_v<TT, T&>
+    box(TT&& t, GG&& guard) noexcept(noexcept(static_cast<T&>(static_cast<TT&&>(t))))
+      : value(static_cast<T&>(t))
+    {
+        guard.release();
+    }
+    T& get() const noexcept { return value.get(); }
+    T& move() const noexcept { return get(); }
+    void reset(T& t) noexcept { value = std::ref(t); }
+};
+
+// new policy-based exception proof design by Eric Niebler
+struct on_exit_policy
+{
+    bool execute_{ true };
+
+    void release() noexcept { execute_ = false; }
+
+    bool should_execute() const noexcept { return execute_; }
+};
+
+struct on_fail_policy
+{
+    int ec_{ std::uncaught_exceptions() };
+
+    void release() noexcept { ec_ = std::numeric_limits<int>::max(); }
+
+    bool should_execute() const noexcept { return ec_ < std::uncaught_exceptions(); }
+};
+
+struct on_success_policy
+{
+    int ec_{ std::uncaught_exceptions() };
+
+    void release() noexcept { ec_ = -1; }
+
+    bool should_execute() const noexcept { return ec_ >= std::uncaught_exceptions(); }
+};
+} // namespace detail
+
+template<class EF, class Policy = detail::on_exit_policy>
+class basic_scope_exit; // silence brain dead clang warning -Wmismatched-tags
+
+// PS: It would be nice if just the following would work in C++17
+// PS: however, we need a real class for template argument deduction
+// PS: and a deduction guide, because the ctors are partially instantiated
+// template<class EF>
+// using scope_exit = basic_scope_exit<EF, detail::on_exit_policy>;
+
+template<class EF>
+struct [[nodiscard]] scope_exit : basic_scope_exit<EF, detail::on_exit_policy>
+{
+    using basic_scope_exit<EF, detail::on_exit_policy>::basic_scope_exit;
+};
+
+template<class EF>
+scope_exit(EF) -> scope_exit<EF>;
+
+// template<class EF>
+// using scope_fail = basic_scope_exit<EF, detail::on_fail_policy>;
+
+template<class EF>
+struct scope_fail : basic_scope_exit<EF, detail::on_fail_policy>
+{
+    using basic_scope_exit<EF, detail::on_fail_policy>::basic_scope_exit;
+};
+
+template<class EF>
+scope_fail(EF) -> scope_fail<EF>;
+
+// template<class EF>
+// using scope_success = basic_scope_exit<EF, detail::on_success_policy>;
+
+template<class EF>
+struct scope_success : basic_scope_exit<EF, detail::on_success_policy>
+{
+    using basic_scope_exit<EF, detail::on_success_policy>::basic_scope_exit;
+};
+
+template<class EF>
+scope_success(EF) -> scope_success<EF>;
+
+namespace detail {
+// DETAIL:
+template<class Policy, class EF>
+auto
+_make_guard(EF&& ef)
+{
+    return basic_scope_exit<std::decay_t<EF>, Policy>(std::forward<EF>(ef));
+}
+struct _empty_scope_exit
+{
+    void release() const noexcept {}
+};
+
+} // namespace detail
+
+// Requires: EF is Callable
+// Requires: EF is nothrow MoveConstructible OR CopyConstructible
+template<class EF, class Policy /*= on_exit_policy*/>
+class [[nodiscard]] basic_scope_exit : Policy
+{
+    static_assert(std::is_invocable_v<EF>, "scope guard must be callable");
+    [[no_unique_address]] detail::box<EF> exit_function;
+
+    static auto _make_failsafe(std::true_type, const void*) { return detail::_empty_scope_exit{}; }
+    static auto _make_failsafe(std::true_type, void (*)()) { return detail::_empty_scope_exit{}; }
+    template<typename Fn>
+    static auto _make_failsafe(std::false_type, Fn* fn)
+    {
+        return basic_scope_exit<Fn&, Policy>(*fn);
+    }
+    template<typename EFP>
+    using _ctor_from = std::is_constructible<detail::box<EF>, EFP, detail::_empty_scope_exit>;
+    template<typename EFP>
+    using _noexcept_ctor_from =
+      std::bool_constant<noexcept(detail::box<EF>(std::declval<EFP>(), detail::_empty_scope_exit{}))>;
+
+  public:
+    template<typename EFP>
+        requires _ctor_from<EFP>::value
+    explicit basic_scope_exit(EFP&& ef) noexcept(_noexcept_ctor_from<EFP>::value)
+      : exit_function(std::forward<EFP>(ef), _make_failsafe(_noexcept_ctor_from<EFP>{}, &ef))
+    {
+    }
+    basic_scope_exit(basic_scope_exit&& that) noexcept(noexcept(detail::box<EF>(that.exit_function.move(), that)))
+      : Policy(that)
+      , exit_function(that.exit_function.move(), that)
+    {
+    }
+    ~basic_scope_exit() noexcept(noexcept(exit_function.get()()))
+    {
+        if (this->should_execute())
+            exit_function.get()();
+    }
+    basic_scope_exit(const basic_scope_exit&) = delete;
+    basic_scope_exit& operator=(const basic_scope_exit&) = delete;
+    basic_scope_exit& operator=(basic_scope_exit&&) = delete;
+
+    using Policy::release;
+};
+
+template<class EF, class Policy>
+void
+swap(basic_scope_exit<EF, Policy>&, basic_scope_exit<EF, Policy>&) = delete;
+
+template<typename R, typename D>
+class unique_resource
+{
+    static_assert((std::is_move_constructible_v<R> && std::is_nothrow_move_constructible_v<R>) ||
+                    std::is_copy_constructible_v<R>,
+                  "resource must be nothrow_move_constructible or copy_constructible");
+    static_assert((std::is_move_constructible_v<R> && std::is_nothrow_move_constructible_v<D>) ||
+                    std::is_copy_constructible_v<D>,
+                  "deleter must be nothrow_move_constructible or copy_constructible");
+
+    static const unique_resource& this_; // never ODR used! Just for getting no_except() expr
+
+    [[no_unique_address]] detail::box<R> resource{};
+    [[no_unique_address]] detail::box<D> deleter{};
+    bool execute_on_destruction{ false };
+
+    static constexpr auto is_nothrow_delete_v =
+      std::bool_constant<noexcept(std::declval<D&>()(std::declval<R&>()))>::value;
+
+  public: // should be private
+    template<typename RR, typename DD>
+        requires std::is_constructible_v<detail::box<R>, RR, detail::_empty_scope_exit> &&
+                   std::is_constructible_v<detail::box<D>, DD, detail::_empty_scope_exit>
+    unique_resource(RR&& r, DD&& d, bool should_run) noexcept(
+      noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{})) &&
+      noexcept(detail::box<D>(std::forward<DD>(d), detail::_empty_scope_exit{})))
+      : resource(std::forward<RR>(r), scope_exit([&] {
+                     if (should_run)
+                         d(r);
+                 }))
+      , deleter(std::forward<DD>(d), scope_exit([&, this] {
+                    if (should_run)
+                        d(get());
+                }))
+      , execute_on_destruction{ should_run }
+    {
+    }
+    // need help in making the factory a nice friend...
+    // the following two ICEs my g++ and gives compile errors about mismatche
+    // exception spec on clang7
+    //    template<typename RM, typename DM, typename S>
+    //    friend
+    //    auto make_unique_resource_checked(RM &&r, const S &invalid, DM &&d)
+    //    noexcept(noexcept(make_unique_resource(std::forward<RM>(r),
+    //    std::forward<DM>(d))));
+    // the following as well:
+    //    template<typename MR, typename MD, typename S>
+    //    friend
+    //	auto make_unique_resource_checked(MR &&r, const S &invalid, MD &&d)
+    //    noexcept(std::is_nothrow_constructible_v<std::decay_t<MR>,MR> &&
+    //    		std::is_nothrow_constructible_v<std::decay_t<MD>,MD>)
+    //    ->unique_resource<std::decay_t<MR>,std::decay_t<MD>>;
+
+  public:
+    unique_resource() = default;
+
+    template<typename RR, typename DD>
+        requires std::is_constructible_v<detail::box<R>, RR, detail::_empty_scope_exit> &&
+                   std::is_constructible_v<detail::box<D>, DD, detail::_empty_scope_exit>
+    unique_resource(RR&& r,
+                    DD&& d) noexcept(noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{})) &&
+                                     noexcept(detail::box<D>(std::forward<DD>(d), detail::_empty_scope_exit{})))
+      : resource(std::forward<RR>(r), scope_exit([&] { d(r); }))
+      , deleter(std::forward<DD>(d), scope_exit([&, this] { d(get()); }))
+      , execute_on_destruction{ true }
+    {
+    }
+    unique_resource(unique_resource&& that) noexcept(
+      noexcept(detail::box<R>(that.resource.move(), detail::_empty_scope_exit{})) &&
+      noexcept(detail::box<D>(that.deleter.move(), detail::_empty_scope_exit{})))
+      : resource(that.resource.move(), detail::_empty_scope_exit{})
+      , deleter(that.deleter.move(), scope_exit([&, this] {
+                    if (that.execute_on_destruction)
+                        that.get_deleter()(get());
+                    that.release();
+                }))
+      , execute_on_destruction(std::exchange(that.execute_on_destruction, false))
+    {
+    }
+
+    unique_resource& operator=(unique_resource&& that) noexcept(is_nothrow_delete_v &&
+                                                                std::is_nothrow_move_assignable_v<R> &&
+                                                                std::is_nothrow_move_assignable_v<D>)
+    {
+        static_assert(std::is_nothrow_move_assignable<R>::value || std::is_copy_assignable<R>::value,
+                      "The resource must be nothrow-move assignable, or copy assignable");
+        static_assert(std::is_nothrow_move_assignable<D>::value || std::is_copy_assignable<D>::value,
+                      "The deleter must be nothrow-move assignable, or copy assignable");
+        if (&that != this) {
+            reset();
+            if constexpr (std::is_nothrow_move_assignable_v<detail::box<R>>)
+                if constexpr (std::is_nothrow_move_assignable_v<detail::box<D>>) {
+                    resource = std::move(that.resource);
+                    deleter = std::move(that.deleter);
+                } else {
+                    deleter = _as_const(that.deleter);
+                    resource = std::move(that.resource);
+                }
+            else if constexpr (std::is_nothrow_move_assignable_v<detail::box<D>>) {
+                resource = _as_const(that.resource);
+                deleter = std::move(that.deleter);
+            } else {
+                resource = _as_const(that.resource);
+                deleter = _as_const(that.deleter);
+            }
+            execute_on_destruction = std::exchange(that.execute_on_destruction, false);
+        }
+        return *this;
+    }
+    ~unique_resource() // noexcept(is_nowthrow_delete_v) // removed deleter must
+                       // not throw
+    {
+        reset();
+    }
+
+    void reset() noexcept
+    {
+        if (execute_on_destruction) {
+            execute_on_destruction = false;
+            get_deleter()(get());
+        }
+    }
+    template<typename RR>
+    auto reset(RR&& r) noexcept(noexcept(resource.reset(std::forward<RR>(r))))
+      -> decltype(resource.reset(std::forward<RR>(r)), void())
+    {
+        auto&& guard = scope_fail([&, this] { get_deleter()(r); }); // -Wunused-variable on clang
+        reset();
+        resource.reset(std::forward<RR>(r));
+        execute_on_destruction = true;
+    }
+    void release() noexcept { execute_on_destruction = false; }
+    decltype(auto) get() const noexcept { return resource.get(); }
+    decltype(auto) get_deleter() const noexcept { return deleter.get(); }
+    template<typename RR = R>
+        requires std::is_pointer_v<RR>
+    auto operator->() const noexcept //(noexcept(detail::for_noexcept_on_copy_construction(this_.get())))
+      -> decltype(get())
+    {
+        return get();
+    }
+    template<typename RR = R>
+        requires std::is_pointer_v<RR> && (!std::is_void_v<std::remove_pointer_t<RR>>)
+    std::add_lvalue_reference_t<std::remove_pointer_t<R>> operator*() const noexcept
+    {
+        return *get();
+    }
+
+    unique_resource& operator=(const unique_resource&) = delete;
+    unique_resource(const unique_resource&) = delete;
+};
+
+template<typename R, typename D>
+unique_resource(R, D) -> unique_resource<R, D>;
+template<typename R, typename D>
+unique_resource(R, D, bool) -> unique_resource<R, D>;
+
+template<typename R, typename D, typename S>
+[[nodiscard]] auto
+make_unique_resource_checked(R&& r, const S& invalid, D&& d) noexcept(
+  std::is_nothrow_constructible_v<std::decay_t<R>, R> &&
+  std::is_nothrow_constructible_v<std::decay_t<D>, D>) -> unique_resource<std::decay_t<R>, std::decay_t<D>>
+{
+    bool const mustrelease(r == invalid);
+    unique_resource resource{ std::forward<R>(r), std::forward<D>(d), !mustrelease };
+    return resource;
+}
+
+// end of (c) Eric Niebler part
+
+#undef USE_STD_EXPERIMENTAL_RESOURCE
+#endif

--- a/cpp/cpu/ddtrace_stack/src/echion/danger.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/danger.cc
@@ -1,0 +1,268 @@
+#include <echion/danger.h>
+#include <echion/state.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cerrno>
+#include <csetjmp>
+#include <cstdio>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static const size_t page_size = []() -> size_t {
+    auto v = sysconf(_SC_PAGESIZE);
+
+#ifdef PL_DARWIN
+    if (v <= 0) {
+        // Fallback on macOS just in case
+        v = getpagesize();
+    }
+#endif
+
+    if (v <= 0) {
+        fprintf(stderr, "Failed to detect page size, falling back to 4096\n");
+        return 4096;
+    }
+
+    return v;
+}();
+
+struct sigaction g_old_segv;
+struct sigaction g_old_bus;
+
+thread_local ThreadAltStack t_altstack;
+
+// We "arm" by publishing a valid jmp env for this thread.
+thread_local sigjmp_buf t_jmpenv;
+thread_local volatile sig_atomic_t t_handler_armed = 0;
+
+// Guards against a signal-handler chaining cycle. The unarmed path below chains
+// to the previously installed handler and re-raises; if that handler chains back
+// to us (e.g. profiler <-> crashtracker pointing at each other), we would loop
+// forever and hang the process. If we re-enter the unarmed path while already
+// chaining, fall through to the default disposition so termination is guaranteed.
+thread_local volatile sig_atomic_t t_in_unarmed_chain = 0;
+
+static inline void
+arm_fault_handler()
+{
+    t_handler_armed = 1;
+    __asm__ __volatile__("" ::: "memory");
+}
+
+static inline void
+disarm_fault_handler()
+{
+    __asm__ __volatile__("" ::: "memory");
+    t_handler_armed = 0;
+}
+
+static void
+segv_handler(int signo, siginfo_t*, void*)
+{
+    if (!t_handler_armed) {
+        if (t_in_unarmed_chain) {
+            // We are being re-entered while already chaining to a previous
+            // handler: the handler chain has cycled back to us. Restore the
+            // default disposition and re-raise to guarantee the process
+            // terminates instead of looping forever.
+            struct sigaction dfl
+            {};
+            dfl.sa_handler = SIG_DFL;
+            sigemptyset(&dfl.sa_mask);
+            dfl.sa_flags = 0;
+            sigaction(signo, &dfl, nullptr);
+            pthread_kill(pthread_self(), signo);
+            return;
+        }
+        t_in_unarmed_chain = 1;
+
+        struct sigaction* old = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
+        // Restore the previous handler and re-raise so default/old handling occurs.
+        // Use pthread_kill(pthread_self(), signo): thread-directed (targets the
+        // faulting thread, which is guaranteed to be the current thread for
+        // synchronous signals like SIGSEGV/SIGBUS) and async-signal-safe per POSIX,
+        // unlike raise which acquires a lock internally.
+        sigaction(signo, old, nullptr);
+        pthread_kill(pthread_self(), signo);
+        return;
+    }
+
+    // Jump back to the armed site. Use 1 so sigsetjmp returns nonzero.
+    siglongjmp(t_jmpenv, 1);
+}
+
+int
+init_segv_catcher()
+{
+    if (t_altstack.ensure_installed() != 0) {
+        return -1;
+    }
+
+    struct sigaction sa
+    {};
+    sa.sa_sigaction = segv_handler;
+    sigemptyset(&sa.sa_mask);
+    // SA_SIGINFO for 3-arg handler; SA_ONSTACK to run on alt stack; SA_NODEFER to avoid having to use savemask
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER;
+
+    // Check each handler separately to avoid overwriting g_old_segv/g_old_bus
+    // with our own handler (which would cause infinite loops on unhandled signals).
+    struct sigaction current;
+
+    bool need_segv = true;
+    if (sigaction(SIGSEGV, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        need_segv = false;
+    }
+    if (need_segv) {
+        if (sigaction(SIGSEGV, &sa, &g_old_segv) != 0) {
+            return -1;
+        }
+    }
+
+    bool need_bus = true;
+    if (sigaction(SIGBUS, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        need_bus = false;
+    }
+    if (need_bus) {
+        if (sigaction(SIGBUS, &sa, &g_old_bus) != 0) {
+            if (need_segv) {
+                // Roll back SIGSEGV install on failure.
+                sigaction(SIGSEGV, &g_old_segv, nullptr);
+            }
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+bool
+segv_handler_installed()
+{
+    // Recovery needs our handler to own BOTH SIGSEGV and SIGBUS
+    // (a copy fault can arrive as either); anything else means we can't recover.
+    const int signals[] = { SIGSEGV, SIGBUS };
+    for (int signo : signals) {
+        struct sigaction current;
+        if (sigaction(signo, nullptr, &current) != 0) {
+            return false;
+        }
+        if (current.sa_sigaction != segv_handler || (current.sa_flags & SA_SIGINFO) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void
+uninstall_segv_handler()
+{
+    // Restore the saved previous handlers, removing our handler from the chain.
+    // This is used before letting another component (e.g., faulthandler) install
+    // its own handler, so it saves the correct previous handler rather than ours.
+    // After the other component installs, call init_segv_catcher to reinstall
+    // ours on top, creating the correct non-cyclic chain.
+    struct sigaction current;
+    if (sigaction(SIGSEGV, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        sigaction(SIGSEGV, &g_old_segv, nullptr);
+    }
+    if (sigaction(SIGBUS, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        sigaction(SIGBUS, &g_old_bus, nullptr);
+    }
+}
+
+#if defined PL_LINUX
+using safe_memcpy_return_t = ssize_t;
+#elif defined PL_DARWIN
+using safe_memcpy_return_t = mach_vm_size_t;
+#endif
+
+safe_memcpy_return_t
+safe_memcpy(void* dst, const void* src, size_t n)
+{
+    if (t_altstack.ensure_installed() != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    bool t_faulted = false;
+
+    auto* d = static_cast<uint8_t*>(dst);
+    auto* s = static_cast<const uint8_t*>(src);
+    safe_memcpy_return_t rem = static_cast<safe_memcpy_return_t>(n);
+
+    arm_fault_handler();
+    if (sigsetjmp(t_jmpenv, /* save sig mask = */ 0) != 0) {
+        // We arrived here from siglongjmp after a fault.
+        t_faulted = true;
+        goto landing;
+    }
+
+    // Copy in page-bounded chunks (at most one fault per bad page).
+    while (rem) {
+        // Values are always <= page_size, so the unsigned-to-signed narrowing is safe.
+        safe_memcpy_return_t to_src_pg = static_cast<safe_memcpy_return_t>(
+          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(s)) & (page_size - 1)));
+        safe_memcpy_return_t to_dst_pg = static_cast<safe_memcpy_return_t>(
+          page_size - (static_cast<uintptr_t>(reinterpret_cast<uintptr_t>(d)) & (page_size - 1)));
+        safe_memcpy_return_t chunk = std::min(rem, std::min(to_src_pg, to_dst_pg));
+
+        // Optional early probe to fault before entering large memcpy
+        (void)*static_cast<volatile const uint8_t*>(s);
+
+        // If this faults, we'll siglongjmp back to the sigsetjmp above.
+        (void)memcpy(d, s, static_cast<size_t>(chunk));
+
+        d += chunk;
+        s += chunk;
+        rem -= chunk;
+    }
+
+landing:
+    disarm_fault_handler();
+
+    if (t_faulted) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    return static_cast<safe_memcpy_return_t>(n);
+}
+
+#if defined PL_LINUX
+ssize_t
+safe_memcpy_wrapper(pid_t,
+                    const struct iovec* dstvec,
+                    unsigned long int dstiovcnt,
+                    const struct iovec* srcvec,
+                    unsigned long int srciovcnt,
+                    unsigned long int)
+{
+    (void)dstiovcnt;
+    (void)srciovcnt;
+    assert(dstiovcnt == 1);
+    assert(srciovcnt == 1);
+
+    size_t to_copy = std::min(dstvec->iov_len, srcvec->iov_len);
+    return safe_memcpy(dstvec->iov_base, srcvec->iov_base, to_copy);
+}
+#elif defined PL_DARWIN
+kern_return_t
+safe_memcpy_wrapper(vm_map_read_t target_task,
+                    mach_vm_address_t address,
+                    mach_vm_size_t size,
+                    mach_vm_address_t data,
+                    mach_vm_size_t* outsize)
+{
+    (void)target_task;
+
+    auto copied =
+      safe_memcpy(reinterpret_cast<void*>(data), reinterpret_cast<void*>(address), static_cast<size_t>(size));
+    *outsize = copied;
+    return copied == size ? KERN_SUCCESS : KERN_FAILURE;
+}
+#endif

--- a/cpp/cpu/ddtrace_stack/src/echion/frame.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/frame.cc
@@ -1,0 +1,293 @@
+#include <echion/frame.h>
+
+#include <echion/echion_sampler.h>
+#include <echion/errors.h>
+
+#include <profiling_helpers/frame_accessors.h>
+#include <profiling_helpers/linetable_parser.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+#include <cstddef>
+#include <limits>
+#endif // PY_VERSION_HEX >= 0x030b0000
+
+// ------------------------------------------------------------------------
+Result<Frame::Ptr>
+Frame::create(EchionSampler& echion, PyCodeObject* code, int lasti)
+{
+    auto maybe_filename = echion.string_table().key(code->co_filename, StringTag::FileName);
+    if (!maybe_filename) {
+        return ErrorKind::FrameError;
+    }
+
+    auto maybe_name = echion.string_table().key(DataDog::get_code_name(code), StringTag::FuncName);
+
+    if (!maybe_name) {
+        return ErrorKind::FrameError;
+    }
+
+    auto frame = std::make_unique<Frame>(*maybe_filename, *maybe_name);
+    auto infer_location_success = frame->infer_location(code, lasti);
+    if (!infer_location_success) {
+        return ErrorKind::LocationError;
+    }
+
+    return frame;
+}
+
+// ----------------------------------------------------------------------------
+Result<void>
+Frame::infer_location(PyCodeObject* code_obj, int instr_offset)
+{
+    Py_ssize_t len = 0;
+
+#if PY_VERSION_HEX >= 0x030a0000
+    auto table = pybytes_to_bytes_and_size(code_obj->co_linetable, &len);
+#else
+    auto table = pybytes_to_bytes_and_size(code_obj->co_lnotab, &len);
+#endif
+
+    if (table == nullptr) {
+        return ErrorKind::LocationError;
+    }
+
+    this->line = DataDog::parse_linetable(table.get(), len, instr_offset, code_obj->co_firstlineno);
+
+    return Result<void>::ok();
+}
+
+// ------------------------------------------------------------------------
+Frame::Key
+Frame::key(PyCodeObject* code, int lasti, int firstlineno)
+{
+    // Include co_firstlineno in the key to prevent ABA-problem cache collisions.
+    // Python's GC can free a PyCodeObject and allocate a new one at the same address. Without
+    // firstlineno, a cached <module> frame could be returned for an unrelated function frame.
+    // The original (code_addr << 16) | lasti formula also loses the top 16 bits of code_addr
+    // and collides when lasti > 0xFFFF; this hash avoids both issues.
+    uintptr_t h = reinterpret_cast<uintptr_t>(code);
+    // 2654435761 is the Knuth multiplicative hash constant: floor(2^32 / phi), where phi is the
+    // golden ratio. It spreads sequential integers across the full 32-bit range.
+    h ^= static_cast<uintptr_t>(static_cast<uint32_t>(lasti)) * 2654435761ULL;
+    // 40503 is floor(2^16 / phi), the 16-bit analogue of the Knuth constant above.
+    h ^= static_cast<uintptr_t>(static_cast<uint32_t>(firstlineno)) * 40503ULL;
+    return h;
+}
+
+// ------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030b0000
+Result<std::reference_wrapper<Frame>>
+Frame::read(EchionSampler& echion, _PyInterpreterFrame* frame_addr, _PyInterpreterFrame** prev_addr)
+#else
+Result<std::reference_wrapper<Frame>>
+Frame::read(EchionSampler& echion, PyObject* frame_addr, PyObject** prev_addr)
+#endif
+{
+    if (frame_addr == nullptr) {
+        return ErrorKind::FrameError;
+    }
+
+#if PY_VERSION_HEX >= 0x030b0000
+    _PyInterpreterFrame iframe;
+    auto resolved_addr =
+      stack_chunk ? reinterpret_cast<_PyInterpreterFrame*>(stack_chunk->resolve(frame_addr)) : frame_addr;
+
+    if (resolved_addr != frame_addr) {
+        if (resolved_addr == nullptr) {
+            return ErrorKind::FrameError;
+        }
+
+        // The frame is in the stack chunk, try to copy it into the local frame object.
+        // Note: resolved_addr points into the stack chunk's local buffer and may not be
+        // aligned to alignof(_PyInterpreterFrame). Copy into the aligned local
+        // iframe before accessing any fields to avoid undefined behaviour.
+        std::memcpy(&iframe, resolved_addr, sizeof(iframe));
+    } else {
+        // The frame is not in the stack chunk, directly copy the frame object.
+        if (copy_type(frame_addr, iframe)) {
+            return ErrorKind::FrameError;
+        }
+    }
+    frame_addr = &iframe;
+
+#if PY_VERSION_HEX >= 0x030c0000
+#if PY_VERSION_HEX >= 0x030e0000
+    // Python 3.14 introduced FRAME_OWNED_BY_INTERPRETER, and frames of this
+    // type are also ignored by the upstream profiler.
+    // See
+    // https://github.com/python/cpython/blob/ebf955df7a89ed0c7968f79faec1de49f61ed7cb/Modules/_remote_debugging_module.c#L2134
+    if (frame_addr->owner == FRAME_OWNED_BY_CSTACK || frame_addr->owner == FRAME_OWNED_BY_INTERPRETER) {
+#else
+    if (frame_addr->owner == FRAME_OWNED_BY_CSTACK) {
+#endif // PY_VERSION_HEX >= 0x030e0000
+        *prev_addr = frame_addr->previous;
+        // This is a C frame, we just need to ignore it
+        return std::ref(C_FRAME);
+    }
+
+    if (frame_addr->owner != FRAME_OWNED_BY_THREAD && frame_addr->owner != FRAME_OWNED_BY_GENERATOR) {
+        return ErrorKind::FrameError;
+    }
+#endif // PY_VERSION_HEX >= 0x030c0000
+
+    auto compute_lasti = [](uintptr_t instr_addr, uintptr_t code_obj_addr) -> Result<int> {
+        constexpr uintptr_t code_unit_size = sizeof(_Py_CODEUNIT);
+        constexpr uintptr_t code_unit_alignment = alignof(_Py_CODEUNIT);
+
+        if ((instr_addr % code_unit_alignment) != 0 || (code_obj_addr % code_unit_alignment) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t code_start_addr = code_obj_addr + offsetof(PyCodeObject, co_code_adaptive);
+        if ((code_start_addr % code_unit_alignment) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        if (instr_addr < code_start_addr) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t delta = instr_addr - code_start_addr;
+        if ((delta % code_unit_size) != 0) {
+            return ErrorKind::FrameError;
+        }
+
+        const uintptr_t lasti_index = delta / code_unit_size;
+        if (lasti_index > static_cast<uintptr_t>(std::numeric_limits<int>::max())) {
+            return ErrorKind::FrameError;
+        }
+
+        return static_cast<int>(lasti_index);
+    };
+
+    // We cannot use _PyInterpreterFrame_LASTI because _PyCode_CODE reads
+    // from the code object, which is a remote address here.  Use offsetof
+    // arithmetic instead to avoid dereferencing it.
+#if PY_VERSION_HEX >= 0x030d0000
+    // DataDog::get_code_from_frame() handles both Python 3.13 (untagged
+    // f_executable) and 3.14+ (tagged _PyStackRef f_executable) transparently.
+    PyCodeObject* code_obj = DataDog::get_code_from_frame(frame_addr);
+    if (code_obj == nullptr || frame_addr->instr_ptr == nullptr) {
+        return ErrorKind::FrameError;
+    }
+
+    // In Python 3.13+, instr_ptr points to the current instruction.
+    // Compute lasti with raw addresses to avoid UB on misaligned fuzzed pointers.
+    auto maybe_lasti =
+      compute_lasti(reinterpret_cast<uintptr_t>(frame_addr->instr_ptr), reinterpret_cast<uintptr_t>(code_obj));
+    if (!maybe_lasti) {
+        return ErrorKind::FrameError;
+    }
+    const int lasti = *maybe_lasti;
+
+    auto maybe_frame = Frame::get(echion, code_obj, lasti);
+    if (!maybe_frame) {
+        return ErrorKind::FrameError;
+    }
+
+    auto& frame = maybe_frame->get();
+#else
+    if (frame_addr->f_code == nullptr || frame_addr->prev_instr == nullptr) {
+        return ErrorKind::FrameError;
+    }
+
+    auto maybe_lasti = compute_lasti(reinterpret_cast<uintptr_t>(frame_addr->prev_instr),
+                                     reinterpret_cast<uintptr_t>(frame_addr->f_code));
+    if (!maybe_lasti) {
+        return ErrorKind::FrameError;
+    }
+    const int lasti = *maybe_lasti;
+
+    auto maybe_frame = Frame::get(echion, frame_addr->f_code, lasti);
+    if (!maybe_frame) {
+        return ErrorKind::FrameError;
+    }
+
+    auto& frame = maybe_frame->get();
+#endif // PY_VERSION_HEX >= 0x030d0000
+    *prev_addr = &frame == &INVALID_FRAME ? NULL : frame_addr->previous;
+
+#else  // PY_VERSION_HEX < 0x030b0000
+    // Unwind the stack from leaf to root and store it in a stack. This way we
+    // can print it from root to leaf.
+    PyFrameObject py_frame;
+
+    if (copy_type(frame_addr, py_frame)) {
+        return ErrorKind::FrameError;
+    }
+
+    auto maybe_frame = Frame::get(echion, py_frame.f_code, py_frame.f_lasti);
+    if (!maybe_frame) {
+        return ErrorKind::FrameError;
+    }
+
+    auto& frame = maybe_frame->get();
+    *prev_addr = (&frame == &INVALID_FRAME) ? NULL : reinterpret_cast<PyObject*>(py_frame.f_back);
+#endif // PY_VERSION_HEX >= 0x030b0000
+
+    return std::ref(frame);
+}
+
+// ----------------------------------------------------------------------------
+Result<std::reference_wrapper<Frame>>
+Frame::get(EchionSampler& echion, PyCodeObject* code_addr, int lasti)
+{
+    // Read co_firstlineno before the cache lookup so it is part of the key.
+    // This prevents ABA-problem false hits: if Python frees a PyCodeObject and allocates
+    // a new one at the same address, co_firstlineno will differ and we get a cache miss
+    // (triggering a fresh read) instead of returning a stale frame (e.g. "<module>").
+    // We read only the single int field to keep the cost of cache hits low.
+    int firstlineno;
+    {
+        auto* firstlineno_addr =
+          reinterpret_cast<decltype(PyCodeObject::co_firstlineno)*>( // NOLINT(performance-no-int-to-ptr)
+            reinterpret_cast<uintptr_t>(code_addr) + offsetof(PyCodeObject, co_firstlineno));
+        if (copy_type(firstlineno_addr, firstlineno)) {
+            return std::ref(INVALID_FRAME);
+        }
+    }
+
+    auto frame_key = Frame::key(code_addr, lasti, firstlineno);
+
+    auto maybe_frame = echion.frame_cache().lookup(frame_key);
+    if (maybe_frame) {
+        return *maybe_frame;
+    }
+
+    PyCodeObject code;
+    if (copy_type(code_addr, code)) {
+        return std::ref(INVALID_FRAME);
+    }
+
+    auto maybe_new_frame = Frame::create(echion, &code, lasti);
+    if (!maybe_new_frame) {
+        return std::ref(INVALID_FRAME);
+    }
+
+    auto new_frame = std::move(*maybe_new_frame);
+    new_frame->cache_key = frame_key;
+    new_frame->code_object = reinterpret_cast<uintptr_t>(code_addr);
+    new_frame->lasti = lasti;
+    new_frame->first_lineno = firstlineno;
+    auto& f = *new_frame;
+    echion.frame_cache().store(frame_key, std::move(new_frame));
+    return std::ref(f);
+}
+
+// ----------------------------------------------------------------------------
+Frame&
+Frame::get(EchionSampler& echion, StringTable::Key name)
+{
+    uintptr_t frame_key = static_cast<uintptr_t>(name);
+
+    auto maybe_frame = echion.frame_cache().lookup(frame_key);
+    if (maybe_frame) {
+        return *maybe_frame;
+    }
+
+    auto frame = std::make_unique<Frame>(name);
+    frame->cache_key = frame_key;
+    auto& f = *frame;
+    echion.frame_cache().store(frame_key, std::move(frame));
+    return f;
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/greenlets.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/greenlets.cc
@@ -1,0 +1,44 @@
+#include <echion/greenlets.h>
+
+#include <echion/echion_sampler.h>
+
+void
+GreenletInfo::unwind(EchionSampler& echion, PyObject* cur_frame, PyThreadState* tstate, FrameStack& stack)
+{
+    PyObject* frame_addr = NULL;
+#if PY_VERSION_HEX >= 0x030d0000
+    if (cur_frame == Py_None) {
+        frame_addr = reinterpret_cast<PyObject*>(tstate->current_frame);
+    } else {
+        // cur_frame may be a stale pointer if the greenlet finished between
+        // the snapshot (Phase 1) and unwind (Phase 2). Use copy_type to read
+        // safely instead of dereferencing directly.
+        struct _frame frame_copy;
+        if (copy_type(cur_frame, frame_copy))
+            return;
+
+        frame_addr = reinterpret_cast<PyObject*>(frame_copy.f_frame);
+    }
+#elif PY_VERSION_HEX >= 0x030b0000
+    if (cur_frame == Py_None) {
+        _PyCFrame cframe;
+        _PyCFrame* cframe_addr = tstate->cframe;
+        if (copy_type(cframe_addr, cframe)) {
+            return;
+        }
+
+        frame_addr = reinterpret_cast<PyObject*>(cframe.current_frame);
+    } else {
+        // cur_frame may be a stale pointer if the greenlet finished between
+        // the snapshot (Phase 1) and unwind (Phase 2). Use copy_type to read
+        // safely instead of dereferencing directly.
+        struct _frame frame_copy;
+        if (copy_type(cur_frame, frame_copy))
+            return;
+        frame_addr = reinterpret_cast<PyObject*>(frame_copy.f_frame);
+    }
+#else // Python < 3.11
+    frame_addr = cur_frame == Py_None ? reinterpret_cast<PyObject*>(tstate->frame) : cur_frame;
+#endif
+    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/interp.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/interp.cc
@@ -1,0 +1,49 @@
+#include <echion/interp.h>
+
+void
+for_each_interp(_PyRuntimeState* runtime, const std::function<void(InterpreterInfo& interp)>& callback)
+{
+    InterpreterInfo interpreter_info = { 0 };
+
+    // Limit interpreter iteration to prevent infinite loops from cycles or corrupted memory.
+    // This limit is based on CPython's tachyon profiler (256) and should be more than
+    // enough for realistic use cases (most applications use 1 interpreter).
+    const size_t MAX_INTERPRETERS = 256;
+
+    char* interp_addr = reinterpret_cast<char*>(runtime->interpreters.head);
+    char* prev_interp_addr = nullptr;
+
+    // Safety: prevent infinite loops from cycles or corrupted interpreter linked lists
+    for (size_t iteration_count = 0; iteration_count < MAX_INTERPRETERS && interp_addr != NULL; ++iteration_count) {
+
+        // Cycle detection: if we didn't advance from previous iteration, we're stuck
+        if (prev_interp_addr != nullptr && interp_addr == prev_interp_addr) {
+            break; // Cycle detected or failed to advance
+        }
+        prev_interp_addr = interp_addr;
+
+        // Always read next pointer first - we need it to advance
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, next), interpreter_info.next))
+            break; // Can't read next, can't advance - stop iteration
+
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, id), interpreter_info.id)) {
+            interp_addr = reinterpret_cast<char*>(interpreter_info.next);
+            continue;
+        }
+
+#if PY_VERSION_HEX >= 0x030b0000
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, threads.head), interpreter_info.tstate_head))
+#else
+        if (copy_type(interp_addr + offsetof(PyInterpreterState, tstate_head), interpreter_info.tstate_head))
+#endif
+        {
+            interp_addr = reinterpret_cast<char*>(interpreter_info.next);
+            continue;
+        }
+
+        callback(interpreter_info);
+
+        // Move to next interpreter
+        interp_addr = reinterpret_cast<char*>(interpreter_info.next);
+    }
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/long.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/long.cc
@@ -1,0 +1,44 @@
+#include <echion/long.h>
+
+#if PY_VERSION_HEX >= 0x030c0000
+[[nodiscard]] Result<long long>
+pylong_to_llong(PyObject* long_addr)
+{
+    // Only used to extract a task-id on Python 3.12, omits overflow checks
+    PyLongObject long_obj;
+    long long ret = 0;
+
+    if (copy_type(long_addr, long_obj))
+        return ErrorKind::PyLongError;
+
+    if (!PyLong_CheckExact(&long_obj))
+        return ErrorKind::PyLongError;
+
+    if (_PyLong_IsCompact(&long_obj)) {
+        ret = static_cast<long long>(_PyLong_CompactValue(&long_obj));
+    } else {
+        // If we're here, then we need to iterate over the digits
+        // We might overflow, but we don't care for now
+        int sign = _PyLong_NonCompactSign(&long_obj);
+        Py_ssize_t i = _PyLong_DigitCount(&long_obj);
+
+        if (i > MAX_DIGITS) {
+            return ErrorKind::PyLongError;
+        }
+
+        // Copy over the digits as ob_digit is allocated dynamically with
+        // PyObject_Malloc.
+        digit digits[MAX_DIGITS];
+        if (copy_generic(long_obj.long_value.ob_digit, digits, i * sizeof(digit))) {
+            return ErrorKind::PyLongError;
+        }
+        while (--i >= 0) {
+            ret <<= PyLong_SHIFT;
+            ret |= digits[i];
+        }
+        ret *= sign;
+    }
+
+    return ret;
+}
+#endif

--- a/cpp/cpu/ddtrace_stack/src/echion/mirrors.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/mirrors.cc
@@ -1,0 +1,47 @@
+#include <echion/mirrors.h>
+
+[[nodiscard]] Result<MirrorSet>
+MirrorSet::create(PyObject* set_addr)
+{
+    PySetObject set;
+
+    if (copy_type(set_addr, set)) {
+        return ErrorKind::MirrorError;
+    }
+
+    // Validate mask before adding 1 then multiplying to prevent signed integer overflow.
+    // The overflow could happen on the +1, or on the *sizeof(setentry), which either
+    // way would wrap to a negative value and cause memory issues.
+    if (set.mask < 0 || set.mask >= MAX_MIRROR_ITEMS) {
+        return ErrorKind::MirrorError;
+    }
+    auto size = set.mask + 1;
+
+    ssize_t table_size = static_cast<ssize_t>(size * sizeof(setentry));
+    auto data = std::make_unique<char[]>(table_size);
+    if (copy_generic(set.table, data.get(), table_size)) {
+        return ErrorKind::MirrorError;
+    }
+
+    set.table = reinterpret_cast<setentry*>(data.get());
+
+    return MirrorSet(size, set, std::move(data));
+}
+
+[[nodiscard]] Result<std::unordered_set<PyObject*>>
+MirrorSet::as_unordered_set()
+{
+    if (data == nullptr) {
+        return ErrorKind::MirrorError;
+    }
+
+    std::unordered_set<PyObject*> uset;
+
+    for (size_t i = 0; i < size; i++) {
+        auto entry = set.table[i];
+        if (entry.key != NULL)
+            uset.insert(entry.key);
+    }
+
+    return uset;
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/stack_chunk.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/stack_chunk.cc
@@ -1,0 +1,122 @@
+#include <echion/stack_chunk.h>
+
+#if PY_VERSION_HEX >= 0x030b0000
+
+#if PY_VERSION_HEX >= 0x030e0000
+#include <internal/pycore_interpframe_structs.h>
+#endif
+
+// ----------------------------------------------------------------------------
+Result<void>
+StackChunk::update(_PyStackChunk* chunk_addr)
+{
+    return update_with_depth(chunk_addr, 0);
+}
+
+// ----------------------------------------------------------------------------
+Result<void>
+StackChunk::update_with_depth(_PyStackChunk* chunk_addr, size_t depth)
+{
+    if (depth >= kMaxChunkDepth) {
+        return ErrorKind::StackChunkError;
+    }
+
+    _PyStackChunk chunk;
+
+    if (copy_type(chunk_addr, chunk)) {
+        return ErrorKind::StackChunkError;
+    }
+
+    // It's possible that the memory we read is corrupted/not valid anymore and the
+    // chunk.size is not meaningful. Weed out those cases here to make sure we don't
+    // try to allocate absurd amounts of memory.
+    if (chunk.size > MAX_CHUNK_SIZE) {
+        return ErrorKind::StackChunkError;
+    }
+
+    origin = chunk_addr;
+    // if data_capacity is not enough, reallocate.
+    if (chunk.size > data_capacity) {
+        data_capacity = std::max(chunk.size, data_capacity);
+        data.resize(data_capacity);
+    }
+
+    // Copy the data up until the size of the chunk
+    if (copy_generic(chunk_addr, data.data(), chunk.size)) {
+        return ErrorKind::StackChunkError;
+    }
+
+    // Store the size we actually copied. This is critical for bounds checking in StackChunk::resolve.
+    // We must NOT read chunk->size from the copied data because a race condition can cause
+    // it to be larger than what was actually copied, leading to out-of-bounds access.
+    copied_size = chunk.size;
+
+    if (chunk.previous != NULL) {
+        if (chunk.previous == chunk_addr) {
+            previous = nullptr;
+            return Result<void>::ok();
+        }
+        if (previous == nullptr)
+            previous = std::make_unique<StackChunk>();
+
+        auto update_success = previous->update_with_depth(reinterpret_cast<_PyStackChunk*>(chunk.previous), depth + 1);
+        if (!update_success) {
+            previous = nullptr;
+        }
+    } else {
+        previous = nullptr;
+    }
+
+    return Result<void>::ok();
+}
+
+// ----------------------------------------------------------------------------
+void*
+StackChunk::resolve(void* address)
+{
+    // If data is not properly initialized, simply return the address
+    if (!is_valid()) {
+        return address;
+    }
+
+    // Use copied_size for bounds checking, NOT chunk->size from the copied data.
+    // A race condition during copying can cause the header's size field to be larger
+    // than what was actually copied, leading to out-of-bounds access and SEGV.
+    //
+    // We check that the ENTIRE _PyInterpreterFrame fits within the copied
+    // buffer, not just the start address. Without this, a frame near the
+    // end of the chunk would pass the bounds check but subsequent field accesses
+    // (e.g. ->owner, ->instr_ptr) would read past the buffer (heap-buffer-overflow).
+    constexpr size_t frame_object_size = sizeof(_PyInterpreterFrame);
+    auto origin_char = reinterpret_cast<char*>(origin);
+    auto address_char = reinterpret_cast<char*>(address);
+
+    // Check if the address falls within this chunk's copied range
+    if (address_char >= origin_char && address_char < origin_char + copied_size) {
+        // Address is in this chunk. Verify the full object fits.
+        if (address_char + frame_object_size <= origin_char + copied_size) {
+            return data.data() + (address_char - origin_char);
+        }
+        // The object starts in this chunk but extends past what we copied.
+        // Return nullptr to signal that this frame cannot be safely read.
+        // We must NOT fall through to copy_type on the original address because
+        // the chunk memory may have been modified by the target thread since our
+        // snapshot, leading to stale pointers and SIGSEGV.
+        return nullptr;
+    }
+
+    if (previous)
+        return previous->resolve(address);
+
+    return address;
+}
+
+// ----------------------------------------------------------------------------
+bool
+StackChunk::is_valid() const
+{
+    return data_capacity > 0 && copied_size > 0 && copied_size >= sizeof(_PyStackChunk) && data.size() >= copied_size &&
+           data.data() != nullptr && origin != nullptr;
+}
+
+#endif // PY_VERSION_HEX >= 0x030b0000

--- a/cpp/cpu/ddtrace_stack/src/echion/stacks.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/stacks.cc
@@ -1,0 +1,118 @@
+#include <echion/stacks.h>
+
+#include <echion/echion_sampler.h>
+#include <unordered_set>
+
+#include "dd_wrapper/include/profiler_state.hpp"
+
+void
+FrameStack::render(EchionSampler& echion)
+{
+    auto& renderer = echion.renderer();
+    auto& registry = Datadog::ProfilerState::get().native_call_registry;
+
+    for (auto it = this->begin(); it != this->end(); ++it) {
+        auto& frame = *it;
+
+        // Inject native frame BEFORE its Python caller.
+        // sys.monitoring reports instruction offsets in bytes, while the sampler computes
+        // frame.lasti in _Py_CODEUNIT units. Convert to bytes for the registry lookup.
+        if (frame.code_object != 0 && frame.lasti >= 0) {
+            int offset_bytes = frame.lasti * static_cast<int>(sizeof(_Py_CODEUNIT));
+            auto maybe_entry = registry.lookup(frame.code_object, offset_bytes, frame.first_lineno);
+            if (maybe_entry) {
+                const auto& entry = maybe_entry->get();
+                renderer.render_native_frame(entry.name, entry.module);
+            }
+        }
+
+        renderer.render_frame(frame);
+    }
+}
+
+// Unwind Python frames starting from frame_addr and push them onto stack.
+// @param seen_frames: Cycle-detection set. Cleared on entry; capacity is reused
+//                     by callers (typically EchionSampler::seen_frames_scratch).
+// @param max_depth: Maximum number of frames to unwind. Defaults to max_frames.
+// @return: Number of frames added to the stack.
+size_t
+unwind_frame(EchionSampler& echion,
+             PyObject* frame_addr,
+             FrameStack& stack,
+             std::unordered_set<PyObject*>& seen_frames,
+             size_t max_depth)
+{
+    seen_frames.clear();
+    size_t count = 0;
+
+    PyObject* current_frame_addr = frame_addr;
+    while (current_frame_addr != NULL && stack.size() < max_frames) {
+        if (seen_frames.contains(current_frame_addr))
+            break;
+
+        seen_frames.insert(current_frame_addr);
+
+#if PY_VERSION_HEX >= 0x030b0000
+        auto maybe_frame = Frame::read(echion,
+                                       reinterpret_cast<_PyInterpreterFrame*>(current_frame_addr),
+                                       reinterpret_cast<_PyInterpreterFrame**>(&current_frame_addr));
+#else
+        auto maybe_frame = Frame::read(echion, current_frame_addr, &current_frame_addr);
+#endif
+        if (!maybe_frame) {
+            break;
+        }
+
+        if (maybe_frame->get().name == StringTable::C_FRAME) {
+            continue;
+        }
+
+        stack.push_back(maybe_frame->get());
+        count++;
+
+        if (count >= max_depth) {
+            break;
+        }
+    }
+
+    return count;
+}
+
+// Convenience variant that owns its own scratch set and delegates to the
+// primary overload above. For callers without a reusable scratch set to share.
+size_t
+unwind_frame(EchionSampler& echion, PyObject* frame_addr, FrameStack& stack, size_t max_depth)
+{
+    std::unordered_set<PyObject*> local_seen_frames;
+    return unwind_frame(echion, frame_addr, stack, local_seen_frames, max_depth);
+}
+
+void
+unwind_python_stack(EchionSampler& echion, PyThreadState* tstate, FrameStack& stack)
+{
+    stack.clear();
+#if PY_VERSION_HEX >= 0x030b0000
+    if (stack_chunk == nullptr) {
+        stack_chunk = std::make_unique<StackChunk>();
+    }
+
+    if (!stack_chunk->update(reinterpret_cast<_PyStackChunk*>(tstate->datastack_chunk))) {
+        stack_chunk = nullptr;
+    }
+#endif
+
+#if PY_VERSION_HEX >= 0x030d0000
+    PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->current_frame);
+#elif PY_VERSION_HEX >= 0x030b0000
+    _PyCFrame cframe;
+    _PyCFrame* cframe_addr = tstate->cframe;
+    if (copy_type(cframe_addr, cframe))
+        // TODO: Invalid frame
+        return;
+
+    PyObject* frame_addr = reinterpret_cast<PyObject*>(cframe.current_frame);
+#else // Python < 3.11
+    PyObject* frame_addr = reinterpret_cast<PyObject*>(tstate->frame);
+#endif
+    unwind_frame(echion, frame_addr, stack, echion.seen_frames_scratch());
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/strings.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/strings.cc
@@ -1,0 +1,79 @@
+#include <echion/strings.h>
+
+std::unique_ptr<unsigned char[]>
+pybytes_to_bytes_and_size(PyObject* bytes_addr, Py_ssize_t* size)
+{
+    PyBytesObject bytes;
+
+    if (copy_type(bytes_addr, bytes))
+        return nullptr;
+
+    *size = bytes.ob_base.ob_size;
+    if (*size < 0 || *size > MAX_STRING_SIZE)
+        return nullptr;
+
+    auto data = std::make_unique<unsigned char[]>(*size);
+    if (copy_generic(reinterpret_cast<char*>(bytes_addr) + offsetof(PyBytesObject, ob_sval), data.get(), *size))
+        return nullptr;
+
+    return data;
+}
+Result<std::string>
+pyunicode_to_utf8(PyObject* str_addr)
+{
+    PyUnicodeObject str;
+    if (copy_type(str_addr, str))
+        return ErrorKind::PyUnicodeError;
+
+    PyASCIIObject& ascii = str._base._base;
+
+    if (ascii.state.kind != 1)
+        return ErrorKind::PyUnicodeError;
+
+    const char* data = ascii.state.compact
+                         ? reinterpret_cast<const char*>(reinterpret_cast<const uint8_t*>(str_addr) + sizeof(ascii))
+                         : static_cast<const char*>(str._base.utf8);
+    if (data == NULL)
+        return ErrorKind::PyUnicodeError;
+
+    Py_ssize_t size = ascii.state.compact ? ascii.length : str._base.utf8_length;
+    if (size < 0 || size > 1024)
+        return ErrorKind::PyUnicodeError;
+
+    auto dest = std::string(size, '\0');
+    if (copy_generic(data, dest.data(), size))
+        return ErrorKind::PyUnicodeError;
+
+    return Result<std::string>(dest);
+}
+
+[[nodiscard]] Result<StringTable::Key>
+StringTable::key(PyObject* s, StringTag tag)
+{
+    const std::lock_guard<std::mutex> lock(table_lock);
+
+    auto k = make_tagged_key(reinterpret_cast<uintptr_t>(s), tag);
+
+    if (table_.find(k) == table_.end()) {
+        auto maybe_unicode = pyunicode_to_utf8(s);
+        if (!maybe_unicode) {
+            return ErrorKind::PyUnicodeError;
+        }
+
+        table_.emplace(k, std::move(*maybe_unicode));
+    }
+
+    return Result<Key>(k);
+}
+
+[[nodiscard]] Result<std::reference_wrapper<const std::string>>
+StringTable::lookup(StringTable::Key key) const
+{
+    const std::lock_guard<std::mutex> lock(table_lock);
+
+    const auto it = table_.find(key);
+    if (it == table_.cend())
+        return ErrorKind::LookupError;
+
+    return std::ref(it->second);
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/tasks.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/tasks.cc
@@ -1,0 +1,285 @@
+#include <echion/echion_sampler.h>
+#include <echion/tasks.h>
+
+#include <echion/long.h>
+
+#include <array>
+#include <stack>
+#include <utility>
+#include <vector>
+
+namespace {
+Result<TaskName>
+read_task_name(PyObject* task_name)
+{
+#if PY_VERSION_HEX >= 0x030c0000
+    // CPython stores the default asyncio task name as a PyLong and formats
+    // "Task-N" lazily. Keep the integer in the task snapshot and format the
+    // label only when rendering the sample, instead of adding high-cardinality
+    // default names to the global StringTable.
+    auto maybe_long = pylong_to_llong(task_name);
+    if (maybe_long) {
+        return TaskName::from_asyncio_task_id(static_cast<std::uint64_t>(*maybe_long));
+    }
+#endif
+
+    auto maybe_unicode = pyunicode_to_utf8(task_name);
+    if (!maybe_unicode) {
+        return ErrorKind::PyUnicodeError;
+    }
+
+    return TaskName::from_literal(std::move(*maybe_unicode));
+}
+} // namespace
+
+Result<GenInfo::Ptr>
+GenInfo::create(PyObject* gen_addr)
+{
+    return create_impl(gen_addr);
+}
+
+Result<GenInfo::Ptr>
+GenInfo::create_impl(PyObject* gen_addr)
+{
+    // Each node records the coroutine address, its frame address, and the fields
+    // needed to compute is_running for the leaf of the await chain.
+    struct Node
+    {
+        PyObject* origin;
+        PyObject* frame;
+#if PY_VERSION_HEX >= 0x030b0000
+        int8_t gi_frame_state;
+#elif PY_VERSION_HEX >= 0x030a0000
+        bool frame_is_executing;
+#else
+        int gi_running;
+#endif
+    };
+    static_assert(sizeof(Node) * MAX_RECURSION_DEPTH <= static_cast<size_t>(10) * 1024,
+                  "Node array too large (max 10KB)");
+    std::array<Node, MAX_RECURSION_DEPTH> chain;
+    size_t chain_size = 0;
+
+    PyObject* cur = gen_addr;
+    for (size_t depth = 0; depth < MAX_RECURSION_DEPTH; ++depth) {
+        PyGenObject gen;
+        if (copy_type(cur, gen)) {
+            break;
+        }
+
+        // PyAsyncGenASend is a transparent wrapper: follow its ags_gen pointer
+        // without adding a node to the chain.
+        if (PyAsyncGenASend_CheckExact(&gen)) {
+            static_assert(
+              sizeof(PyAsyncGenASend) <= sizeof(PyGenObject),
+              "PyAsyncGenASend must be smaller than PyGenObject in order for copy_type to have copied enough data.");
+            PyAsyncGenASend* asend = reinterpret_cast<PyAsyncGenASend*>(&gen);
+            cur = reinterpret_cast<PyObject*>(asend->ags_gen);
+            continue;
+        }
+
+        if (!PyCoro_CheckExact(&gen) && !PyAsyncGen_CheckExact(&gen)) {
+            break;
+        }
+
+#if PY_VERSION_HEX >= 0x030b0000
+        auto gen_frame =
+          (gen.gi_frame_state == FRAME_CLEARED)
+            ? NULL
+            : reinterpret_cast<PyObject*>(reinterpret_cast<char*>(cur) + offsetof(PyGenObject, gi_iframe));
+#else
+        auto gen_frame = reinterpret_cast<PyObject*>(gen.gi_frame);
+#endif
+
+        PyFrameObject f;
+        if (copy_type(gen_frame, f)) {
+            break;
+        }
+
+        PyObject* yf = (gen_frame != NULL ? PyGen_yf(&gen, gen_frame) : NULL);
+
+        Node node;
+        node.origin = cur;
+        node.frame = gen_frame;
+#if PY_VERSION_HEX >= 0x030b0000
+        node.gi_frame_state = gen.gi_frame_state;
+#elif PY_VERSION_HEX >= 0x030a0000
+        node.frame_is_executing = (gen_frame != NULL) && _PyFrame_IsExecuting(&f);
+#else
+        node.gi_running = gen.gi_running;
+#endif
+        chain[chain_size++] = node;
+
+        if (yf == NULL || yf == cur) {
+            break;
+        }
+        cur = yf;
+    }
+
+    if (chain_size == 0) {
+        return ErrorKind::GenInfoError;
+    }
+
+    // is_running propagates from the leaf (deepest awaited coroutine) all the way
+    // up to the root: each coroutine that is awaiting another one is "running" iff
+    // the coroutine it awaits is running.
+    bool chain_is_running = false;
+    {
+        const auto& leaf = chain[chain_size - 1];
+#if PY_VERSION_HEX >= 0x030b0000
+        chain_is_running = (leaf.gi_frame_state == FRAME_EXECUTING);
+#elif PY_VERSION_HEX >= 0x030a0000
+        chain_is_running = leaf.frame_is_executing;
+#else
+        chain_is_running = (leaf.gi_running != 0);
+#endif
+    }
+
+    // Build the GenInfo linked list from the leaf back to the root.
+    GenInfo::Ptr result = nullptr;
+    for (size_t i = chain_size; i > 0; --i) {
+        const auto& node = chain[i - 1];
+        result = std::make_unique<GenInfo>(node.origin, node.frame, std::move(result), chain_is_running);
+    }
+
+    return result;
+}
+
+// ----------------------------------------------------------------------------
+Result<TaskInfo::Ptr>
+TaskInfo::create(EchionSampler& echion, TaskObj* task_addr)
+{
+    return create_impl(echion, task_addr, 0);
+}
+
+Result<TaskInfo::Ptr>
+TaskInfo::create_impl(EchionSampler& echion, TaskObj* task_addr, size_t recursion_depth)
+{
+    if (recursion_depth > MAX_RECURSION_DEPTH) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    TaskObj task;
+    if (copy_type(task_addr, task)) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    auto maybe_coro = GenInfo::create(task.task_coro);
+    if (!maybe_coro) {
+        return ErrorKind::TaskInfoGeneratorError;
+    }
+
+    auto maybe_name = read_task_name(task.task_name);
+    if (!maybe_name) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    auto task_name = std::move(*maybe_name);
+    auto task_loop = task.task_loop;
+
+    TaskInfo::Ptr task_waiter = nullptr;
+    if (task.task_fut_waiter) {
+        auto maybe_waiter =
+          TaskInfo::create_impl(echion, reinterpret_cast<TaskObj*>(task.task_fut_waiter), recursion_depth + 1);
+        if (maybe_waiter) {
+            task_waiter = std::move(*maybe_waiter);
+        }
+    }
+
+    return std::make_unique<TaskInfo>(reinterpret_cast<PyObject*>(task_addr),
+                                      task_loop,
+                                      std::move(*maybe_coro),
+                                      std::move(task_name),
+                                      std::move(task_waiter));
+}
+
+// When uvloop.run() is used, the top-level Task contains a wrapper coroutine
+// named "run.<locals>.wrapper" that just validates the loop type and awaits the user's main
+// coroutine. We skip this frame to keep the stack clean and consistent with regular asyncio.
+bool
+is_uvloop_wrapper_frame(EchionSampler& echion, bool using_uvloop, const Frame& frame)
+{
+    if (!using_uvloop) {
+        return false;
+    }
+
+    auto maybe_name = echion.string_table().lookup(frame.name);
+    if (!maybe_name) {
+        return false;
+    }
+    const auto& frame_name = maybe_name->get();
+
+#if PY_VERSION_HEX >= 0x030b0000
+    // Python 3.11+: qualified name includes the enclosing function
+    constexpr std::string_view wrapper_name = "run.<locals>.wrapper";
+    return frame_name == wrapper_name;
+#else
+    // Python < 3.11: just check for "wrapper" in uvloop/__init__.py
+    constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
+    constexpr std::string_view wrapper = "wrapper";
+    auto maybe_filename = echion.string_table().lookup(frame.filename);
+    if (!maybe_filename) {
+        return false;
+    }
+    const auto& filename = maybe_filename->get();
+    auto is_uvloop = filename.size() >= uvloop_init_py.size() &&
+                     filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
+    return is_uvloop && (frame_name == wrapper);
+#endif
+}
+
+size_t
+TaskInfo::unwind(EchionSampler& echion, FrameStack& stack, bool using_uvloop)
+{
+    // TODO: Check for running task.
+    (void)echion;
+
+    // Use a vector-based std::stack as we only push_back/pop_back
+    std::stack<PyObject*, std::vector<PyObject*>> coro_frames;
+
+    // Unwind the coro chain
+    size_t coro_chain_depth = 0;
+    for (auto py_coro = this->coro.get(); py_coro != NULL; py_coro = py_coro->await.get()) {
+        coro_chain_depth++;
+        if (coro_chain_depth > MAX_RECURSION_DEPTH) {
+            break;
+        }
+
+        if (py_coro->frame != NULL) {
+            coro_frames.push(py_coro->frame);
+        }
+    }
+
+    // Total number of frames added to the Stack
+    size_t count = 0;
+
+    // Unwind the coro frames
+    while (!coro_frames.empty()) {
+        PyObject* frame = coro_frames.top();
+        coro_frames.pop();
+
+        // We only need the single Task frame from each coroutine, not the full Python stack (which we already have
+        // from the Thread Stack).
+        // For a running Task, unwind_frame would also yield the asyncio runtime frames "on top"
+        // of the Task frame, but we would discard those anyway. Limiting to 1 frame avoids walking
+        // the Frame chain unnecessarily.
+        auto new_frames = unwind_frame(echion, frame, stack, echion.seen_frames_scratch(), 1);
+        assert(new_frames <= 1 && "expected exactly 1 frame to be unwound (or 0 in case of an error)");
+
+        // If we failed to unwind the Frame, stop unwinding the coroutine chain; otherwise we could
+        // end up with Stacks with missing Frames between two coroutines Frames.
+        if (new_frames == 0) {
+            break;
+        }
+
+        // Skip the uvloop wrapper frame if present (only at the outermost level of the top-level Task)
+        if (!stack.empty() && is_uvloop_wrapper_frame(echion, using_uvloop, stack.back())) {
+            stack.pop_back();
+            continue;
+        }
+
+        count += 1;
+    }
+
+    return count;
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/threads.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/threads.cc
@@ -1,0 +1,954 @@
+#include <echion/state.h>
+#include <echion/tasks.h>
+#include <echion/threads.h>
+
+#include <echion/echion_sampler.h>
+
+#include "dd_wrapper/include/defer.hpp"
+
+#include <algorithm>
+#include <optional>
+#include <string_view>
+
+void
+ThreadInfo::reset_cycle_state() noexcept
+{
+    current_tasks.clear();
+    current_greenlets.clear();
+}
+
+void
+ThreadInfo::unwind(EchionSampler& echion, PyThreadState* tstate)
+{
+    // This entry reset is a precondition for a new snapshot: never append to logical state from an earlier cycle.
+    reset_cycle_state();
+
+    unwind_python_stack(echion, tstate, python_stack);
+
+    if (asyncio_loop) {
+        // unwind_tasks returns a [[nodiscard]] Result<void>.
+        // We cast it to void to ignore failures.
+        (void)unwind_tasks(echion, tstate);
+    } else {
+        // We make the assumption that gevent and asyncio are not mixed
+        // together to keep the logic here simple. We can always revisit this
+        // should there be a substantial demand for it.
+        unwind_greenlets(echion, tstate, native_id);
+    }
+}
+
+// ----------------------------------------------------------------------------
+Result<void>
+ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate)
+{
+    // The size of the "pure Python" stack (before asyncio Frames).
+    // Defaults to the full Python stack size (and updated if we find the boundary frame)
+    size_t upper_python_stack_size = python_stack.size();
+
+    // Check if the Python stack contains the asyncio boundary frame.
+    // For regular asyncio, this is "Handle._run" from asyncio/events.py.
+    // For uvloop, this is "Runner.run" from asyncio/runners.py (uvloop uses asyncio.Runner internally).
+    // To avoid having to do string comparisons every time we unwind Tasks, we keep track
+    // of the cache key of the boundary frame.
+
+    // Note: We use separate cache keys for asyncio and uvloop because switching between them
+    // (though unlikely at runtime) would cause incorrect boundary detection otherwise.
+    auto& asyncio_frame_cache_key = echion.asyncio_frame_cache_key();
+    auto& uvloop_frame_cache_key = echion.uvloop_frame_cache_key();
+
+    auto& frame_cache_key = using_uvloop ? uvloop_frame_cache_key : asyncio_frame_cache_key;
+
+    if (!frame_cache_key) {
+        for (size_t i = 0; i < python_stack.size(); i++) {
+            const auto& frame = python_stack[i];
+            auto maybe_frame_name = echion.string_table().lookup(frame.name);
+            if (!maybe_frame_name) {
+                continue;
+            }
+            const auto& frame_name = maybe_frame_name->get();
+
+            bool is_boundary_frame = false;
+
+            if (using_uvloop) {
+                // For uvloop, the boundary frame depends on the Python version:
+                // - Python 3.11+: Runner.run from asyncio/runners.py (uvloop uses asyncio.Runner)
+                // - Python < 3.11: run from uvloop/__init__.py (uvloop has its own implementation)
+#if PY_VERSION_HEX >= 0x030b0000
+                constexpr std::string_view runner_run = "Runner.run";
+                is_boundary_frame = frame_name == runner_run;
+#else
+                constexpr std::string_view uvloop_init_py = "uvloop/__init__.py";
+                constexpr std::string_view run = "run";
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
+                auto is_uvloop = filename.rfind(uvloop_init_py) == filename.size() - uvloop_init_py.size();
+                is_boundary_frame = is_uvloop && (frame_name == run);
+#endif
+            } else {
+                // For regular asyncio, the boundary frame is Handle._run from asyncio/events.py
+#if PY_VERSION_HEX >= 0x030b0000
+                // After Python 3.11, function names in Frames are qualified with e.g. the class name, so we
+                // can use the qualified name to identify the "_run" Frame.
+                constexpr std::string_view _run = "Handle._run";
+                is_boundary_frame = frame_name == _run;
+#else
+                // Before Python 3.11, function names in Frames are not qualified, so we
+                // can use the filename to identify the "_run" Frame.
+                constexpr std::string_view asyncio_events_py = "asyncio/events.py";
+                constexpr std::string_view _run = "_run";
+                auto maybe_filename = echion.string_table().lookup(frame.filename);
+                if (!maybe_filename) {
+                    continue;
+                }
+                const auto& filename = maybe_filename->get();
+                auto is_asyncio = filename.size() >= asyncio_events_py.size() &&
+                                  filename.rfind(asyncio_events_py) == filename.size() - asyncio_events_py.size();
+                is_boundary_frame = is_asyncio && (frame_name.size() >= _run.size() &&
+                                                   frame_name.rfind(_run) == frame_name.size() - _run.size());
+#endif
+            }
+
+            if (is_boundary_frame) {
+                // Although Frames are stored in an LRUCache, the cache key is ALWAYS the same
+                // even if the Frame gets evicted from the cache.
+                // This means we can keep the cache key and reuse it to determine
+                // whether we see the boundary Frame in the Python stack.
+                frame_cache_key = frame.cache_key;
+                upper_python_stack_size = python_stack.size() - i;
+                break;
+            }
+        }
+    } else {
+        for (size_t i = 0; i < python_stack.size(); i++) {
+            const auto& frame = python_stack[i];
+            if (frame.cache_key == *frame_cache_key) {
+                upper_python_stack_size = python_stack.size() - i;
+                break;
+            }
+        }
+    }
+
+    std::vector<TaskInfo::Ref> leaf_tasks;
+    std::unordered_set<PyObject*> parent_tasks;
+    std::unordered_map<PyObject*, TaskInfo::Ref> waitee_map; // Indexed by task origin
+    std::unordered_map<PyObject*, TaskInfo::Ref> origin_map; // Indexed by task origin
+
+    auto maybe_all_tasks = get_all_tasks(echion, tstate);
+    if (!maybe_all_tasks) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    auto all_tasks = std::move(*maybe_all_tasks);
+    echion.add_asyncio_task_count(all_tasks.size());
+    {
+        auto& previous_task_objects = echion.previous_task_objects();
+        std::lock_guard<std::mutex> lock(echion.task_link_map_lock());
+
+        auto& task_link_map = echion.task_link_map();
+        auto& weak_task_link_map = echion.weak_task_link_map();
+
+        // Clean up the task_link_map. Remove entries associated to tasks that
+        // no longer exist.
+        std::unordered_set<PyObject*> all_task_origins;
+        std::transform(all_tasks.cbegin(),
+                       all_tasks.cend(),
+                       std::inserter(all_task_origins, all_task_origins.begin()),
+                       [](const TaskInfo::Ptr& task) { return task->origin; });
+
+        std::vector<PyObject*> to_remove;
+        for (auto kv : task_link_map) {
+            if (all_task_origins.find(kv.first) == all_task_origins.end())
+                to_remove.push_back(kv.first);
+        }
+        for (auto key : to_remove) {
+            // Only remove the link if the Child Task previously existed; otherwise it's a Task that
+            // has just been created and that wasn't in all_tasks when we took the snapshot.
+            if (auto it = previous_task_objects.find(key); it != previous_task_objects.end()) {
+                task_link_map.erase(key);
+            }
+        }
+
+        // Determine the parent tasks from the gather links.
+        std::transform(task_link_map.cbegin(),
+                       task_link_map.cend(),
+                       std::inserter(parent_tasks, parent_tasks.begin()),
+                       [](const std::pair<PyObject*, PyObject*>& kv) { return kv.second; });
+
+        // Clean up the weak_task_link_map.
+        // Remove entries associated to tasks that no longer exist.
+        all_task_origins.clear();
+        std::transform(all_tasks.cbegin(),
+                       all_tasks.cend(),
+                       std::inserter(all_task_origins, all_task_origins.begin()),
+                       [](const TaskInfo::Ptr& task) { return task->origin; });
+
+        to_remove.clear();
+        for (auto kv : weak_task_link_map) {
+            if (all_task_origins.find(kv.first) == all_task_origins.end())
+                to_remove.push_back(kv.first);
+        }
+
+        for (auto key : to_remove) {
+            weak_task_link_map.erase(key);
+        }
+
+        // Determine the parent tasks from the gather (strong) links.
+        for (auto& link : task_link_map) {
+            auto parent = link.second;
+
+            // Check if the parent is actually the child of another Task
+            auto is_child = weak_task_link_map.find(parent) != weak_task_link_map.end();
+
+            // Only insert if we do not know of a Task that created the current Task
+            if (!is_child) {
+                parent_tasks.insert(parent);
+            }
+        }
+
+        // Copy all Task object pointers into previous_task_objects
+        previous_task_objects.clear();
+        for (const auto& task : all_tasks) {
+            previous_task_objects.insert(task->origin);
+        }
+    }
+
+    for (auto& task : all_tasks) {
+        origin_map.emplace(task->origin, std::ref(*task));
+
+        if (task->waiter != nullptr)
+            waitee_map.emplace(task->waiter->origin, std::ref(*task));
+        else if (parent_tasks.find(task->origin) == parent_tasks.end()) {
+            leaf_tasks.push_back(std::ref(*task));
+        }
+    }
+
+    // Pre-compute per-task coroutine stacks so that each task's coroutine chain is walked exactly once.
+    // Without this, a parent task's coroutine chain would be walked once for each child task that
+    // references it in its task chain (e.g. 10 children from asyncio.gather = 10 redundant unwinds
+    // of the parent's coroutine chain).
+    std::unordered_map<PyObject*, FrameStack> task_coro_stacks;
+    for (auto& task : all_tasks) {
+        FrameStack task_stack;
+        task->unwind(echion, task_stack, using_uvloop);
+        task_coro_stacks.emplace(task->origin, std::move(task_stack));
+    }
+
+    // Make sure the on CPU task is first
+    for (size_t i = 0; i < leaf_tasks.size(); i++) {
+        if (leaf_tasks[i].get().is_on_cpu) {
+            if (i > 0) {
+                std::swap(leaf_tasks[i], leaf_tasks[0]);
+            }
+            break;
+        }
+    }
+
+    for (auto& leaf_task : leaf_tasks) {
+        // Must match _task.task_object_address() so lock and stack samples correlate.
+        auto task_id = reinterpret_cast<uintptr_t>(leaf_task.get().origin);
+        auto stack_info = std::make_unique<StackInfo>(leaf_task.get().name, leaf_task.get().is_on_cpu, task_id);
+        auto& stack = stack_info->stack;
+
+        // Safety: prevent infinite loops from cycles in task chain maps
+        size_t task_chain_depth = 0;
+        for (auto current_task = leaf_task;;) {
+            if (++task_chain_depth > MAX_RECURSION_DEPTH) {
+                break;
+            }
+            auto& task = current_task.get();
+
+            // Look up the pre-computed coroutine stack for this task.
+            // FrameStack order is leaf-to-root. For on-CPU tasks, synchronous frames from
+            // python_stack must be appended before coroutine frames.
+            // Decide how many coroutine frames to keep before appending the on-CPU sync frames below.
+            // This preserves the previous max_frames truncation behavior while avoiding front insertion.
+            const FrameStack* task_stack = nullptr;
+            size_t task_stack_size = 0;
+            size_t task_frames_to_push = 0;
+            if (auto it = task_coro_stacks.find(task.origin); it != task_coro_stacks.end()) {
+                task_stack = &it->second;
+                task_stack_size = task_stack->size();
+                if (stack.size() < max_frames) {
+                    task_frames_to_push = std::min(task_stack_size, max_frames - stack.size());
+                }
+            }
+            if (task.is_on_cpu) {
+                // Get the "bottom" part of the Python synchronous Stack, that is to say the
+                // synchronous functions and coroutines called by the Task's outermost coroutine
+                // The number of Frames to push is the total number of Frames in the Python stack, from which we
+                // subtract the number of Frames in the "upper Python stack" (asyncio machinery + sync entrypoint)
+                // This gives us [outermost coroutine, ... , innermost coroutine, outermost sync function, ... ,
+                // innermost sync function]
+                // TODO: This may be incorrect if the Task that we know is on CPU does not match the Task that
+                //       actually was on CPU when the Python Thread Stack was captured. One way to work around this
+                //       may be to look at every Task Stack and match it against the Thread Stack. This would be
+                //       somewhat costly though, and so far I have not seen a single instance of this race condition.
+                size_t frames_to_push = (python_stack.size() > upper_python_stack_size + task_stack_size)
+                                          ? python_stack.size() - upper_python_stack_size - task_stack_size
+                                          : 0;
+                // These frames should render before the coroutine frames. Append them first in leaf-to-root order.
+                for (size_t i = 0; i < frames_to_push; i++) {
+                    const auto& python_frame = python_stack[i];
+
+                    // Skip the uvloop wrapper frame if present in the Python stack
+                    if (is_uvloop_wrapper_frame(echion, using_uvloop, python_frame)) {
+                        continue;
+                    }
+                    stack.push_back(python_frame);
+                }
+            }
+            if (task_stack != nullptr) {
+                for (size_t i = 0; i < task_frames_to_push; i++) {
+                    stack.push_back((*task_stack)[i]);
+                }
+            }
+
+            // Task labels are rendered separately from frames; do not add a synthetic
+            // frame for the task name here.
+
+            // Get the next task in the chain
+            PyObject* task_origin = task.origin;
+            if (auto maybe_waitee = waitee_map.find(task_origin); maybe_waitee != waitee_map.end()) {
+                current_task = maybe_waitee->second;
+                continue;
+            }
+
+            {
+                // Check for, e.g., gather links
+                std::lock_guard<std::mutex> lock(echion.task_link_map_lock());
+                auto& task_link_map = echion.task_link_map();
+                auto& weak_task_link_map = echion.weak_task_link_map();
+
+                if (auto maybe_parent = task_link_map.find(task_origin); maybe_parent != task_link_map.end()) {
+                    if (auto maybe_origin = origin_map.find(maybe_parent->second); maybe_origin != origin_map.end()) {
+                        current_task = maybe_origin->second;
+                        continue;
+                    }
+                }
+
+                // Check for weak links
+                if (weak_task_link_map.find(task_origin) != weak_task_link_map.end() &&
+                    origin_map.find(weak_task_link_map[task_origin]) != origin_map.end()) {
+                    current_task = origin_map.find(weak_task_link_map[task_origin])->second;
+                    continue;
+                }
+            }
+
+            break;
+        }
+
+        // Finish off with the remaining thread stack
+        // If we have seen an on-CPU Task, then upper_python_stack_size will be set and will include the sync entry
+        // point and the asyncio machinery Frames. Otherwise, we are in `select` (idle) and we should push all the
+        // Frames.
+
+        // There could be a race condition where relevant partial Python Thread Stack ends up being different from the
+        // one we saw in TaskInfo::unwind. This is extremely unlikely, I believe, but failing to account for it would
+        // cause an underflow, so let's be conservative.
+        size_t start_index = 0;
+        if (python_stack.size() >= upper_python_stack_size) {
+            start_index = python_stack.size() - upper_python_stack_size;
+        }
+        for (size_t i = start_index; i < python_stack.size(); i++) {
+            const auto& python_frame = python_stack[i];
+            stack.push_back(python_frame);
+        }
+
+        current_tasks.push_back(std::move(stack_info));
+    }
+
+    return Result<void>::ok();
+}
+
+// ----------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x030e0000
+Result<void>
+ThreadInfo::get_tasks_from_thread_linked_list(EchionSampler& echion, std::vector<TaskInfo::Ptr>& tasks)
+{
+    if (this->tstate_addr == 0 || this->asyncio_loop == 0) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    // Calculate thread state's asyncio_tasks_head remote address
+    // Note: Since 3.13+, every PyThreadState is actually allocated as a _PyThreadStateImpl.
+    // We use PyThreadState* everywhere and cast to _PyThreadStateImpl* only when we need
+    // to access asyncio_tasks_head (which is only available in Python 3.14+).
+    // Since tstate_addr is a remote address, we calculate the offset and add it to the address.
+    // get_tasks_from_linked_list will handle copying the head node from remote memory internally.
+    constexpr size_t asyncio_tasks_head_offset = offsetof(_PyThreadStateImpl, asyncio_tasks_head);
+    uintptr_t head_addr = this->tstate_addr + asyncio_tasks_head_offset;
+
+    return get_tasks_from_linked_list(echion, head_addr, tasks);
+}
+
+Result<void>
+ThreadInfo::get_tasks_from_interpreter_linked_list(EchionSampler& echion,
+                                                   PyThreadState* tstate,
+                                                   std::vector<TaskInfo::Ptr>& tasks)
+{
+    if (tstate == nullptr || tstate->interp == nullptr || this->asyncio_loop == 0) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    constexpr size_t asyncio_tasks_head_offset = offsetof(PyInterpreterState, asyncio_tasks_head);
+    uintptr_t head_addr = reinterpret_cast<uintptr_t>(tstate->interp) + asyncio_tasks_head_offset;
+
+    return get_tasks_from_linked_list(echion, head_addr, tasks);
+}
+
+Result<void>
+ThreadInfo::get_tasks_from_linked_list(EchionSampler& echion, uintptr_t head_addr, std::vector<TaskInfo::Ptr>& tasks)
+{
+    if (head_addr == 0 || this->asyncio_loop == 0) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    // Copy head node struct from remote memory to local memory
+    struct llist_node head_node_local;
+    if (copy_type(reinterpret_cast<void*>(head_addr), head_node_local)) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    // Check if list is empty (head points to itself in circular list)
+    uintptr_t head_addr_uint = head_addr;
+    uintptr_t next_as_uint = reinterpret_cast<uintptr_t>(head_node_local.next);
+    uintptr_t prev_as_uint = reinterpret_cast<uintptr_t>(head_node_local.prev);
+    if (next_as_uint == head_addr_uint && prev_as_uint == head_addr_uint) {
+        return Result<void>::ok();
+    }
+
+    struct llist_node current_node = head_node_local; // Start with head node
+
+    // Copied from CPython's _remote_debugging_module.c: MAX_ITERATIONS
+    const size_t MAX_ITERATIONS = 1 << 16;
+    size_t iteration_count = 0;
+
+    // Iterate over linked-list. The linked list is circular, so we stop
+    // when we're back at head.
+    while (reinterpret_cast<uintptr_t>(current_node.next) != head_addr_uint) {
+        // Safety: prevent infinite loops
+        if (++iteration_count > MAX_ITERATIONS) {
+            return ErrorKind::TaskInfoError;
+        }
+
+        if (current_node.next == nullptr) {
+            return ErrorKind::TaskInfoError; // nullptr pointer - invalid list
+        }
+
+        uintptr_t next_node_addr = reinterpret_cast<uintptr_t>(current_node.next);
+
+        // Calculate task_addr from current_node.next
+        size_t task_node_offset_val = offsetof(TaskObj, task_node);
+        uintptr_t task_addr_uint = next_node_addr - task_node_offset_val;
+
+        // Create TaskInfo for the task
+        auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr_uint));
+        if (maybe_task_info) {
+            auto& task_info = *maybe_task_info;
+            if (task_info->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
+                tasks.push_back(std::move(task_info));
+            }
+        }
+
+        // Read next node from current_node.next into current_node
+        if (copy_type(reinterpret_cast<void*>(next_node_addr), current_node)) {
+            return ErrorKind::TaskInfoError; // Failed to read next node
+        }
+    }
+
+    return Result<void>::ok();
+}
+
+Result<std::vector<TaskInfo::Ptr>>
+ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState* tstate)
+{
+    std::vector<TaskInfo::Ptr> tasks;
+    if (this->asyncio_loop == 0)
+        return tasks;
+
+    // Python 3.14+: Native tasks are in linked-list per thread AND per interpreter
+    // CPython iterates over both:
+    // 1. Per-thread list: tstate->asyncio_tasks_head (active tasks)
+    // 2. Per-interpreter list: interp->asyncio_tasks_head (lingering tasks)
+    // First, get tasks from this thread's linked-list (if tstate_addr is set)
+    // Note: We continue processing even if one source fails to maximize partial results
+    if (tstate != nullptr && this->tstate_addr != 0) {
+        (void)get_tasks_from_thread_linked_list(echion, tasks);
+
+        // Second, get tasks from interpreter's linked-list (lingering tasks)
+        (void)get_tasks_from_interpreter_linked_list(echion, tstate, tasks);
+    }
+
+    // Handle third-party tasks from Python _scheduled_tasks WeakSet
+    // In Python 3.14+, _scheduled_tasks is a Python-level weakref.WeakSet() that only contains
+    // tasks that don't inherit from asyncio.Task. Native asyncio.Task instances are stored
+    // in linked-lists (handled above) and are NOT added to _scheduled_tasks.
+    // This is typically empty in practice, but we handle it for completeness.
+    auto asyncio_scheduled_tasks = echion.asyncio_scheduled_tasks();
+    if (asyncio_scheduled_tasks != nullptr) {
+        if (auto maybe_scheduled_tasks_set = MirrorSet::create(asyncio_scheduled_tasks)) {
+            auto scheduled_tasks_set = std::move(*maybe_scheduled_tasks_set);
+            if (auto maybe_scheduled_tasks = scheduled_tasks_set.as_unordered_set()) {
+                auto scheduled_tasks = std::move(*maybe_scheduled_tasks);
+                for (auto task_addr : scheduled_tasks) {
+                    // In WeakSet.data (set), elements are the Task objects themselves
+                    auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
+                    if (maybe_task_info &&
+                        (*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
+                        tasks.push_back(std::move(*maybe_task_info));
+                    }
+                }
+            }
+        }
+    }
+
+    auto asyncio_eager_tasks = echion.asyncio_eager_tasks();
+    if (asyncio_eager_tasks != nullptr) {
+        auto maybe_eager_tasks_set = MirrorSet::create(asyncio_eager_tasks);
+        if (!maybe_eager_tasks_set) {
+            return ErrorKind::TaskInfoError;
+        }
+
+        auto eager_tasks_set = std::move(*maybe_eager_tasks_set);
+
+        auto maybe_eager_tasks = eager_tasks_set.as_unordered_set();
+        if (!maybe_eager_tasks) {
+            return ErrorKind::TaskInfoError;
+        }
+
+        auto eager_tasks = std::move(*maybe_eager_tasks);
+        for (auto task_addr : eager_tasks) {
+            auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
+            if (maybe_task_info) {
+                if ((*maybe_task_info)->loop == reinterpret_cast<PyObject*>(this->asyncio_loop)) {
+                    tasks.push_back(std::move(*maybe_task_info));
+                }
+            }
+        }
+    }
+
+    return tasks;
+}
+#else
+// Pre-Python 3.14: get_all_tasks uses WeakSet approach
+Result<std::vector<TaskInfo::Ptr>>
+ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState*)
+{
+    std::vector<TaskInfo::Ptr> tasks;
+    if (this->asyncio_loop == 0)
+        return tasks;
+
+    auto asyncio_scheduled_tasks = echion.asyncio_scheduled_tasks();
+    auto maybe_scheduled_tasks_set = MirrorSet::create(asyncio_scheduled_tasks);
+    if (!maybe_scheduled_tasks_set) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    auto scheduled_tasks_set = std::move(*maybe_scheduled_tasks_set);
+    auto maybe_scheduled_tasks = scheduled_tasks_set.as_unordered_set();
+    if (!maybe_scheduled_tasks) {
+        return ErrorKind::TaskInfoError;
+    }
+
+    auto scheduled_tasks = std::move(*maybe_scheduled_tasks);
+    for (auto task_wr_addr : scheduled_tasks) {
+        PyWeakReference task_wr;
+        if (copy_type(task_wr_addr, task_wr))
+            continue;
+
+        auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_wr.wr_object));
+        if (maybe_task_info) {
+            if (reinterpret_cast<uintptr_t>((*maybe_task_info)->loop) == this->asyncio_loop) {
+                tasks.push_back(std::move(*maybe_task_info));
+            }
+        }
+    }
+
+    auto asyncio_eager_tasks = echion.asyncio_eager_tasks();
+    if (asyncio_eager_tasks != nullptr) {
+        auto maybe_eager_tasks_set = MirrorSet::create(asyncio_eager_tasks);
+        if (!maybe_eager_tasks_set) {
+            return ErrorKind::TaskInfoError;
+        }
+
+        auto eager_tasks_set = std::move(*maybe_eager_tasks_set);
+
+        auto maybe_eager_tasks = eager_tasks_set.as_unordered_set();
+        if (!maybe_eager_tasks) {
+            return ErrorKind::TaskInfoError;
+        }
+
+        auto eager_tasks = std::move(*maybe_eager_tasks);
+        for (auto task_addr : eager_tasks) {
+            auto maybe_task_info = TaskInfo::create(echion, reinterpret_cast<TaskObj*>(task_addr));
+            if (maybe_task_info) {
+                if (reinterpret_cast<uintptr_t>((*maybe_task_info)->loop) == this->asyncio_loop) {
+                    tasks.push_back(std::move(*maybe_task_info));
+                }
+            }
+        }
+    }
+
+    return tasks;
+}
+#endif // PY_VERSION_HEX >= 0x030e0000
+
+// ----------------------------------------------------------------------------
+void
+ThreadInfo::unwind_greenlets(EchionSampler& echion, PyThreadState* tstate, unsigned long cur_native_id)
+{
+    std::vector<GreenletSnapshot> snapshots;
+
+    // Phase 1: Snapshot greenlet data under the lock.
+    // This minimises the time we hold greenlet_info_map_lock, which is also
+    // acquired by update_greenlet_frame() on every greenlet switch.  Holding
+    // the lock during the expensive unwind (Phase 2) would block ALL greenlet
+    // switches and lead to resource exhaustion (e.g. DB connection pools).
+    {
+        const std::lock_guard<std::mutex> guard(echion.greenlet_info_map_lock());
+
+        auto& greenlet_info_map = echion.greenlet_info_map();
+        auto& greenlet_parent_map = echion.greenlet_parent_map();
+        auto& greenlet_thread_map = echion.greenlet_thread_map();
+
+        if (greenlet_thread_map.find(cur_native_id) == greenlet_thread_map.end())
+            return;
+
+        std::unordered_set<GreenletInfo::ID> parent_greenlets;
+
+        // Collect all parent greenlets
+        std::transform(greenlet_parent_map.cbegin(),
+                       greenlet_parent_map.cend(),
+                       std::inserter(parent_greenlets, parent_greenlets.begin()),
+                       [](const std::pair<GreenletInfo::ID, GreenletInfo::ID>& kv) { return kv.second; });
+
+        // Snapshot the leaf greenlets and precompute their parent chains
+        for (auto& [gid, greenlet] : greenlet_info_map) {
+            if (parent_greenlets.contains(gid))
+                continue;
+
+            auto frame = greenlet->frame;
+            if (frame == FRAME_NOT_SET) {
+                // The greenlet has not been started yet or has finished
+                continue;
+            }
+
+            GreenletSnapshot snap{ gid, greenlet->name, frame, {} };
+
+            // Precompute parent chain while we still hold the lock
+            auto current_id = gid;
+            std::unordered_set<GreenletInfo::ID> visited;
+            // The limit here is arbitrary, but it should be more than enough for
+            // most use cases.
+            const size_t MAX_GREENLET_DEPTH = 512;
+            // Safety: prevent infinite loops from cycles or corrupted parent maps
+            for (size_t iteration_count = 0; iteration_count < MAX_GREENLET_DEPTH; ++iteration_count) {
+                // Check for cycles
+                if (visited.contains(current_id))
+                    break;
+                visited.insert(current_id);
+
+                auto pit = greenlet_parent_map.find(current_id);
+                if (pit == greenlet_parent_map.end())
+                    break;
+
+                auto parent_id = pit->second;
+                auto git = greenlet_info_map.find(parent_id);
+                if (git == greenlet_info_map.end())
+                    break;
+
+                auto parent_frame = git->second->frame;
+                if (parent_frame == FRAME_NOT_SET || parent_frame == Py_None)
+                    break;
+
+                snap.parent_chain.emplace_back(git->second->name, parent_frame);
+
+                // Move up the greenlet chain
+                current_id = parent_id;
+            }
+
+            snapshots.push_back(std::move(snap));
+        }
+    } // Lock released here
+
+    // Phase 2: Unwind outside the lock.
+    // The expensive process_vm_readv / copy_type calls happen here, without
+    // blocking greenlet switches.  Snapshotted frame pointers may have become
+    // stale, but unwind_frame() handles invalid pointers gracefully via
+    // copy_type() which returns non-zero on failure.
+    for (auto& snap : snapshots) {
+        bool on_cpu = snap.frame == Py_None;
+        auto stack_info = std::make_unique<StackInfo>(snap.name, on_cpu, snap.greenlet_id);
+        auto& stack = stack_info->stack;
+
+        GreenletInfo temp(snap.greenlet_id, snap.frame, snap.name);
+        temp.unwind(echion, snap.frame, tstate, stack);
+
+        for (auto& [parent_name, parent_frame] : snap.parent_chain) {
+            GreenletInfo parent_temp(0, parent_frame, parent_name);
+            parent_temp.unwind(echion, parent_frame, tstate, stack);
+        }
+
+        current_greenlets.push_back(std::move(stack_info));
+    }
+
+    // Make sure the on-CPU greenlet is first. render_task_begin reuses the
+    // sample created by render_thread_begin for the first task it renders;
+    // that sample already received push_cputime via render_cpu_time. Tasks
+    // rendered after the first start a new sample and, if on_cpu is true,
+    // push thread_state.cpu_time_ns again, double-counting CPU time.
+    //
+    // unwind_tasks performs the analogous swap on leaf_tasks above. Note that
+    // the "on-CPU" signal differs: asyncio's is_on_cpu is derived from frame
+    // matching during unwind, while a greenlet's on_cpu is set from
+    // snap.frame == Py_None (see the loop above), which is the sentinel
+    // greenlet uses for its currently-running greenlet. If that sentinel
+    // changes, this swap silently no-ops and the over-count returns.
+    //
+    // If no greenlet is on CPU (e.g. all workers are sleeping while the Hub
+    // is running, which is filtered out as a parent), no entry triggers
+    // render_task_begin's push_cputime branch, so order does not matter and
+    // this loop falls through harmlessly. Empty current_greenlets is also
+    // safe (loop body never executes).
+    for (size_t i = 1; i < current_greenlets.size(); i++) {
+        if (current_greenlets[i]->on_cpu) {
+            std::swap(current_greenlets[i], current_greenlets[0]);
+            break;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+void
+ThreadInfo::render_unwound_stacks(EchionSampler& echion)
+{
+    auto& renderer = echion.renderer();
+
+    // Render in this order of priority
+    // 1. asyncio Tasks stacks (if any)
+    // 2. Greenlets stacks (if any)
+    // 3. The normal thread stack (if no asyncio tasks or greenlets)
+    if (!current_tasks.empty()) {
+        for (auto& task_stack_info : current_tasks) {
+            task_stack_info->task_name.visit_string([&](std::string_view task_name) {
+                renderer.render_task_begin(task_name, task_stack_info->on_cpu, task_stack_info->task_id);
+            });
+
+            task_stack_info->stack.render(echion);
+
+            renderer.render_stack_end();
+        }
+    } else if (!current_greenlets.empty()) {
+        for (auto& greenlet_stack : current_greenlets) {
+            greenlet_stack->task_name.visit_string([&](std::string_view task_name) {
+                renderer.render_task_begin(task_name, greenlet_stack->on_cpu, greenlet_stack->task_id);
+            });
+
+            auto& stack = greenlet_stack->stack;
+            stack.render(echion);
+
+            renderer.render_stack_end();
+        }
+    } else {
+        python_stack.render(echion);
+        renderer.render_stack_end();
+    }
+}
+
+// ----------------------------------------------------------------------------
+Result<void>
+ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t delta)
+{
+    auto& renderer = echion.renderer();
+
+    // This exit reset complements unwind's entry reset. It covers returns before unwind and exceptions after partial
+    // task or greenlet state has been populated, so no logical snapshot survives the cycle that created it.
+    defer
+    {
+        reset_cycle_state();
+    };
+
+    renderer.render_thread_begin(tstate, name, delta, thread_id, native_id);
+
+    microsecond_t previous_cpu_time = cpu_time;
+    auto update_cpu_time_success = update_cpu_time();
+    if (!update_cpu_time_success) {
+        return ErrorKind::CpuTimeError;
+    }
+
+    renderer.render_cpu_time(cpu_time - previous_cpu_time);
+
+    this->unwind(echion, tstate);
+    this->render_unwound_stacks(echion);
+
+    return Result<void>::ok();
+}
+
+Result<void>
+ThreadInfo::update_cpu_time()
+{
+#if defined PL_LINUX
+    struct timespec ts;
+    if (clock_gettime(cpu_clock_id, &ts)) {
+        // If the clock is invalid, we skip updating the CPU time.
+        // This can happen if we try to compute CPU time for a thread that has exited.
+        if (errno == EINVAL) {
+            return Result<void>::ok();
+        }
+
+        return ErrorKind::CpuTimeError;
+    }
+
+    this->cpu_time = TS_TO_MICROSECOND(ts);
+#elif defined PL_DARWIN
+    thread_basic_info_data_t info;
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = thread_info(
+      static_cast<thread_act_t>(this->mach_port), THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&info), &count);
+
+    if (kr != KERN_SUCCESS) {
+        // If the thread is invalid, we skip updating the CPU time.
+        // This can happen if we try to compute CPU time for a thread that has exited.
+        if (kr == KERN_INVALID_ARGUMENT) {
+            return Result<void>::ok();
+        }
+
+        return ErrorKind::CpuTimeError;
+    }
+
+    if (info.flags & TH_FLAGS_IDLE) {
+        return Result<void>::ok();
+    }
+
+    this->cpu_time = TV_TO_MICROSECOND(info.user_time) + TV_TO_MICROSECOND(info.system_time);
+#endif
+
+    return Result<void>::ok();
+}
+
+void
+for_each_thread(EchionSampler& echion, InterpreterInfo& interp, const PyThreadStateCallback& callback)
+{
+    std::unordered_set<PyThreadState*> threads;
+    std::unordered_set<PyThreadState*> seen_threads;
+
+    // Start from the thread list head
+    threads.insert(static_cast<PyThreadState*>(interp.tstate_head));
+
+    while (!threads.empty()) {
+        // Pop the next thread
+        PyThreadState* tstate_addr = *threads.begin();
+        threads.erase(threads.begin());
+
+        // Mark the thread as seen
+        seen_threads.insert(tstate_addr);
+
+        // Since threads can be created and destroyed at any time, we make
+        // a copy of the structure before trying to read its fields.
+        PyThreadState tstate;
+        if (copy_type(tstate_addr, tstate))
+            // We failed to copy the thread so we skip it.
+            continue;
+
+        // Enqueue the unseen threads that we can reach from this thread.
+        if (tstate.next != NULL && seen_threads.find(tstate.next) == seen_threads.end())
+            threads.insert(tstate.next);
+        if (tstate.prev != NULL && seen_threads.find(tstate.prev) == seen_threads.end())
+            threads.insert(tstate.prev);
+
+        {
+            const std::lock_guard<std::mutex> guard(echion.thread_info_map_lock());
+
+            // Pyroscope patch: auto-register threads discovered here, and
+            // refresh entries whose thread has since been replaced.
+            //
+            // Upstream relies on ddtrace/profiling/collector/stack.py patching
+            // the threading module to call stack_thread_register() for every
+            // thread, which both creates the ThreadInfo and *overwrites* any
+            // existing entry under the same key. Pyroscope vendors no Python,
+            // so both halves have to happen here. Upstream's behaviour when the
+            // lookup misses -- `continue` -- would skip every single thread and
+            // the profiler would produce nothing at all.
+            //
+            // Inserting only when absent is not enough. This map is keyed by
+            // pthread_t, and pthread_t values are recycled once a thread exits.
+            // A new thread inheriting a dead thread's pthread_t would keep the
+            // dead thread's cached ThreadInfo, whose cpu_clock_id was derived
+            // from the *old* kernel TID -- so update_cpu_time() reads a clock
+            // that no longer exists and the CPU delta stays zero for the rest
+            // of that thread's life. A workload that repeatedly creates and
+            // destroys threads reported 5% of the CPU it actually used before
+            // this was handled.
+            //
+            // native_thread_id (the kernel TID) is both the input to
+            // ThreadInfo::create()'s clock derivation and the discriminator for
+            // reuse: it is unique to a live thread, so a mismatch means the
+            // pthread_t was recycled.
+            //
+            // Entries for dead threads are never evicted, which is acceptable
+            // because pthread_t reuse bounds the map at roughly the peak number
+            // of concurrent threads rather than the total ever created.
+            //
+            // PyThreadState::native_thread_id only exists from CPython 3.11 on,
+            // and only Linux can derive a usable clock from it, so this whole
+            // path is conditional. Everywhere else the lookup miss falls through
+            // to upstream's `continue` and the profiler yields nothing --
+            // rust/src/cpu/mod.rs refuses to start it on those platforms rather
+            // than let it report an empty profile.
+#define PYROSCOPE_AUTO_REGISTER_THREADS (defined(PL_LINUX) && PY_VERSION_HEX >= 0x030b0000)
+
+#if PYROSCOPE_AUTO_REGISTER_THREADS
+            const unsigned long discovered_native_id = tstate.native_thread_id;
+#endif
+
+            auto it = echion.thread_info_map().find(tstate.thread_id);
+#if PYROSCOPE_AUTO_REGISTER_THREADS
+            const bool absent = it == echion.thread_info_map().end();
+            const bool recycled =
+              !absent && discovered_native_id != 0 && it->second->native_id != discovered_native_id;
+            if (absent || recycled) {
+                // The Python-level thread name is not reachable from here
+                // without touching Python objects off-GIL, so ThreadInfo gets an
+                // empty name and this profiler reports no thread_name tag.
+                auto maybe_thread_info = ThreadInfo::create(tstate.thread_id, discovered_native_id, "");
+                if (!maybe_thread_info) {
+                    // Thread is gone or its clock is unreadable; skip this cycle.
+                    continue;
+                }
+                if (absent) {
+                    it = echion.thread_info_map()
+                           .emplace(tstate.thread_id, std::move(*maybe_thread_info))
+                           .first;
+                } else {
+                    it->second = std::move(*maybe_thread_info);
+                }
+            }
+#else
+            // TODO(macos): the Darwin path cannot auto-register safely.
+            // ThreadInfo::create() calls pthread_mach_thread_np() on a pthread_t
+            // copied out of a concurrently changing interpreter list, which is
+            // undefined for a stale value. The likely fix is to use native_id
+            // directly (on macOS CPython sets native_thread_id from
+            // pthread_mach_thread_np(pthread_self()), so it is already the mach
+            // port) and let update_cpu_time()'s thread_info() call fail cleanly
+            // for a dead port -- needs verifying against 3.11-3.14 first.
+            if (it == echion.thread_info_map().end()) {
+                continue;
+            }
+#endif /* PYROSCOPE_AUTO_REGISTER_THREADS */
+#undef PYROSCOPE_AUTO_REGISTER_THREADS
+
+            // Update the tstate_addr for thread info, so we can access
+            // asyncio_tasks_head field from `_PyThreadStateImpl` struct
+            // later when we unwind tasks.
+            auto thread_info = it->second.get();
+            thread_info->tstate_addr = reinterpret_cast<uintptr_t>(tstate_addr);
+
+            // Call back with the copied thread state
+            callback(&tstate, *thread_info);
+        }
+    }
+}

--- a/cpp/cpu/ddtrace_stack/src/echion/vm.cc
+++ b/cpp/cpu/ddtrace_stack/src/echion/vm.cc
@@ -1,0 +1,198 @@
+#include <cstdio>
+#include <cstring>
+
+#include <echion/vm.h>
+
+// Returns true when _DD_PROFILING_STACK_FAST_COPY is set to a falsy value.
+// Called only during static init (constructor time), so getenv is safe here.
+static bool
+fast_copy_env_disabled()
+{
+    const char* val = getenv("_DD_PROFILING_STACK_FAST_COPY");
+    if (val == nullptr) {
+        return false;
+    }
+    return strcmp(val, "0") == 0 || strcmp(val, "false") == 0 || strcmp(val, "False") == 0;
+}
+
+#if defined PL_LINUX
+static bool
+probe_process_vm_readv()
+{
+    char src[128];
+    char dst[128];
+    for (size_t i = 0; i < 128; i++) {
+        src[i] = 0x41;
+        dst[i] = ~0x42;
+    }
+
+    struct iovec iov_dst = { dst, sizeof(dst) };
+    struct iovec iov_src = { src, sizeof(src) };
+    ssize_t result = process_vm_readv(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+    return result == static_cast<ssize_t>(sizeof(src));
+}
+
+// Pyroscope patch: dropped `__attribute__((constructor))` and renamed
+// init_safe_copy -> pyroscope_init_safe_copy.
+//
+// Upstream runs this at dlopen, i.e. on `import pyroscope`, which installs
+// process-wide SIGSEGV/SIGBUS handlers and a 1 MiB alt stack whether or not
+// this profiler is ever selected -- an unacceptable side effect for users who
+// only ever run py-spy. src/pyroscope_entry.cpp calls it explicitly (under a
+// std::once_flag) when the sampler is started instead. See ../VENDOR.md.
+void
+pyroscope_init_safe_copy()
+{
+    // Always probe process_vm_readv so we know whether it is a valid fallback.
+    process_vm_readv_available = probe_process_vm_readv();
+
+    // Honor the fast-copy opt-out: when disabled via env var, skip installing
+    // the SIGSEGV/SIGBUS handlers and alt stack entirely.
+    if (fast_copy_env_disabled()) {
+        fast_copy_user_disabled = true;
+        if (process_vm_readv_available) {
+            safe_copy = process_vm_readv;
+        } else {
+            fprintf(stderr, "Failed to initialize safe copy interface\n");
+            failed_safe_copy = true;
+        }
+        return;
+    }
+
+    // Try safe_memcpy (fast path) first.
+    if (init_segv_catcher() == 0) {
+        safe_copy = safe_memcpy_wrapper;
+        fast_copy_active = true;
+        safe_memcpy_initialized = true;
+    } else {
+        // std::cerr might not have been fully initialized at this point.
+        fprintf(stderr, "Failed to initialize segv catcher. Trying process_vm_readv.\n");
+        if (process_vm_readv_available) {
+            safe_copy = process_vm_readv;
+            mark_fast_copy_syscall_fallback();
+        } else {
+            fprintf(stderr, "Failed to initialize safe copy interface\n");
+            failed_safe_copy = true;
+        }
+    }
+}
+#elif defined PL_DARWIN
+// Pyroscope patch: dropped `__attribute__((constructor))` and renamed
+// init_safe_copy -> pyroscope_init_safe_copy.
+//
+// Upstream runs this at dlopen, i.e. on `import pyroscope`, which installs
+// process-wide SIGSEGV/SIGBUS handlers and a 1 MiB alt stack whether or not
+// this profiler is ever selected -- an unacceptable side effect for users who
+// only ever run py-spy. src/pyroscope_entry.cpp calls it explicitly (under a
+// std::once_flag) when the sampler is started instead. See ../VENDOR.md.
+void
+pyroscope_init_safe_copy()
+{
+    // Honor the fast-copy opt-out: skip installing signal handlers when disabled.
+    if (fast_copy_env_disabled()) {
+        fast_copy_user_disabled = true;
+        return;
+    }
+
+    if (init_segv_catcher() == 0) {
+        safe_copy = safe_memcpy_wrapper;
+        fast_copy_active = true;
+        safe_memcpy_initialized = true;
+        return;
+    }
+
+    // std::cerr might not be fully initialized at constructor time.
+    fprintf(stderr, "Failed to initialize segv catcher. Using mach_vm_read_overwrite instead.\n");
+    mark_fast_copy_syscall_fallback();
+}
+#endif // PL_DARWIN
+
+bool
+set_fast_copy_enabled(bool enabled)
+{
+    if (enabled) {
+        // Fast copy enabled: prefer safe_memcpy, fall back to process_vm_readv.
+        if (safe_memcpy_initialized) {
+            safe_copy = safe_memcpy_wrapper;
+            fast_copy_active = true;
+            return true;
+        }
+        fprintf(stderr,
+                "Warning: fast copy requested but safe_memcpy was not initialized; falling back to process_vm_readv\n");
+        mark_fast_copy_syscall_fallback();
+
+        // Fall through to process_vm_readv.
+    }
+
+    // Fast copy disabled (or safe_memcpy unavailable): try process_vm_readv only.
+#if defined PL_LINUX
+    if (process_vm_readv_available) {
+        safe_copy = process_vm_readv;
+        fast_copy_active = false;
+        return true;
+    }
+    fprintf(stderr,
+            "No safe memory copy method available (safe_memcpy and process_vm_readv both failed); disabling stack "
+            "profiling\n");
+    failed_safe_copy = true;
+    return false;
+#elif defined PL_DARWIN
+    // mach_vm_read_overwrite is always available on macOS.
+    safe_copy = mach_vm_read_overwrite;
+    fast_copy_active = false;
+    return true;
+#endif
+}
+
+int
+copy_memory(proc_ref_t proc_ref, const void* addr, ssize_t len, void* buf)
+{
+    ssize_t result = -1;
+
+    // Early exit on zero length
+    if (len <= 0) {
+        return 0;
+    }
+
+    // Early exit on zero page
+    if (reinterpret_cast<uintptr_t>(addr) < 4096) {
+        return static_cast<int>(result);
+    }
+
+#if defined PL_LINUX
+    struct iovec local[1];
+    struct iovec remote[1];
+
+    local[0].iov_base = buf;
+    local[0].iov_len = len;
+    remote[0].iov_base = const_cast<void*>(addr);
+    remote[0].iov_len = len;
+
+    result = safe_copy(proc_ref, local, 1, remote, 1, 0);
+
+#elif defined PL_DARWIN
+    kern_return_t kr = safe_copy(proc_ref,
+                                 reinterpret_cast<mach_vm_address_t>(addr),
+                                 len,
+                                 reinterpret_cast<mach_vm_address_t>(buf),
+                                 reinterpret_cast<mach_vm_size_t*>(&result));
+
+    if (kr != KERN_SUCCESS) {
+        g_copy_memory_error_count.fetch_add(1, std::memory_order_relaxed);
+        return -1;
+    }
+
+#endif
+
+    int ret = len != result;
+    if (ret) {
+        g_copy_memory_error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    return ret;
+}
+
+void
+_set_pid(pid_t _pid)
+{
+    pid = _pid;
+}

--- a/cpp/cpu/ddtrace_stack/src/origin_task_links.cpp
+++ b/cpp/cpu/ddtrace_stack/src/origin_task_links.cpp
@@ -1,0 +1,89 @@
+#include "origin_task_links.hpp"
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace Datadog {
+
+void
+OriginTaskLinks::enable()
+{
+    enabled_.store(true, std::memory_order_release);
+}
+
+void
+OriginTaskLinks::disable_and_reset()
+{
+    // Clear the flag before taking the map mutex so a worker that observed
+    // enabled before stop cannot insert a stale entry after the map is cleared.
+    enabled_.store(false, std::memory_order_release);
+    std::lock_guard<std::mutex> lock(mtx);
+    thread_id_to_origin_task.clear();
+}
+
+void
+OriginTaskLinks::link_origin_task(uint64_t thread_id, uint64_t task_id, std::string task_name)
+{
+    if (!is_enabled()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+    // Re-check under the mutex: disable_and_reset() may have cleared the map
+    // between the first check and lock acquisition.
+    if (!is_enabled()) {
+        return;
+    }
+
+    auto [it, inserted] = thread_id_to_origin_task.try_emplace(thread_id, task_id, std::move(task_name));
+    if (!inserted) {
+        it->second.task_id = task_id;
+        it->second.task_name = std::move(task_name);
+    }
+}
+
+const std::optional<OriginTask>
+OriginTaskLinks::get_origin_task(uint64_t thread_id)
+{
+    if (!is_enabled()) {
+        return std::nullopt;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+
+    auto it = thread_id_to_origin_task.find(thread_id);
+    if (it != thread_id_to_origin_task.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void
+OriginTaskLinks::unlink_origin_task(uint64_t thread_id)
+{
+    if (!is_enabled()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mtx);
+
+    thread_id_to_origin_task.erase(thread_id); // This is a no-op if the key is not found
+}
+
+void
+OriginTaskLinks::postfork_child()
+{
+    auto& instance = get_instance();
+    // Inherited enabled_ may still be true from the parent; stay disabled until
+    // the child sampler is restarted and enable() is called again.
+    instance.enabled_.store(false, std::memory_order_relaxed);
+    // NB placement-new to re-init and leak the mutex because doing anything else is UB
+    new (&instance.mtx) std::mutex();
+    // Map may be mid-mutation if fork raced with link/unlink; reconstruct
+    // without inspecting contents.
+    new (&instance.thread_id_to_origin_task) std::unordered_map<uint64_t, OriginTask>();
+}
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/src/pyroscope_entry.cpp
+++ b/cpp/cpu/ddtrace_stack/src/pyroscope_entry.cpp
@@ -1,0 +1,112 @@
+// Pyroscope C ABI for the vendored dd-trace-py stack (echion) sampler.
+//
+// Replaces upstream's src/stack.cpp, which was a CPython extension module
+// (PyMethodDef stack_start/stack_stop/register_thread/link_span/
+// track_greenlet/...) driven from ddtrace/profiling/collector/stack.py. We
+// vendor no Python, so this file drives the sampler directly instead.
+//
+// Dropped along with the Python layer, because all of them are Datadog product
+// features with no Pyroscope equivalent and no bearing on CPU sampling cost:
+// span linking, greenlet tracking, asyncio task attribution, and sys.monitoring
+// native call tracking.
+
+#include <Python.h>
+
+#include <cstdint>
+#include <mutex>
+
+#include "echion/config.h"
+#include "echion/vm.h"
+#include "sampler.hpp"
+
+namespace {
+std::mutex g_mutex;
+bool g_running = false;
+std::once_flag g_safe_copy_once;
+} // namespace
+
+extern "C" {
+
+// Starts the echion sampling thread.
+// `sample_rate_hz` is samples per second; `max_nframes` caps stack depth.
+// Returns 0 on success, non-zero on failure (with a Python exception set).
+int
+pyroscope_cpu_ddtrace_start(uint32_t sample_rate_hz, uint32_t max_nframes)
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_running) {
+        return 1;
+    }
+    if (sample_rate_hz == 0) {
+        return 2;
+    }
+
+    // Install the SIGSEGV/SIGBUS recovery handlers and pick a memory-copy
+    // strategy. Upstream does this from a library constructor; we patched that
+    // out so importing pyroscope does not install signal handlers for users who
+    // never select this profiler. See the Pyroscope patch in src/echion/vm.cc.
+    //
+    // Deliberately never torn down on stop: the handler chains to the previous
+    // disposition for anything it does not own, so leaving it installed is
+    // benign, whereas uninstalling it while fast_copy_active stays true would
+    // leave safe_memcpy without its recovery path on a subsequent restart
+    // (Sampler::sampling_thread only reinstalls under its own std::once_flag).
+    std::call_once(g_safe_copy_once, []() { pyroscope_init_safe_copy(); });
+
+    auto& sampler = Datadog::Sampler::get();
+
+    // Sampler::set_interval takes FRACTIONAL SECONDS, not microseconds -- see
+    // upstream stack.cpp's stack_set_interval ("Assumes the interval is given
+    // in fractional seconds"). Passing microseconds here makes the sampling
+    // thread sleep for hours and the stop path time out waiting for it.
+    const double interval_s = 1.0 / static_cast<double>(sample_rate_hz);
+    sampler.set_interval(interval_s);
+
+    // echion reads the depth cap from this global rather than from Sampler.
+    if (max_nframes > 0) {
+        max_frames = max_nframes;
+    }
+
+    // Adaptive sampling varies the interval to hit a CPU-overhead target. That
+    // is a sensible default for Datadog, but it makes the sample rate the user
+    // asked for a suggestion rather than a setting, and it quietly trades
+    // samples for overhead under load. Pin the interval instead.
+    sampler.set_adaptive_sampling(false);
+
+    if (!sampler.start()) {
+        PyErr_SetString(PyExc_RuntimeError, "ddtrace stack profiler: failed to start sampling thread");
+        return 3;
+    }
+
+    g_running = true;
+    return 0;
+}
+
+void
+pyroscope_cpu_ddtrace_stop(void)
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (!g_running) {
+        return;
+    }
+    Datadog::Sampler::get().stop();
+    g_running = false;
+}
+
+// Disarm in a freshly forked child.
+//
+// Deliberately does NOT touch the Sampler: the pthread_atfork child handler
+// registered by Sampler::one_time_setup() has already run
+// stack_postfork_cleanup(), which resets echion's mutexes and maps. Calling
+// Sampler::postfork_child() a second time here would redo that work on state
+// the first pass already rebuilt.
+//
+// g_mutex is not taken: it may have been held by a thread that no longer
+// exists, and only this (single) thread runs in the child.
+void
+pyroscope_cpu_ddtrace_postfork_child(void)
+{
+    g_running = false;
+}
+
+} // extern "C"

--- a/cpp/cpu/ddtrace_stack/src/pyroscope_renderer.cpp
+++ b/cpp/cpu/ddtrace_stack/src/pyroscope_renderer.cpp
@@ -1,0 +1,164 @@
+// Pyroscope replacement for dd-trace-py's src/stack_renderer.cpp.
+// See include/stack_renderer.hpp for why upstream's version is not vendored.
+//
+// echion pushes frames leaf-first as it unwinds, which is the order
+// Pyroscope::CpuSample and py-spy both expect, so no reversal is needed.
+
+#include "stack_renderer.hpp"
+
+#include <unistd.h>
+
+#include "echion/echion_sampler.h"
+#include "echion/strings.h"
+#include "sampler.hpp"
+
+namespace Datadog {
+
+namespace {
+constexpr std::string_view kMissingFilename = "<unknown file>";
+constexpr std::string_view kMissingName = "<unknown function>";
+
+// Deepest stack we accumulate. echion enforces its own max_frames; this is a
+// backstop so a runaway unwind cannot grow the sample without bound.
+constexpr size_t kMaxFrames = 512;
+} // namespace
+
+StackRenderer::StackRenderer()
+  : sample(kMaxFrames)
+{
+    pid = static_cast<uint32_t>(getpid());
+}
+
+void
+StackRenderer::render_thread_begin(PyThreadState* /*tstate*/,
+                                   std::string_view name,
+                                   microsecond_t wall_time_us,
+                                   uintptr_t thread_id,
+                                   unsigned long native_id)
+{
+    // A previous stack that never saw render_stack_end (e.g. the unwind
+    // failed) would otherwise bleed its frames into this one.
+    sample.clear();
+    sample_active = true;
+
+    thread_state.id = thread_id;
+    thread_state.native_id = native_id;
+    thread_state.name = std::string(name);
+    thread_state.wall_time_ns = 1000 * wall_time_us;
+    thread_state.cpu_time_ns = 0; // filled in by render_cpu_time
+
+    sample.set_pid(pid);
+    sample.set_thread(static_cast<uint64_t>(thread_id), thread_state.name);
+}
+
+void
+StackRenderer::render_task_begin(std::string_view /*task_name*/, bool /*on_cpu*/, uint64_t /*task_id*/)
+{
+    // Pyroscope does not model asyncio tasks as a separate dimension, so a
+    // task simply continues the current thread's sample. If echion starts a
+    // task without a preceding thread_begin, treat it as the start of a stack
+    // so its frames are not dropped.
+    if (!sample_active) {
+        sample.clear();
+        sample_active = true;
+        sample.set_pid(pid);
+        sample.set_thread(static_cast<uint64_t>(thread_state.id), thread_state.name);
+    }
+}
+
+void
+StackRenderer::render_frame(Frame& frame)
+{
+    if (!sample_active) {
+        return;
+    }
+
+    // The frame is owned by an LRU cache that may have evicted it, leaving the
+    // string table keys stale. That is per-frame, not fatal, so fall back to
+    // placeholders rather than dropping the whole sample.
+    const auto& string_table = Sampler::get().get_echion().string_table();
+
+    std::string_view name_str = kMissingName;
+    auto maybe_name = string_table.lookup(frame.name);
+    if (maybe_name) {
+        name_str = maybe_name->get();
+    }
+
+    std::string_view filename_str = kMissingFilename;
+    auto maybe_filename = string_table.lookup(frame.filename);
+    if (maybe_filename) {
+        filename_str = maybe_filename->get();
+    }
+
+    // Safe to borrow: the string table owns these std::strings and does not
+    // mutate them while we hold the sampling thread, and export_sample() runs
+    // before we return to the sampler loop.
+    sample.push_frame(name_str, filename_str, static_cast<int>(frame.line));
+}
+
+void
+StackRenderer::render_cpu_time(microsecond_t cpu_time_us)
+{
+    // This is the CPU time this thread actually consumed since the previous
+    // sampling tick, read from its per-thread CPU clock. It is what makes the
+    // sample a CPU sample; see render_stack_end().
+    thread_state.cpu_time_ns = 1000 * cpu_time_us;
+}
+
+void
+StackRenderer::render_native_frame(const std::string& name, const std::string& module)
+{
+    if (!sample_active) {
+        return;
+    }
+    // Native frames carry no line number.
+    sample.push_frame(name, module, 0);
+}
+
+void
+StackRenderer::render_stack_end()
+{
+    if (!sample_active) {
+        return;
+    }
+
+    // Weight the sample by the CPU time this thread actually burned, NOT by
+    // one sampling period.
+    //
+    // This sampler is wall-clock driven: it wakes on an interval and walks
+    // every Python thread, so it produces one stack per thread per tick
+    // whether or not that thread ran. Crediting each of those a full period of
+    // CPU inflates the profile by roughly the thread count -- it will happily
+    // report more CPU than the process could possibly have consumed -- and
+    // attributes CPU to threads that were blocked on I/O or waiting for the
+    // GIL.
+    //
+    // A thread that consumed no CPU since the last tick contributes nothing;
+    // export_sample() drops a zero-CPU sample.
+    sample.set_cpu_nanos(thread_state.cpu_time_ns > 0
+                           ? static_cast<uint64_t>(thread_state.cpu_time_ns)
+                           : 0);
+    sample.export_sample();
+    sample.clear();
+    // Consume the delta so it cannot be counted twice if the sampler renders
+    // several stacks (e.g. tasks) for the same thread in one tick.
+    thread_state.cpu_time_ns = 0;
+    sample_active = false;
+}
+
+void
+StackRenderer::abort_sample()
+{
+    sample.clear();
+    sample_active = false;
+}
+
+void
+StackRenderer::postfork_child()
+{
+    // Any sample in flight belonged to a thread that did not survive the fork.
+    abort_sample();
+    pid = static_cast<uint32_t>(getpid());
+}
+
+} // namespace Datadog

--- a/cpp/cpu/ddtrace_stack/src/sampler.cpp
+++ b/cpp/cpu/ddtrace_stack/src/sampler.cpp
@@ -1,0 +1,956 @@
+#include "sampler.hpp"
+
+#include "constants.hpp"
+#include "dd_wrapper/include/profiler_state.hpp"
+#include "dd_wrapper/include/sample.hpp"
+#include "origin_task_links.hpp"
+#include "thread_span_links.hpp"
+
+#include "echion/danger.h"
+#include "echion/echion_sampler.h"
+#include "echion/errors.h"
+#include "echion/greenlets.h"
+#include "echion/interp.h"
+#include "echion/strings.h"
+#include "echion/tasks.h"
+#include "echion/threads.h"
+#include "echion/vm.h"
+
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <pthread.h>
+#include <thread>
+#include <utility>
+
+using namespace Datadog;
+
+static void
+update_fast_copy_stats(ProfilerStats& stats)
+{
+    stats.set_fast_copy_memory_user_disabled(fast_copy_user_disabled);
+    stats.set_fast_copy_memory_capable(safe_memcpy_initialized);
+    stats.set_fast_copy_memory_syscall_fallback(fast_copy_syscall_fallback);
+    stats.set_fast_copy_memory_enabled(fast_copy_active);
+}
+
+void
+Datadog::seed_fast_copy_profiler_stats()
+{
+    update_fast_copy_stats(Sample::profile_borrow().stats());
+}
+
+// Helper class for spawning a std::thread with control over its default stack size
+#ifdef __linux__
+#include <ctime>
+#include <sys/resource.h>
+#include <unistd.h>
+
+struct ThreadArgs
+{
+    Sampler* sampler;
+    uint64_t seq_num;
+};
+
+void*
+call_sampling_thread(void* args)
+{
+    ThreadArgs thread_args = *static_cast<ThreadArgs*>(args);
+    delete static_cast<ThreadArgs*>(args); // no longer needed, dynamic alloc
+    Sampler* sampler = thread_args.sampler;
+    sampler->sampling_thread(thread_args.seq_num);
+    return nullptr;
+}
+
+pthread_t
+create_thread_with_stack(size_t stack_size, Sampler* sampler, uint64_t seq_num)
+{
+    pthread_attr_t attr;
+    if (pthread_attr_init(&attr) != 0) {
+        return 0;
+    }
+    if (stack_size > 0) {
+        if (pthread_attr_setstacksize(&attr, stack_size) != 0) {
+            std::cerr << "Failed to set sampling thread stack size (" << stack_size << " bytes): " << strerror(errno)
+                      << std::endl;
+        }
+    }
+
+    pthread_t thread_id{ 0 };
+    auto* thread_args = new ThreadArgs{ sampler, seq_num };
+    int ret = pthread_create(&thread_id, &attr, call_sampling_thread, thread_args);
+
+    pthread_attr_destroy(&attr);
+
+    if (ret != 0) {
+        std::cerr << "Failed to create sampling thread (stack_size=" << stack_size << "): " << strerror(ret)
+                  << std::endl;
+        delete thread_args; // usually deleted in the thread, but need to clean it up here
+        return 0;
+    }
+    return thread_id;
+}
+#elif defined(__MACH__)
+#include <mach/mach.h>
+#endif
+
+namespace {
+
+// Returns the CPU time of the calling thread in microseconds, or 0 on error.
+uint64_t
+get_thread_cpu_time_us()
+{
+#if defined(__linux__)
+    struct timespec ts
+    {
+        0, 0
+    };
+
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) {
+        return 0;
+    }
+
+    return static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
+#elif defined(__MACH__)
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    thread_basic_info_data_t info;
+    thread_port_t thread = mach_thread_self();
+    int kr = thread_info(thread, THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&info), &count);
+    mach_port_deallocate(mach_task_self(), thread);
+    if (kr != KERN_SUCCESS) {
+        return 0;
+    }
+
+    return static_cast<uint64_t>(info.user_time.seconds + info.system_time.seconds) * 1'000'000ULL +
+           info.user_time.microseconds + info.system_time.microseconds;
+#else
+    return 0;
+#endif
+}
+
+} // namespace
+
+void
+Sampler::adapt_sampling_interval()
+{
+#if defined(__linux__)
+    struct timespec ts
+    {
+        0, 0
+    };
+
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+    auto new_process_count = static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
+
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+    auto new_sampler_thread_count = static_cast<uint64_t>(ts.tv_sec * 1'000'000ULL + ts.tv_nsec / 1000);
+#elif defined(__MACH__)
+    // Get the process CPU time
+    task_thread_times_info_data_t task_info_data;
+    mach_msg_type_number_t task_info_count = TASK_THREAD_TIMES_INFO_COUNT;
+
+    if (task_info(
+          mach_task_self(), TASK_THREAD_TIMES_INFO, reinterpret_cast<task_info_t>(&task_info_data), &task_info_count) !=
+        KERN_SUCCESS) {
+        return;
+    }
+
+    auto new_process_count =
+      static_cast<uint64_t>(task_info_data.user_time.seconds * 1e6 + task_info_data.user_time.microseconds +
+                            task_info_data.system_time.seconds * 1e6 + task_info_data.system_time.microseconds);
+
+    // Get the sampling thread CPU time
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    thread_basic_info_data_t info;
+
+    thread_port_t thread = mach_thread_self(); // perf: call once
+    int kr = thread_info(thread, THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&info), &count);
+    mach_port_deallocate(mach_task_self(), thread);
+    if (kr != KERN_SUCCESS) {
+        return;
+    }
+
+    auto new_sampler_thread_count =
+      static_cast<uint64_t>(info.user_time.seconds * 1e6 + info.user_time.microseconds +
+                            info.system_time.seconds * 1e6 + info.system_time.microseconds);
+#endif
+    auto sampler_thread_delta = static_cast<double>(new_sampler_thread_count - sampler_thread_count);
+    auto process_delta =
+      static_cast<double>(new_process_count) - static_cast<double>(process_count) - sampler_thread_delta;
+    if (process_delta <= 0) {
+        process_delta = 1; // Avoid division by zero or negative values
+    }
+
+    // Rolling window for p_stable: maintain a ring buffer of process_delta values and
+    // take the p-th percentile as a stable estimate of app CPU usage. This prevents the
+    // sampling rate from collapsing during brief idle periods.
+    {
+        size_t window_capacity =
+          static_cast<size_t>(static_cast<double>(p_stable_window_s) * 1e6 / g_adaptive_sampling_interval_us);
+        if (window_capacity < 1) {
+            window_capacity = 1;
+        }
+
+        // On window shrink, clear the buffer to avoid stale data skewing the percentile.
+        if (process_delta_window.size() > window_capacity) {
+            process_delta_window.clear();
+            process_delta_window_head = 0;
+        }
+
+        if (process_delta_window.size() < window_capacity) {
+            process_delta_window.push_back(process_delta);
+        } else {
+            process_delta_window[process_delta_window_head] = process_delta;
+            process_delta_window_head = (process_delta_window_head + 1) % window_capacity;
+        }
+    }
+
+    // Compute p_stable as the p-th percentile of the rolling window.
+    // The ring buffer is always non-empty here (we just pushed to it above).
+    double p_stable;
+    {
+        // copy; sort is O(n log n), cheap for ~2400 entries
+        auto sorted = process_delta_window;
+        std::sort(sorted.begin(), sorted.end());
+        size_t idx = static_cast<size_t>(p_stable_percentile_frac * static_cast<double>(sorted.size() - 1));
+        p_stable = sorted[idx];
+    }
+
+    auto current_interval = static_cast<double>(sample_interval_us.load());
+
+    // Compute the CPU time budget for the sampler per adaptation window:
+    //   budget = baseline (absolute floor) + o * max(process_delta, p_stable)
+    // Where:
+    //   baseline      = configurable absolute floor (prevents starvation on idle apps)
+    //   o             = target overhead fraction
+    //   process_delta = current app CPU usage (reacts immediately to spikes)
+    //   p_stable      = slow-decaying p95 estimate (prevents premature backoff after brief idle)
+    //
+    // Taking max(process_delta, p_stable) makes the budget expand instantly when CPU spikes
+    // (quick capture of 0→100 scenarios) while decaying very slowly when CPU drops.
+    //
+    // The new interval is derived so that s (sampler CPU time) matches the budget:
+    //   I' = I * (s / budget)
+    auto budget = baseline_cpu_us_per_adapt_window + target_overhead * std::max(process_delta, p_stable);
+    if (budget <= 0) {
+        budget = 1.0; // Avoid division by zero
+    }
+
+    auto new_interval = static_cast<microsecond_t>(current_interval * (sampler_thread_delta / budget));
+
+    // Cap the new interval to the min/max sampling period
+    if (new_interval < g_min_sampling_period_us) {
+        new_interval = g_min_sampling_period_us;
+    } else if (new_interval > max_sampling_period_us) {
+        new_interval = max_sampling_period_us;
+    }
+
+    sample_interval_us.store(new_interval);
+    Sample::profile_borrow().stats().set_sampling_interval_us(new_interval);
+
+    // Update the counters for the next iteration
+    process_count = new_process_count;
+    sampler_thread_count = new_sampler_thread_count;
+}
+
+void
+Sampler::capture_samples(const microsecond_t wall_time_us)
+{
+    auto* const runtime = &_PyRuntime;
+
+    // When max_threads_per_sample is set, we collect all threads first, then apply
+    // reservoir sampling (Algorithm R) to select a uniform random subset, and only
+    // sample the selected threads. This caps the O(n_threads) stack-unwinding cost.
+    if (max_threads_per_sample == 0) {
+        for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
+            for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
+                auto success = thread.sample(*echion, tstate, wall_time_us);
+                if (success) {
+                    Sample::profile_borrow().stats().increment_sample_count();
+                }
+            });
+        });
+    } else {
+        thread_candidates.clear();
+
+        for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
+            for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& /*thread*/) {
+                thread_candidates.push_back(*tstate);
+            });
+        });
+
+        // Algorithm R: if we have more threads than the cap, select a uniform random subset.
+        // Selected threads are placed in [0, sample_count). Overflow threads remain in
+        // [sample_count, size) as fallbacks in case a selected thread was unregistered
+        // between collection and sampling.
+        // We use Algorithm R rather than the asymptotically faster Algorithm L because we
+        // already traverse all threads unconditionally above (the CPython thread list is a
+        // linked list, so discovery always costs O(n)). Algorithm L's advantage is skipping
+        // elements to reduce random-number generation, but that only pays off when iteration
+        // itself is expensive — it isn't here. Algorithm R is simpler and sufficient.
+        size_t sample_count = thread_candidates.size();
+        if (sample_count > max_threads_per_sample) {
+            for (size_t i = max_threads_per_sample; i < sample_count; i++) {
+                std::uniform_int_distribution<size_t> dist(0, i);
+                size_t j = dist(rng);
+                if (j < max_threads_per_sample) {
+                    std::swap(thread_candidates[j], thread_candidates[i]);
+                }
+            }
+            sample_count = max_threads_per_sample;
+        }
+
+        // Apply inverse-probability weighting: each sampled thread represents n/k threads,
+        // so scale wall_time_us up to preserve correct absolute wall-time totals.
+        // Note: If a thread disappears between snapshot collection and sampling, fewer than
+        // sample_count threads are actually sampled. The weight per sample is pre-computed
+        // so the total reported wall time can be slightly under the true value under high
+        // thread churn. This is a rare edge case.
+        const size_t n_total = thread_candidates.size();
+        const microsecond_t effective_wall_time_us =
+          (sample_count < n_total)
+            ? wall_time_us * static_cast<microsecond_t>(n_total) / static_cast<microsecond_t>(sample_count)
+            : wall_time_us;
+
+        size_t fallback_idx = sample_count;
+        for (size_t i = 0; i < sample_count; i++) {
+            // The lock is acquired per iteration rather than for the whole loop so that new
+            // threads can register (which also needs this lock) between stack unwinds. Holding
+            // it for the entire loop would block thread registration for the full sampling cycle.
+            const std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
+
+            // The tstate is a snapshot captured earlier, and thread_info_map is re-looked up
+            // here by thread_id. Under extreme thread churn a pthread_t could theoretically
+            // be reused between snapshot collection and this lookup (old thread exits, new
+            // thread registers with same ID), causing the new ThreadInfo to be paired with
+            // the old tstate. This window is a few microseconds and pthread_t reuse within
+            // it is unlikely.
+            auto it = echion->thread_info_map().find(thread_candidates[i].thread_id);
+            if (it == echion->thread_info_map().end()) {
+                // Thread was unregistered; try to fill from overflow
+                for (; fallback_idx < thread_candidates.size(); ++fallback_idx) {
+                    auto fb_it = echion->thread_info_map().find(thread_candidates[fallback_idx].thread_id);
+                    if (fb_it != echion->thread_info_map().end()) {
+                        thread_candidates[i] = thread_candidates[fallback_idx];
+                        it = fb_it;
+                        // Advance so this candidate isn't reused on the next fallback search
+                        fallback_idx++;
+                        break;
+                    }
+                }
+                if (it == echion->thread_info_map().end()) {
+                    continue;
+                }
+            }
+            auto success = it->second->sample(*echion, &thread_candidates[i], effective_wall_time_us);
+            if (success) {
+                Sample::profile_borrow().stats().increment_sample_count();
+            }
+        }
+    }
+}
+
+void
+Sampler::sampling_thread(const uint64_t seq_num)
+{
+    // Mark thread as running
+    thread_running.store(true);
+
+    seed_fast_copy_profiler_stats();
+
+    // (Re)install our SIGSEGV/SIGBUS handlers once, but ONLY if we still own them.
+    //
+    // safe_memcpy recovers only when our handler owns BOTH signals (see danger.cc).
+    // We can chain on top of handlers we coordinate with (faulthandler, crashtracker:
+    // pause + uninstall/reinstall in stack.cpp / crashtracking.py). Libraries such as
+    // abseil (vLLM/gRPC) or PyTorch/CUDA install their own handlers independently—often
+    // lazily on other threads—so overwriting them breaks their crash path and faults
+    // during sampling may still reach their handler instead of our siglongjmp (PROF-14568).
+    // If a foreign owner is already authoritative, leave it in place and fall back to
+    // the syscall copy rather than reclaiming on top.
+    static std::once_flag segv_handler_once;
+    if (fast_copy_active) {
+        std::call_once(segv_handler_once, []() {
+            if (segv_handler_installed()) {
+                init_segv_catcher();
+            }
+        });
+    }
+
+    using namespace std::chrono;
+    auto sample_time_prev = steady_clock::now();
+    auto interval_adjust_time_prev = sample_time_prev;
+
+    // safe_memcpy recovery needs us to own both handlers (PROF-14568): warm up on the
+    // syscall copy, upgrade only if we still own them, then re-check and fall back.
+    const bool fast_copy_desired = fast_copy_active;
+#if defined PL_LINUX
+    const bool syscall_copy_available = process_vm_readv_available;
+#else
+    const bool syscall_copy_available = true; // mach_vm_read_overwrite is always available
+#endif
+    // Warm up only when fast copy is wanted and a safe fallback path exists to run on.
+    const bool fast_copy_warmup = fast_copy_desired && syscall_copy_available;
+    bool fast_copy_upgraded = !fast_copy_warmup;
+    bool handler_fallback_done = false;
+    const auto fast_copy_warmup_deadline =
+      sample_time_prev + duration_cast<steady_clock::duration>(duration<double>(fast_copy_warmup_seconds));
+    if (fast_copy_warmup) {
+        // Drop to the safe syscall copy for the startup window.
+        set_fast_copy_enabled(false);
+    }
+
+    while (seq_num == thread_seq_num.load()) {
+        // Check if a pause has been requested (e.g., for signal handler swapping).
+        // Block until resumed or the thread is asked to stop.
+        if (pause_requested_.load(std::memory_order_acquire)) {
+            std::unique_lock<std::mutex> lock(pause_mutex_);
+            paused_.store(true, std::memory_order_release);
+            pause_cv_.notify_all();
+            pause_cv_.wait(lock, [&] {
+                return !pause_requested_.load(std::memory_order_acquire) || seq_num != thread_seq_num.load();
+            });
+            paused_.store(false, std::memory_order_release);
+            if (seq_num != thread_seq_num.load()) {
+                break;
+            }
+        }
+
+        // Measure CPU time before acquiring the profile lock so lock-wait time
+        // is not counted as sampling overhead.
+        auto sample_capture_cpu_before = get_thread_cpu_time_us();
+
+        auto sample_time_now = steady_clock::now();
+        auto wall_time_us = duration_cast<microseconds>(sample_time_now - sample_time_prev).count();
+        sample_time_prev = sample_time_now;
+
+        // Foreign handler handling (see notes before the loop); faulthandler's
+        // transient swaps are safe since the sampler is paused around them.
+        if (fast_copy_desired) {
+            if (!fast_copy_upgraded) {
+                // Warmup window: still on the safe syscall copy. Once it elapses,
+                // upgrade to safe_memcpy only if we still own the handlers.
+                if (sample_time_now >= fast_copy_warmup_deadline) {
+                    fast_copy_upgraded = true; // decide once
+                    if (segv_handler_installed()) {
+                        set_fast_copy_enabled(true);
+                    } else {
+                        // Another component already owns a handler; stay on the safe
+                        // syscall copy (already active from warmup) for the life of
+                        // the process.
+                        handler_fallback_done = true;
+                        mark_fast_copy_syscall_fallback();
+                        std::cerr << "ddtrace stack profiler: another component owns the SIGSEGV/SIGBUS "
+                                     "handler; keeping the syscall-based memory copy to avoid crashing."
+                                  << std::endl;
+                    }
+                }
+            } else if (fast_copy_active && !handler_fallback_done && !segv_handler_installed()) {
+                // A handler was taken over after upgrading; fall back permanently
+                // (no debounce). This is not free: it pins the process to the slower
+                // syscall copy for its remaining lifetime, which can meaningfully
+                // degrade sample quality (e.g. on asyncio workloads). We still prefer
+                // it over the alternative, which is crashing under a foreign handler.
+                handler_fallback_done = true;
+                mark_fast_copy_syscall_fallback();
+                std::cerr << "ddtrace stack profiler: SIGSEGV/SIGBUS handler was taken over by another "
+                             "component; falling back to syscall-based memory copy to avoid crashing."
+                          << std::endl;
+                if (!set_fast_copy_enabled(false)) {
+                    // No safe fallback available (e.g. process_vm_readv blocked), so
+                    // safe_memcpy is still active; reading under a foreign handler would
+                    // crash - stop sampling instead.
+                    std::cerr << "ddtrace stack profiler: no safe memory-copy fallback available; "
+                                 "stopping stack sampling to avoid crashing."
+                              << std::endl;
+                    break;
+                }
+            }
+        }
+
+        // Reset per-cycle asyncio task accumulator before iterating sampled threads
+        echion->reset_asyncio_task_count();
+
+        try {
+            capture_samples(wall_time_us);
+
+            // Collect greenlet count before acquiring the profile lock to avoid
+            // holding two locks simultaneously (greenlet lock then profile lock).
+            size_t greenlet_count;
+            {
+                const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+                greenlet_count = echion->greenlet_info_map().size();
+            }
+
+            // Drain copy_memory errors accumulated since the last sampling cycle.
+            auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);
+
+            if (do_adaptive_sampling) {
+                // Adjust the sampling interval at most every second
+                if (sample_time_now - interval_adjust_time_prev > microseconds(g_adaptive_sampling_interval_us)) {
+                    adapt_sampling_interval();
+                    interval_adjust_time_prev = sample_time_now;
+                }
+            }
+
+            // Measure CPU time before acquiring the profile lock so lock-wait time is
+            // not counted as sampling overhead.
+            auto sample_capture_cpu_after = get_thread_cpu_time_us();
+
+            // Update all end-of-cycle stats under a single borrow so they always land in
+            // the same upload window as the samples they describe. Without this, the uploader
+            // could swap cur_profiler_stats between two separate borrow calls, silently
+            // shifting some counters (including sample_capture_cpu_time_us) into the next window.
+            {
+                auto borrow = Sample::profile_borrow();
+
+                borrow.stats().increment_sampling_event_count();
+                borrow.stats().set_string_table_count(echion->string_table().size());
+                update_fast_copy_stats(borrow.stats());
+                borrow.stats().set_asyncio_task_count(echion->asyncio_task_count());
+                borrow.stats().set_greenlet_count(greenlet_count);
+
+                if (copy_errors > 0) {
+                    borrow.stats().add_copy_memory_error_count(copy_errors);
+                }
+
+                size_t cpu_diff = sample_capture_cpu_after - sample_capture_cpu_before;
+                if (cpu_diff > 0) {
+                    borrow.stats().add_sample_capture_cpu_time_us(cpu_diff);
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Unexpected error in sampling thread: " << e.what() << std::endl;
+
+            // If the exception interrupted a sample mid-build (after render_thread_begin
+            // but before render_stack_end), return it to the pool instead of leaking it.
+            echion->renderer().abort_sample();
+
+            // Mark the sampler inactive so a subsequent fork does not restart this
+            // sampler that has stopped due to an error (see prefork).
+            sampler_active_.store(false);
+
+            // Stop the sampling loop.
+            break;
+        }
+
+        // Before sleeping, check whether the user has called for this thread to die.
+        if (seq_num != thread_seq_num.load()) {
+            break;
+        }
+
+        // Sleep for the remainder of the interval, get it atomically
+        // Generally speaking system "sleep" times will wait _at least_ as long as the specified time, so
+        // in actual fact the duration may be more than we indicated.  This tends to be more true on busy
+        // systems.
+        std::this_thread::sleep_until(sample_time_now + microseconds(sample_interval_us.load()));
+    }
+
+    // Signal that the thread is exiting
+    {
+        std::lock_guard<std::mutex> lock(thread_exit_mutex);
+        thread_running.store(false);
+    }
+    thread_exit_cv.notify_all();
+}
+
+void
+Sampler::set_interval(double new_interval_s)
+{
+    microsecond_t new_interval_us = static_cast<microsecond_t>(new_interval_s * 1e6);
+    sample_interval_us.store(new_interval_us);
+    Sample::profile_borrow().stats().set_sampling_interval_us(new_interval_us);
+}
+
+Sampler::Sampler()
+  : echion{ std::make_unique<EchionSampler>(g_default_echion_frame_cache_size) }
+{
+}
+
+Sampler&
+Sampler::get()
+{
+    static Sampler instance;
+    return instance;
+}
+
+void
+Sampler::postfork_child()
+{
+    // Clear stale task/greenlet entries from parent process.
+    // No lock needed: only one thread exists in child immediately after fork.
+
+    // The sampling thread from the parent doesn't exist in the child.
+    // Reset the flag so stop() doesn't wait for a non-existent thread.
+    thread_running.store(false);
+    new (&thread_exit_mutex) std::mutex();
+    new (&thread_exit_cv) std::condition_variable();
+
+    // Reset pause state - the parent's sampling thread (and any in-progress
+    // pause) doesn't exist in the child.
+    pause_requested_.store(false);
+    paused_.store(false);
+    new (&pause_mutex_) std::mutex();
+    new (&pause_cv_) std::condition_variable();
+
+    // Clear stale echion state (mutexes, maps) from parent process
+    if (echion) {
+        echion->postfork_child();
+    }
+
+    // Note: the Thread Info Map has been reset in EchionSampler::postfork_child.
+    auto& thread_info_map = echion->thread_info_map();
+
+    // Refresh the ThreadInfo for the current (only) Thread.
+    // The pthread_t (thread_id) is preserved across fork, but native_id and
+    // cpu_clock_id/mach_port must be updated for the child process.
+#if defined PL_LINUX
+    auto current_thread_id = static_cast<uintptr_t>(pthread_self());
+#elif defined PL_DARWIN
+    auto current_thread_id = reinterpret_cast<uintptr_t>(pthread_self());
+#endif
+
+    // After fork, the current thread is the main (and only) thread,
+    // so native_id == pid.
+    auto native_id = static_cast<unsigned long>(getpid());
+    const std::string thread_name = "MainThread";
+
+    auto maybe_thread_info = ThreadInfo::create(current_thread_id, native_id, thread_name.c_str());
+    if (maybe_thread_info) {
+        thread_info_map.emplace(current_thread_id, std::move(*maybe_thread_info));
+    } else {
+        std::cerr << "Failed to register thread: " << std::hex << current_thread_id << std::dec << " (" << native_id
+                  << ") " << thread_name << std::endl;
+    }
+}
+
+void
+Sampler::prefork()
+{
+    was_running_at_fork_ = sampler_active_.load();
+}
+
+void
+Sampler::postfork_parent()
+{
+    // The parent's sampling thread survives the fork unchanged; no restart needed.
+    // Calling start() here would launch a second thread and cause a data race on
+    // EchionSampler state.
+}
+
+bool
+Sampler::restart_after_fork()
+{
+    // Restart the sampler if it was running before fork.
+    // We use the saved flag because postfork_child() resets the live sampler
+    // state (thread_running, etc.) before this runs.
+    if (was_running_at_fork_) {
+        return start();
+    }
+    return false;
+}
+
+static void
+stack_atfork_prepare()
+{
+    Sampler::get().prefork();
+}
+
+static void
+stack_atfork_parent()
+{
+    Sampler::get().postfork_parent();
+}
+
+static void
+stack_postfork_cleanup()
+{
+    // Update PID in Echion
+    _set_pid(getpid());
+
+    // Reset ThreadSpanLinks state (reset locks, clear span-thread mappings)
+    ThreadSpanLinks::postfork_child();
+
+    // Reset OriginTaskLinks state (reset locks, clear origin-task mappings)
+    OriginTaskLinks::postfork_child();
+
+    // Clear Sampler state (reset locks, clear mappings, etc.)
+    Sampler::get().postfork_child();
+}
+
+void
+stack_atfork_child()
+{
+    // Clean up Sampler state, do not start the Sampler yet.
+    stack_postfork_cleanup();
+
+    // Pyroscope patch: do not restart the sampler in the fork child.
+    //
+    // Upstream calls Sampler::restart_after_fork() here. Pyroscope's fork
+    // policy is the opposite: rust/src/lib.rs::at_fork_after_in_child stops
+    // profiling and deliberately leaks the agent, because the agent's threads
+    // did not survive the fork. An auto-restarted sampler would keep pushing
+    // samples into a Rust sink that no uploader is draining, forever.
+    //
+    // The cleanup above is still wanted, and is deliberately left on
+    // pthread_atfork rather than moved to Rust: it re-inits echion's mutexes
+    // and maps with placement new, and pthread_atfork also covers a raw
+    // fork(2) from C, which os.register_at_fork would miss.
+    //
+    // Because this handler already ran the cleanup,
+    // pyroscope_cpu_ddtrace_postfork_child() must NOT call
+    // Sampler::postfork_child() again. See src/pyroscope_entry.cpp.
+}
+
+__attribute__((constructor)) void
+stack_init()
+{
+    _set_pid(getpid());
+    ThreadSpanLinks::postfork_child();
+    OriginTaskLinks::postfork_child();
+}
+
+void
+Sampler::one_time_setup()
+{
+    // It is unlikely, but possible, that the caller has forked since application startup, but before starting echion.
+    // Run the cleanup to ensure that we're tracking the correct process.
+    stack_postfork_cleanup();
+
+    // ProfilerState::start registers
+    // dd_wrapper's pthread_atfork handler before Sampler::start is called,
+    // so the POSIX FIFO child-handler ordering guarantees dd_wrapper's
+    // postfork_child runs first — rebuilding the Profiles Dictionary before the
+    // sampling thread restarts and calls intern_string.
+    // More details in https://github.com/DataDog/dd-trace-py/pull/17183
+    pthread_atfork(stack_atfork_prepare, stack_atfork_parent, stack_atfork_child);
+}
+
+void
+Sampler::register_thread(uint64_t id, uint64_t native_id, const char* name)
+{
+    // Registering threads requires coordinating with one of echion's global locks, which we take here.
+    const std::lock_guard<std::mutex> thread_info_guard{ echion->thread_info_map_lock() };
+
+    static bool has_errored = false;
+    auto it = echion->thread_info_map().find(id);
+    if (it == echion->thread_info_map().end()) {
+        auto maybe_thread_info = ThreadInfo::create(id, native_id, name);
+        if (maybe_thread_info) {
+            echion->thread_info_map().emplace(id, std::move(*maybe_thread_info));
+        } else {
+            if (!has_errored) {
+                has_errored = true;
+                std::cerr << "Failed to register thread: " << std::hex << id << std::dec << " (" << native_id << ") "
+                          << name << std::endl;
+            }
+        }
+    } else {
+        auto maybe_thread_info = ThreadInfo::create(id, native_id, name);
+        if (maybe_thread_info) {
+            it->second = std::move(*maybe_thread_info);
+        } else {
+            if (!has_errored) {
+                has_errored = true;
+                std::cerr << "Failed to register thread: " << std::hex << id << std::dec << " (" << native_id << ") "
+                          << name << std::endl;
+            }
+        }
+    }
+}
+
+void
+Sampler::unregister_thread(uint64_t id)
+{
+    // unregistering threads requires coordinating with one of echion's global locks, which we take here.
+    const std::lock_guard<std::mutex> thread_info_guard{ echion->thread_info_map_lock() };
+    echion->thread_info_map().erase(id);
+}
+
+bool
+Sampler::start()
+{
+    static std::once_flag once;
+    std::call_once(once, [this]() { this->one_time_setup(); });
+
+    sampler_active_.store(true);
+
+    // Launch the sampling thread.
+    // Thread lifetime is bounded by the value of the sequence number.  When it is changed from the value the thread was
+    // launched with, the thread will exit.
+#ifdef __linux__
+    rlimit stack_sz = {};
+    getrlimit(RLIMIT_STACK, &stack_sz);
+    // If RLIMIT_STACK is unlimited, glibc's pthread_attr_setstacksize accepts
+    // RLIM_INFINITY (no upper-bound check) but pthread_create then fails to
+    // mmap() a stack of that size (ENOMEM).  Fall back to 8 MB -- the Linux
+    // default -- so the sampling thread is always created successfully.
+    const size_t stack_size = (stack_sz.rlim_cur == RLIM_INFINITY) ? 8ULL * 1024 * 1024 : stack_sz.rlim_cur;
+    auto thread_id = create_thread_with_stack(stack_size, this, ++thread_seq_num);
+    if (thread_id == 0) {
+        sampler_active_.store(false);
+        return false;
+    }
+
+    pthread_detach(thread_id);
+#else
+    try {
+        std::thread t(&Sampler::sampling_thread, this, ++thread_seq_num);
+        t.detach();
+    } catch (const std::exception& e) {
+        sampler_active_.store(false);
+        return false;
+    }
+#endif
+    return true;
+}
+
+void
+Sampler::stop()
+{
+    sampler_active_.store(false);
+
+    // Modifying the thread sequence number will cause the sampling thread to exit when it completes
+    // a sampling loop.
+    ++thread_seq_num;
+
+    // Wake the sampling thread if it's paused, so it can observe the seq_num
+    // change and exit.
+    pause_cv_.notify_all();
+
+    // Wait for the sampling thread to actually exit (with timeout to avoid hanging forever)
+    std::unique_lock<std::mutex> lock(thread_exit_mutex);
+    constexpr auto timeout = std::chrono::seconds(3);
+    bool exited = thread_exit_cv.wait_for(lock, timeout, [this]() { return !thread_running.load(); });
+    if (!exited) {
+        std::cerr << "Failed to stop sampling thread after timeout, exiting forcefully." << std::endl;
+    }
+}
+
+PauseResult
+Sampler::pause()
+{
+    if (!thread_running.load()) {
+        return PauseResult::NotRunning;
+    }
+
+    pause_requested_.store(true, std::memory_order_release);
+
+    // Wait for the sampling thread to reach the pause point (i.e., finish any
+    // in-flight sample) so the caller can safely swap signal handlers.
+    std::unique_lock<std::mutex> lock(pause_mutex_);
+    constexpr auto timeout = std::chrono::seconds(3);
+    bool ok = pause_cv_.wait_for(
+      lock, timeout, [this]() { return paused_.load(std::memory_order_acquire) || !thread_running.load(); });
+
+    if (!ok) {
+        // Timed out -- clear the request so the sampling thread isn't stuck.
+        pause_requested_.store(false, std::memory_order_release);
+        return PauseResult::Timeout;
+    }
+    return PauseResult::Paused;
+}
+
+void
+Sampler::resume()
+{
+    {
+        std::lock_guard<std::mutex> lock(pause_mutex_);
+        pause_requested_.store(false, std::memory_order_release);
+    }
+    pause_cv_.notify_all();
+}
+
+void
+Sampler::track_asyncio_loop(uintptr_t thread_id, PyObject* loop)
+{
+    // Holds echion's global lock
+    std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
+    if (auto it = echion->thread_info_map().find(thread_id); it != echion->thread_info_map().end()) {
+        it->second->asyncio_loop = (loop != Py_None) ? reinterpret_cast<uintptr_t>(loop) : 0;
+    }
+}
+
+void
+Sampler::init_asyncio(PyObject* _asyncio_scheduled_tasks, PyObject* _asyncio_eager_tasks)
+{
+    echion->init_asyncio(_asyncio_scheduled_tasks, _asyncio_eager_tasks);
+}
+
+void
+Sampler::link_tasks(PyObject* parent, PyObject* child)
+{
+    std::lock_guard<std::mutex> guard(echion->task_link_map_lock());
+    echion->task_link_map()[child] = parent;
+}
+
+void
+Sampler::weak_link_tasks(PyObject* parent, PyObject* child)
+{
+    std::lock_guard<std::mutex> guard(echion->task_link_map_lock());
+    echion->weak_task_link_map()[child] = parent;
+}
+
+void
+Sampler::track_greenlet(uintptr_t greenlet_id, TaskName name, PyObject* frame)
+{
+    const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+
+    auto& greenlet_info_map = echion->greenlet_info_map();
+    auto entry = greenlet_info_map.find(greenlet_id);
+    if (entry != greenlet_info_map.end()) {
+        // Greenlet is already tracked so we update its info
+        entry->second = std::make_unique<GreenletInfo>(greenlet_id, frame, std::move(name));
+    } else {
+        greenlet_info_map.emplace(greenlet_id, std::make_unique<GreenletInfo>(greenlet_id, frame, std::move(name)));
+    }
+
+    // Update the thread map
+    auto native_id = PyThread_get_thread_native_id();
+    echion->greenlet_thread_map()[native_id] = greenlet_id;
+}
+
+void
+Sampler::untrack_greenlet(uintptr_t greenlet_id)
+{
+    const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+
+    auto& greenlet_info_map = echion->greenlet_info_map();
+    auto entry = greenlet_info_map.find(greenlet_id);
+    if (entry != greenlet_info_map.end()) {
+        greenlet_info_map.erase(entry);
+    }
+
+    echion->greenlet_parent_map().erase(greenlet_id);
+    echion->greenlet_thread_map().erase(greenlet_id);
+}
+
+void
+Sampler::link_greenlets(uintptr_t parent, uintptr_t child)
+{
+    std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+
+    echion->greenlet_parent_map()[child] = parent;
+}
+
+void
+Sampler::update_greenlet_frame(uintptr_t greenlet_id, PyObject* frame)
+{
+    std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+
+    auto& greenlet_info_map = echion->greenlet_info_map();
+    auto entry = greenlet_info_map.find(greenlet_id);
+    if (entry != greenlet_info_map.end()) {
+        // Update the frame of the greenlet
+        entry->second->frame = frame;
+    }
+}
+
+void
+Sampler::set_uvloop_mode(uintptr_t thread_id, bool value)
+{
+    std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
+    if (auto it = echion->thread_info_map().find(thread_id); it != echion->thread_info_map().end()) {
+        it->second->using_uvloop = value;
+    }
+}

--- a/cpp/cpu/ddtrace_stack/src/thread_span_links.cpp
+++ b/cpp/cpu/ddtrace_stack/src/thread_span_links.cpp
@@ -1,0 +1,81 @@
+#include "thread_span_links.hpp"
+
+#include <mutex>
+#include <optional>
+#include <stdint.h>
+#include <string>
+
+namespace Datadog {
+void
+ThreadSpanLinks::link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_root_span_id, std::string span_type)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+
+    auto it = thread_id_to_span.find(thread_id);
+    if (it == thread_id_to_span.end()) {
+        thread_id_to_span[thread_id] = std::make_unique<Span>(span_id, local_root_span_id, std::move(span_type));
+    } else {
+        it->second->span_id = span_id;
+        it->second->local_root_span_id = local_root_span_id;
+        it->second->span_type = std::move(span_type);
+    }
+}
+
+const std::optional<Span>
+ThreadSpanLinks::get_active_span_from_thread_id(uint64_t thread_id)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+
+    std::optional<Span> span;
+    auto it = thread_id_to_span.find(thread_id);
+    if (it != thread_id_to_span.end()) {
+        span = *(it->second);
+    }
+    return span;
+}
+
+void
+ThreadSpanLinks::unlink_span(uint64_t thread_id)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+
+    thread_id_to_span.erase(thread_id); // This is a no-op if the key is not found
+}
+
+void
+ThreadSpanLinks::unlink_span(uint64_t thread_id, uint64_t expected_span_id)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+
+    auto it = thread_id_to_span.find(thread_id);
+    if (it != thread_id_to_span.end() && it->second->span_id == expected_span_id) {
+        thread_id_to_span.erase(it);
+    }
+}
+
+void
+ThreadSpanLinks::reset()
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    thread_id_to_span.clear();
+}
+
+void
+ThreadSpanLinks::postfork_child()
+{
+    auto& instance = get_instance();
+    // NB placement-new to re-init and leak the mutex because doing anything else is UB
+    new (&instance.mtx) std::mutex();
+    // thread_id_to_span may be in a mid-mutation state if fork raced with
+    // link_span/unlink_span. Its inherited pointers may be inconsistent,
+    // so calling clear (or letting the destructor run) would traverse the same
+    // corrupted linked-list state, which is UB. Instead, reconstruct the map in
+    // place with placement-new without inspecting its contents. This intentionally
+    // leaks the old map's heap allocations (nodes/buckets), but that memory belonged
+    // to the parent's address space snapshot and is a bounded, one-time leak per
+    // fork in the child; freeing it safely is impossible given the possible
+    // corruption, so leaking is the correct trade-off.
+    new (&instance.thread_id_to_span) std::unordered_map<uint64_t, std::unique_ptr<Span>>();
+}
+
+} // namespace Datadog

--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 LOGGER = logging.getLogger(__name__)
 
 LineNo = lib.LineNo
+CpuProfiler = lib.CpuProfiler
 
 def configure(
         app_name=None,
@@ -34,6 +35,7 @@ def configure(
         mem_heap_sample_size=512 * 1024,
         mem_enable_mem_domain=True,
         cpu_enabled=True,
+        cpu_profiler=None,
 ):
     if app_name is not None:
         warnings.warn("app_name is deprecated, use application_name", DeprecationWarning)
@@ -41,6 +43,9 @@ def configure(
 
     if native is not None:
         warnings.warn("native is deprecated and not supported", DeprecationWarning)
+
+    if cpu_profiler is None:
+        cpu_profiler = CpuProfiler.PySpy
 
     LOGGER.disabled = not enable_logging
     if enable_logging:
@@ -70,6 +75,7 @@ def configure(
         mem_heap_sample_size,
         mem_enable_mem_domain,
         cpu_enabled,
+        cpu_profiler,
     )
 
 def shutdown():

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,3 +32,7 @@ cmake = "0.1"
 [features]
 default = []
 memory = []
+# Vendored native CPU profiler (cpp/cpu/). Like `memory`, it reads CPython
+# internals and relies on the GIL, so setup.py enables it only on non
+# free-threaded builds.
+cpu_native = []

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -2,7 +2,7 @@ use cmake::Config;
 use std::env;
 use std::path::{Path, PathBuf};
 
-const NATIVE_SOURCES: &[&str] = &[
+const MEMORY_NATIVE_SOURCES: &[&str] = &[
     "CMakeLists.txt",
     "Pyroscope.h",
     "_memalloc.cpp",
@@ -21,34 +21,123 @@ const NATIVE_SOURCES: &[&str] = &[
     "profiling_helpers/version_compat.h",
 ];
 
+/// The vendored CPU profiler: its CMake project directory under `cpp/cpu/` and
+/// the static library that project produces.
+struct CpuProject {
+    dir: &'static str,
+    lib: &'static str,
+    /// `--cfg` emitted when this project is actually built.
+    /// `rust/src/cpu/native.rs` keys its `extern "C"` declarations off it, so
+    /// build.rs is the single source of truth for what is available and the two
+    /// cannot drift.
+    cfg: &'static str,
+    /// Whether this implementation supports the target we are building for.
+    supported: fn(&str) -> bool,
+}
+
+const CPU_PROJECTS: &[CpuProject] = &[CpuProject {
+    dir: "ddtrace_stack",
+    lib: "pyroscope_cpu_ddtrace",
+    cfg: "pyroscope_cpu_ddtrace",
+    // Linux only: thread auto-registration needs the kernel TID and a clock
+    // derived from it. See the TODO(macos) in
+    // cpp/cpu/ddtrace_stack/src/echion/threads.cc.
+    supported: |os| os == "linux",
+}];
+
+/// Every cfg build.rs can emit. Kept separate from CPU_PROJECTS because the
+/// check-cfg declarations must cover projects skipped on this target too,
+/// otherwise `#[cfg(...)]` on them would warn.
+const ALL_CPU_CFGS: &[&str] = &["pyroscope_cpu_ddtrace"];
+
 fn main() {
-    if cfg!(not(feature = "memory")) {
-        return;
+    // Declare every cfg we may emit, so cargo does not warn about unexpected cfgs.
+    for name in ALL_CPU_CFGS {
+        println!("cargo::rustc-check-cfg=cfg({name})");
     }
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let cpp_dir = manifest_dir.join("../cpp");
-    let cpp_dir = cpp_dir.canonicalize().unwrap();
+    let cpp_dir = manifest_dir.join("../cpp").canonicalize().unwrap();
 
-    rerun_if_native_sources_changed(&manifest_dir, &cpp_dir);
+    let ffi_header = manifest_dir.join("include/pyroscope_ffi.h");
+    println!("cargo:rerun-if-changed={}", ffi_header.display());
 
-    let mut cfg = Config::new(&cpp_dir);
+    let build_memory = cfg!(feature = "memory");
+    let build_cpu = cfg!(feature = "cpu_native");
+    if !build_memory && !build_cpu {
+        return;
+    }
 
+    // Both the memalloc profiler and the vendored CPU sampler read
+    // version-specific CPython internals, so they must be compiled against the
+    // exact interpreter the wheel targets.
     println!("cargo:rerun-if-env-changed=Python3_ROOT_DIR");
-    let python_root = env::var_os("Python3_ROOT_DIR")
-        .expect("Python3_ROOT_DIR must be set (passed from setup.py) so the C++ memalloc profiler is compiled against the target Python version");
-    cfg.define("Python3_ROOT_DIR", &python_root);
     println!("cargo:rerun-if-env-changed=Python3_EXECUTABLE");
+    let python_root = env::var_os("Python3_ROOT_DIR")
+        .expect("Python3_ROOT_DIR must be set (passed from setup.py) so the native profilers are compiled against the target Python version");
     let python_executable = env::var_os("Python3_EXECUTABLE")
-        .expect("Python3_EXECUTABLE must be set (passed from setup.py) so the C++ memalloc profiler is compiled against the exact target Python interpreter");
-    cfg.define("Python3_EXECUTABLE", &python_executable);
-    cfg.define("Python3_FIND_STRATEGY", "LOCATION");
+        .expect("Python3_EXECUTABLE must be set (passed from setup.py) so the native profilers are compiled against the exact target Python interpreter");
 
-    let dst = cfg.build();
+    let configure = |cfg: &mut Config| {
+        cfg.define("Python3_ROOT_DIR", &python_root);
+        cfg.define("Python3_EXECUTABLE", &python_executable);
+        cfg.define("Python3_FIND_STRATEGY", "LOCATION");
+    };
 
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib=static=datadog_mem_profiler_bundled");
+    if build_memory {
+        rerun_if_changed(&cpp_dir, MEMORY_NATIVE_SOURCES);
 
+        let mut cfg = Config::new(&cpp_dir);
+        configure(&mut cfg);
+        let dst = cfg.build();
+
+        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-lib=static=datadog_mem_profiler_bundled");
+    }
+
+    if build_cpu {
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+        let cpu_dir = cpp_dir.join("cpu");
+        // The vendored tree is large and changes as a unit; watch the whole
+        // directory rather than listing every file.
+        rerun_if_dir_changed(&cpu_dir);
+        // The CPU project also compiles against the shared profiling helpers.
+        rerun_if_changed(
+            &cpp_dir,
+            &[
+                "profiling_helpers/frame_accessors.h",
+                "profiling_helpers/linetable_parser.h",
+                "profiling_helpers/version_compat.h",
+            ],
+        );
+
+        for project in CPU_PROJECTS {
+            if !(project.supported)(&target_os) {
+                continue;
+            }
+            let project_dir = cpu_dir.join(project.dir);
+            if !project_dir.join("CMakeLists.txt").exists() {
+                panic!(
+                    "cpu profiler project {} is enabled for {target_os} but {} is missing",
+                    project.dir,
+                    project_dir.display()
+                );
+            }
+
+            let mut cfg = Config::new(&project_dir);
+            configure(&mut cfg);
+            // Install into its own OUT_DIR subtree so the archives cannot
+            // overwrite the memory profiler's.
+            cfg.out_dir(out_dir().join(project.dir));
+            let dst = cfg.build();
+
+            println!("cargo:rustc-link-search=native={}", dst.display());
+            println!("cargo:rustc-link-lib=static={}", project.lib);
+            println!("cargo:rustc-cfg={}", project.cfg);
+        }
+    }
+
+    // C++ runtime, shared by the memory and CPU profilers.
     if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
         println!("cargo:rustc-link-lib=static=c++");
         println!("cargo:rustc-link-arg=-undefined");
@@ -58,12 +147,30 @@ fn main() {
     }
 }
 
-fn rerun_if_native_sources_changed(manifest_dir: &Path, cpp_dir: &Path) {
-    for source in NATIVE_SOURCES {
-        let path = cpp_dir.join(source);
-        println!("cargo:rerun-if-changed={}", path.display());
-    }
+fn out_dir() -> PathBuf {
+    PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set by cargo"))
+}
 
-    let ffi_header = manifest_dir.join("include/pyroscope_ffi.h");
-    println!("cargo:rerun-if-changed={}", ffi_header.display());
+fn rerun_if_changed(base: &Path, sources: &[&str]) {
+    for source in sources {
+        println!("cargo:rerun-if-changed={}", base.join(source).display());
+    }
+}
+
+/// Emit a rerun-if-changed for every file under `dir`.
+///
+/// Cargo only reruns on a directory's own mtime, which does not change when a
+/// file inside it is edited, so the tree is walked explicitly.
+fn rerun_if_dir_changed(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rerun_if_dir_changed(&path);
+        } else {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
 }

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -23,11 +23,17 @@ include = [
   "FFIFrame",
   "FFIHeapSampleValues",
   "FFISample",
+  "FFICpuFrame",
+  "FFICpuSample",
   "pyroscope_memprof_string_table_intern_string",
   "pyroscope_memprof_push_sample",
+  "pyroscope_cpu_push_sample",
 ]
 exclude = [
   "memalloc_start",
   "memalloc_stop",
   "memalloc_heap_py",
+  "pyroscope_cpu_ddtrace_start",
+  "pyroscope_cpu_ddtrace_stop",
+  "pyroscope_cpu_ddtrace_postfork_child",
 ]

--- a/rust/include/pyroscope_ffi.h
+++ b/rust/include/pyroscope_ffi.h
@@ -11,13 +11,63 @@
 #include <stdlib.h>
 
 typedef struct {
-  uint32_t index;
-} FFIInternedString;
-
-typedef struct {
   const char *data;
   uintptr_t len;
 } FFIStringView;
+
+/*
+ A single CPU stack frame.
+
+ Unlike [`FFIFrame`] (the memory path) the strings are not interned.
+ The CPU sink builds owned `String`s so it can feed the existing
+ `StackBuffer`/`StackFrame` types unchanged, which is what keeps a
+ vendored CPU sampler on the same reporting path as py-spy.
+
+ The string data is only borrowed for the duration of the
+ `pyroscope_cpu_push_sample` call; the sink copies it.
+ */
+typedef struct {
+  FFIStringView function_name;
+  FFIStringView file_name;
+  int line;
+} FFICpuFrame;
+
+/*
+ One aggregated CPU stack trace.
+
+ `frames` is leaf-first, matching py-spy's ordering.
+ */
+typedef struct {
+  const FFICpuFrame *frames;
+  uintptr_t len;
+  uint32_t pid;
+  /*
+   `pthread_t` of the sampled thread, so thread tag rules keep working.
+   Zero when the sampler cannot attribute the sample to a thread.
+   */
+  uint64_t thread_id;
+  /*
+   May be empty when the sampler does not know the thread name.
+   */
+  FFIStringView thread_name;
+  /*
+   CPU nanoseconds this sample accounts for.
+
+   Deliberately CPU time rather than a tick count. A wall-clock sampler
+   that walks every thread produces one tick per thread per period; if
+   each of those were credited a full period of CPU, the profile would
+   report several times more CPU than the process actually consumed and
+   would count blocked threads as busy. A sampler that genuinely fires
+   once per period of CPU would simply pass `ticks * period` here.
+
+   A sample with zero CPU is dropped.
+   */
+  uint64_t cpu_nanos;
+} FFICpuSample;
+
+typedef struct {
+  uint32_t index;
+} FFIInternedString;
 
 typedef struct {
   FFIInternedString function_name;
@@ -37,6 +87,20 @@ typedef struct {
   uintptr_t len;
   FFIHeapSampleValues values;
 } FFISample;
+
+/*
+ Receives one aggregated stack trace from the vendored C++ sampler.
+
+ # Safety
+
+ `sample.frames` must point to `sample.len` initialised `FFICpuFrame`s, and
+ every string view must point to valid UTF-8 for the duration of this call.
+
+ This function allocates and takes a lock, so it must **never** be called
+ from a signal handler. The vendored sampler calls it from its ordinary
+ sampling thread; preserve that when porting another one.
+ */
+void pyroscope_cpu_push_sample(FFICpuSample sample);
 
 extern void memalloc_heap_postfork_child(void);
 

--- a/rust/src/backend/types.rs
+++ b/rust/src/backend/types.rs
@@ -112,8 +112,15 @@ impl Metadata {
 /// (which will be encoded into pprof by the session layer) or pre-encoded
 /// pprof bytes produced directly by a backend (e.g. jemalloc).
 pub enum ReportData {
-    /// Structured stack-trace reports that must be pprof-encoded before sending.
+    /// Structured stack-trace reports whose values are counts of sampling
+    /// ticks, each worth one sampling period of CPU.
     Reports(Vec<Report>),
+    /// Structured stack-trace reports whose values are already CPU nanoseconds.
+    ///
+    /// Samplers that measure per-thread CPU time directly use this. Encoding
+    /// them as tick counts would multiply by the sampling period a second time
+    /// and report far more CPU than the process consumed.
+    ReportsCpuNanos(Vec<Report>),
     /// Pre-encoded pprof bytes (may already be gzipped). Used by backends
     /// like jemalloc that produce a complete pprof profile directly.
     RawPprof(Vec<u8>),

--- a/rust/src/cpu/mod.rs
+++ b/rust/src/cpu/mod.rs
@@ -1,0 +1,162 @@
+//! CPU profiler selection.
+//!
+//! py-spy is the default and works everywhere. `Ddtrace` is a vendored native
+//! sampler under `cpp/cpu/ddtrace_stack/` (dd-trace-py's echion-based
+//! wall-clock sampler), driven over a C ABI.
+//!
+//! Both report through the same `StackBuffer` -> `Report` -> `encode::pprof`
+//! -> `session` path, so switching implementations changes what is sampled and
+//! how much it costs, not how the result is encoded or uploaded.
+
+pub mod native;
+
+use crate::backend::{BackendConfig, Report, ReportBatch, ReportData, ThreadTagsSet};
+use crate::error::Result;
+use crate::pyspy_backend::Pyspy;
+use pyo3::prelude::*;
+
+/// Which CPU profiler implementation to run.
+#[pyclass(eq, eq_int, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CpuProfiler {
+    /// py-spy: reads CPython structures out of this process's own memory from a
+    /// background Rust thread. Works on every supported platform.
+    #[default]
+    PySpy = 0,
+    /// dd-trace-py's `stack` sampler (echion): a dedicated sampler thread walks
+    /// every Python thread on a wall-clock interval and weights each stack by
+    /// that thread's CPU delta. See `cpp/cpu/ddtrace_stack/VENDOR.md`.
+    Ddtrace = 1,
+}
+
+impl CpuProfiler {
+    pub fn name(&self) -> &'static str {
+        match self {
+            CpuProfiler::PySpy => "pyspy",
+            CpuProfiler::Ddtrace => "ddtrace",
+        }
+    }
+
+    /// Why this profiler cannot run here, or `Ok(())` if it can.
+    ///
+    /// Callers surface this as an error rather than silently falling back to
+    /// py-spy: a silent fallback would report one implementation's profile
+    /// under another's name.
+    pub fn check_supported(&self, py: Python<'_>) -> std::result::Result<(), String> {
+        match self {
+            CpuProfiler::PySpy => Ok(()),
+            CpuProfiler::Ddtrace => {
+                if !native::ddtrace_built() {
+                    return Err(format!(
+                        "cpu_profiler={} is not available in this build (platform {}/{}); \
+                         it is currently built for Linux only, and not for free-threaded \
+                         interpreters",
+                        self.name(),
+                        std::env::consts::OS,
+                        std::env::consts::ARCH,
+                    ));
+                }
+                // It discovers threads by walking the interpreter's thread list
+                // and deriving each thread's CPU clock from the kernel TID in
+                // PyThreadState::native_thread_id, which only exists from
+                // CPython 3.11 on. Without it the thread map stays empty and
+                // the profile would come back blank, so refuse up front.
+                let v = py.version_info();
+                if (v.major, v.minor) < (3, 11) {
+                    return Err(format!(
+                        "cpu_profiler={} requires CPython 3.11 or newer (running {}.{}); \
+                         it needs PyThreadState::native_thread_id to discover threads",
+                        self.name(),
+                        v.major,
+                        v.minor
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Everything needed to start a CPU profiler, whichever one was selected.
+#[derive(Clone)]
+pub struct CpuConfig {
+    pub profiler: CpuProfiler,
+    pub sample_rate: u32,
+    pub backend_config: BackendConfig,
+    /// py-spy's own config. Only consulted for [`CpuProfiler::PySpy`], except
+    /// that the native path reads `include_idle`/`gil_only` to warn about knobs
+    /// it cannot honour.
+    pub pyspy: py_spy::config::Config,
+}
+
+/// A running CPU profiler.
+///
+/// `Pyspy` is boxed because it is far larger than `NativeCpu` (which holds only
+/// a discriminant and a flag -- the native sampler keeps its state in C++ and in
+/// one global buffer), and the agent stores this enum by value.
+pub enum CpuBackend {
+    PySpy(Box<Pyspy>),
+    Native(native::NativeCpu),
+}
+
+impl CpuBackend {
+    pub fn new(config: CpuConfig, ruleset: ThreadTagsSet) -> Result<Self> {
+        match config.profiler {
+            CpuProfiler::PySpy => Ok(CpuBackend::PySpy(Box::new(Pyspy::new(
+                config.pyspy,
+                config.backend_config,
+                ruleset,
+            )?))),
+            other => Ok(CpuBackend::Native(native::NativeCpu::start(
+                other, &config, ruleset,
+            )?)),
+        }
+    }
+
+    pub fn reporter(&self) -> CpuReporter {
+        match self {
+            CpuBackend::PySpy(pyspy) => CpuReporter::PySpy(pyspy.reporter()),
+            CpuBackend::Native(_) => CpuReporter::Native,
+        }
+    }
+
+    pub fn shutdown_thread(&mut self) -> Result<()> {
+        match self {
+            CpuBackend::PySpy(pyspy) => pyspy.shutdown_thread(),
+            CpuBackend::Native(native) => native.shutdown(),
+        }
+    }
+}
+
+/// Drain handle used by the agent's snapshot loop.
+pub enum CpuReporter {
+    PySpy(crate::pyspy_backend::Reporter),
+    /// The native sampler pushes into one global buffer, so there is nothing
+    /// per-instance to carry here.
+    Native,
+}
+
+impl CpuReporter {
+    pub fn report(&self) -> Result<ReportBatch> {
+        match self {
+            CpuReporter::PySpy(reporter) => reporter.report(),
+            CpuReporter::Native => {
+                let buffer = native::take_buffer()?;
+                let reports: Vec<Report> = buffer.into();
+                Ok(ReportBatch {
+                    profile_type: "process_cpu".into(),
+                    // Values are CPU nanoseconds already, not tick counts.
+                    data: ReportData::ReportsCpuNanos(reports),
+                })
+            }
+        }
+    }
+}
+
+/// Disarm the native sampler in a freshly forked child.
+///
+/// The agent is leaked wholesale in the child (its threads did not survive the
+/// fork), so `CpuBackend::drop` never runs and cannot do this.
+pub fn postfork_child() {
+    native::postfork_child();
+}

--- a/rust/src/cpu/native.rs
+++ b/rust/src/cpu/native.rs
@@ -1,0 +1,522 @@
+//! Sink and FFI surface for the vendored native CPU profiler.
+//!
+//! The C++ sampler in `cpp/cpu/ddtrace_stack/` pushes into the one global
+//! [`StackBuffer`] here, and the agent's snapshot loop drains it through the
+//! same `Report` -> `encode::pprof` -> `session` path py-spy uses.
+
+use crate::backend::{BackendConfig, StackBuffer, StackFrame, StackTrace, ThreadTagsSet};
+use crate::cpu::{CpuConfig, CpuProfiler};
+use crate::encode::pprof::ffi::{FFICpuSample, FFIStringView};
+use crate::error::{PyroscopeError, Result};
+use crate::utils::ThreadId;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+lazy_static! {
+    static ref BUFFER: Mutex<StackBuffer> = Mutex::new(StackBuffer::default());
+    /// Snapshot of the reporting knobs, published by `start()` before the
+    /// sampler is armed and read by the push callback.
+    static ref SINK_CONFIG: Mutex<SinkConfig> = Mutex::new(SinkConfig::default());
+}
+
+/// Which native sampler is currently armed, as a `CpuProfiler` discriminant, or
+/// [`NO_ACTIVE_PROFILER`] when none is.
+///
+/// Read by `postfork_child()`, which runs in a freshly forked child where the
+/// Rust agent state has been leaked wholesale and no lock may be taken.
+static ACTIVE_PROFILER: AtomicU8 = AtomicU8::new(NO_ACTIVE_PROFILER);
+const NO_ACTIVE_PROFILER: u8 = u8::MAX;
+
+#[derive(Default, Clone)]
+struct SinkConfig {
+    backend_config: BackendConfig,
+    ruleset: Option<ThreadTagsSet>,
+}
+
+/// Publish the reporting configuration. Must be called before the sampler is
+/// armed, otherwise samples would race an unset config.
+pub fn set_sink_config(backend_config: BackendConfig, ruleset: ThreadTagsSet) {
+    let mut cfg = SINK_CONFIG.lock().unwrap_or_else(|e| e.into_inner());
+    *cfg = SinkConfig {
+        backend_config,
+        ruleset: Some(ruleset),
+    };
+}
+
+/// Discard buffered samples and the published config.
+///
+/// Called after the sampler is disarmed. Without this, samples buffered by a
+/// stopped session (or inherited across a fork) would leak into the next
+/// session's first profile.
+pub fn clear_state() {
+    let mut buf = BUFFER.lock().unwrap_or_else(|e| e.into_inner());
+    buf.clear();
+    drop(buf);
+    let mut cfg = SINK_CONFIG.lock().unwrap_or_else(|e| e.into_inner());
+    *cfg = SinkConfig::default();
+}
+
+/// Drain everything buffered since the last call.
+pub fn take_buffer() -> Result<StackBuffer> {
+    Ok(std::mem::take(&mut *BUFFER.lock()?))
+}
+
+/// Receives one aggregated stack trace from the vendored C++ sampler.
+///
+/// # Safety
+///
+/// `sample.frames` must point to `sample.len` initialised `FFICpuFrame`s, and
+/// every string view must point to valid UTF-8 for the duration of this call.
+///
+/// This function allocates and takes a lock, so it must **never** be called
+/// from a signal handler. The vendored sampler calls it from its ordinary
+/// sampling thread; preserve that when porting another one.
+#[unsafe(no_mangle)]
+pub extern "C" fn pyroscope_cpu_push_sample(sample: FFICpuSample) {
+    if sample.frames.is_null() || sample.len == 0 || sample.cpu_nanos == 0 {
+        return;
+    }
+
+    let ffi_frames = unsafe { std::slice::from_raw_parts(sample.frames, sample.len) };
+    let mut frames = Vec::with_capacity(ffi_frames.len());
+    for frame in ffi_frames {
+        frames.push(StackFrame {
+            name: unsafe { string_view_to_string(&frame.function_name) },
+            filename: unsafe { string_view_to_string(&frame.file_name) },
+            line: frame.line.max(0) as u32,
+        });
+    }
+
+    let cfg = match SINK_CONFIG.lock() {
+        Ok(cfg) => cfg.clone(),
+        Err(_) => return,
+    };
+    let Some(ruleset) = cfg.ruleset else {
+        // Sampler produced a sample before start() published the config, or
+        // after clear_state() tore it down. Drop it rather than report it with
+        // default (untagged) metadata.
+        return;
+    };
+
+    // pthread_t is c_ulong on glibc and *mut c_void on musl; an integer->pointer
+    // `as` cast covers both.
+    let thread_id =
+        (sample.thread_id != 0).then(|| ThreadId::from(sample.thread_id as libc::pthread_t));
+    let thread_name = unsafe { string_view_to_option_string(&sample.thread_name) };
+
+    let stacktrace = StackTrace::new(
+        &cfg.backend_config,
+        (sample.pid != 0).then_some(sample.pid),
+        thread_id,
+        thread_name,
+        frames,
+    )
+    .add_tag_rules(&ruleset);
+
+    if let Ok(mut buffer) = BUFFER.lock() {
+        // The "count" slot carries CPU nanoseconds for this path; the reporter
+        // tags the batch as ReportsCpuNanos so the encoder does not multiply by
+        // the sampling period again.
+        let _ = buffer.record_with_count(stacktrace, sample.cpu_nanos as usize);
+    }
+}
+
+/// # Safety
+/// `s` must describe valid UTF-8 or be empty/null.
+unsafe fn string_view_to_string(s: &FFIStringView) -> String {
+    if s.data.is_null() || s.len == 0 {
+        return String::new();
+    }
+    // `.cast()` rather than `as *const u8`: c_char is i8 on x86_64 but u8 on
+    // aarch64, so an `as` cast is required on one and flagged as unnecessary by
+    // clippy on the other.
+    let bytes = unsafe { std::slice::from_raw_parts(s.data.cast::<u8>(), s.len) };
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// # Safety
+/// `s` must describe valid UTF-8 or be empty/null.
+unsafe fn string_view_to_option_string(s: &FFIStringView) -> Option<String> {
+    if s.data.is_null() || s.len == 0 {
+        return None;
+    }
+    Some(unsafe { string_view_to_string(s) })
+}
+
+/* ---------------------------------------------------------------------- *
+ * Vendored sampler entry points.
+ *
+ * Implemented by the static library built from cpp/cpu/ddtrace_stack/ by
+ * rust/build.rs. A non-zero return means the sampler failed to start; the C++
+ * side sets a Python exception describing why.
+ * ---------------------------------------------------------------------- */
+
+/// Whether the implementation's static library is part of this build.
+///
+/// The cfg is emitted by `rust/build.rs` for exactly the project it actually
+/// compiled and linked, so this cannot drift from the build.
+pub const fn ddtrace_built() -> bool {
+    cfg!(pyroscope_cpu_ddtrace)
+}
+
+#[cfg(pyroscope_cpu_ddtrace)]
+unsafe extern "C" {
+    fn pyroscope_cpu_ddtrace_start(sample_rate_hz: u32, max_nframes: u32) -> i32;
+    fn pyroscope_cpu_ddtrace_stop();
+    fn pyroscope_cpu_ddtrace_postfork_child();
+}
+
+/// Deepest stack we ask the sampler to capture. Matches py-spy's practical
+/// ceiling and the renderer's own backstop.
+#[allow(dead_code)]
+const MAX_NFRAMES: u32 = 128;
+
+/// A running vendored sampler.
+pub struct NativeCpu {
+    profiler: CpuProfiler,
+    running: bool,
+}
+
+impl NativeCpu {
+    /// Publish the sink configuration, then arm the sampler.
+    ///
+    /// Order matters: the sampler can push a sample as soon as it is armed, and
+    /// the push callback drops samples that arrive before the config is set.
+    pub fn start(
+        profiler: CpuProfiler,
+        config: &CpuConfig,
+        ruleset: ThreadTagsSet,
+    ) -> Result<Self> {
+        warn_about_ignored_options(profiler, config);
+
+        set_sink_config(config.backend_config, ruleset);
+
+        let status = unsafe {
+            match profiler {
+                CpuProfiler::Ddtrace => ddtrace_start(config.sample_rate),
+                CpuProfiler::PySpy => {
+                    clear_state();
+                    return Err(PyroscopeError::new(
+                        "py-spy is not a native CPU profiler backend",
+                    ));
+                }
+            }
+        };
+
+        if status != 0 {
+            clear_state();
+            return Err(PyroscopeError::new(&format!(
+                "native CPU profiler '{}' failed to start (status {status})",
+                profiler.name()
+            )));
+        }
+
+        ACTIVE_PROFILER.store(profiler as u8, Ordering::Release);
+
+        log::debug!(
+            target: "pyroscope-python",
+            "started native CPU profiler '{}' at {}Hz",
+            profiler.name(),
+            config.sample_rate
+        );
+
+        Ok(NativeCpu {
+            profiler,
+            running: true,
+        })
+    }
+
+    pub fn shutdown(&mut self) -> Result<()> {
+        if !self.running {
+            return Ok(());
+        }
+        self.running = false;
+        ACTIVE_PROFILER.store(NO_ACTIVE_PROFILER, Ordering::Release);
+        unsafe {
+            match self.profiler {
+                CpuProfiler::Ddtrace => ddtrace_stop(),
+                CpuProfiler::PySpy => {}
+            }
+        }
+        // Safe to drop buffered samples only after the sampler is disarmed.
+        clear_state();
+        Ok(())
+    }
+}
+
+/// Warn about py-spy-only knobs the native sampler cannot honour.
+///
+/// `oncpu` and `gil_only` are implemented inside py-spy's sampler; the vendored
+/// sampler has no equivalent. It always reports on-CPU work, weighted by each
+/// thread's own CPU clock, so silently ignoring these would give the user a
+/// profile that does not match what they asked for.
+fn warn_about_ignored_options(profiler: CpuProfiler, config: &CpuConfig) {
+    // Defaults are oncpu=true (include_idle=false) and gil_only=true.
+    if config.pyspy.include_idle {
+        log::warn!(
+            target: "pyroscope-python",
+            "oncpu=False is only supported by cpu_profiler=pyspy; \
+             '{}' always samples on-CPU work and will ignore it",
+            profiler.name()
+        );
+    }
+    if !config.pyspy.gil_only {
+        log::warn!(
+            target: "pyroscope-python",
+            "gil_only=False is only supported by cpu_profiler=pyspy; \
+             '{}' will ignore it",
+            profiler.name()
+        );
+    }
+}
+
+impl Drop for NativeCpu {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+/// Disarm the native sampler that was running, in a freshly forked child.
+///
+/// Only the sampler that was actually armed is touched, so a child that was
+/// never profiling does not construct the C++ sampler singleton for the first
+/// time inside a fork child.
+pub fn postfork_child() {
+    let active = ACTIVE_PROFILER.swap(NO_ACTIVE_PROFILER, Ordering::AcqRel);
+    if active == NO_ACTIVE_PROFILER {
+        return;
+    }
+    unsafe {
+        if active == CpuProfiler::Ddtrace as u8 {
+            ddtrace_postfork_child();
+        }
+    }
+    clear_state();
+}
+
+/* --- thin wrappers so the cfg noise lives in one place --- */
+
+unsafe fn ddtrace_start(_sample_rate_hz: u32) -> i32 {
+    #[cfg(pyroscope_cpu_ddtrace)]
+    {
+        unsafe { pyroscope_cpu_ddtrace_start(_sample_rate_hz, MAX_NFRAMES) }
+    }
+    #[cfg(not(pyroscope_cpu_ddtrace))]
+    {
+        -1
+    }
+}
+
+unsafe fn ddtrace_stop() {
+    #[cfg(pyroscope_cpu_ddtrace)]
+    unsafe {
+        pyroscope_cpu_ddtrace_stop()
+    }
+}
+
+unsafe fn ddtrace_postfork_child() {
+    #[cfg(pyroscope_cpu_ddtrace)]
+    unsafe {
+        pyroscope_cpu_ddtrace_postfork_child()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::Tag;
+    use crate::encode::pprof::ffi::FFICpuFrame;
+    use std::ffi::c_char;
+
+    fn view(s: &str) -> FFIStringView {
+        FFIStringView {
+            data: s.as_ptr() as *const c_char,
+            len: s.len(),
+        }
+    }
+
+    fn frame(name: &str, file: &str, line: i32) -> FFICpuFrame {
+        FFICpuFrame {
+            function_name: view(name),
+            file_name: view(file),
+            line,
+        }
+    }
+
+    /// The sink is process-global, so these tests must not run concurrently
+    /// with each other; they are serialized by `SINK_TEST_LOCK`.
+    static SINK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Push one sample and hand back the drained buffer.
+    ///
+    /// Clears the sink afterwards so one test cannot leave a published config
+    /// or buffered samples visible to the next one.
+    fn push_and_take(
+        frames: &[FFICpuFrame],
+        pid: u32,
+        thread_id: u64,
+        thread_name: &str,
+        cpu_nanos: u64,
+        backend_config: BackendConfig,
+        ruleset: ThreadTagsSet,
+    ) -> StackBuffer {
+        clear_state();
+        set_sink_config(backend_config, ruleset);
+        pyroscope_cpu_push_sample(FFICpuSample {
+            frames: frames.as_ptr(),
+            len: frames.len(),
+            pid,
+            thread_id,
+            thread_name: view(thread_name),
+            cpu_nanos,
+        });
+        let buffer = take_buffer().expect("buffer drains");
+        clear_state();
+        buffer
+    }
+
+    #[test]
+    fn push_sample_records_frames_leaf_first() {
+        let _guard = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let frames = [
+            frame("leaf", "/app/a.py", 10),
+            frame("caller", "/app/b.py", 4),
+        ];
+
+        let buffer = push_and_take(
+            &frames,
+            0,
+            0,
+            "",
+            10_000_000,
+            BackendConfig::default(),
+            ThreadTagsSet::new(),
+        );
+
+        assert_eq!(buffer.data.len(), 1);
+        let (trace, cpu_nanos) = buffer.data.iter().next().unwrap();
+        assert_eq!(*cpu_nanos, 10_000_000);
+        assert_eq!(trace.frames.len(), 2);
+        assert_eq!(trace.frames[0].name, "leaf");
+        assert_eq!(trace.frames[0].filename, "/app/a.py");
+        assert_eq!(trace.frames[0].line, 10);
+        assert_eq!(trace.frames[1].name, "caller");
+    }
+
+    #[test]
+    fn push_sample_honours_cpu_nanos() {
+        let _guard = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let frames = [frame("leaf", "/app/a.py", 1)];
+
+        let buffer = push_and_take(
+            &frames,
+            0,
+            0,
+            "",
+            7_000_000,
+            BackendConfig::default(),
+            ThreadTagsSet::new(),
+        );
+
+        // Stored verbatim: the encoder must not multiply by the sampling period
+        // again for this path.
+        assert_eq!(*buffer.data.values().next().unwrap(), 7_000_000);
+    }
+
+    #[test]
+    fn push_sample_applies_thread_tag_rules() {
+        let _guard = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tid: libc::pthread_t = 0x1234 as libc::pthread_t;
+        let ruleset = ThreadTagsSet::new();
+        ruleset
+            .add(crate::backend::ThreadTag::new(
+                ThreadId::from(tid),
+                Tag::new("role".into(), "worker".into()),
+            ))
+            .unwrap();
+
+        let frames = [frame("leaf", "/app/a.py", 1)];
+        let buffer = push_and_take(
+            &frames,
+            42,
+            0x1234,
+            "worker-0",
+            10_000_000,
+            BackendConfig {
+                report_pid: true,
+                report_thread_id: true,
+                report_thread_name: true,
+            },
+            ruleset,
+        );
+
+        let (trace, _) = buffer.data.iter().next().unwrap();
+        let tags: Vec<String> = trace.metadata.tags.iter().map(|t| t.to_string()).collect();
+        assert!(tags.contains(&"role=worker".to_string()), "tags: {tags:?}");
+        assert!(tags.contains(&"pid=42".to_string()), "tags: {tags:?}");
+        assert!(
+            tags.contains(&"thread_name=worker-0".to_string()),
+            "tags: {tags:?}"
+        );
+    }
+
+    #[test]
+    fn push_sample_ignores_empty_and_zero_cpu_samples() {
+        let _guard = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_state();
+        set_sink_config(BackendConfig::default(), ThreadTagsSet::new());
+
+        let frames = [frame("leaf", "/app/a.py", 1)];
+        // Zero length.
+        pyroscope_cpu_push_sample(FFICpuSample {
+            frames: frames.as_ptr(),
+            len: 0,
+            pid: 0,
+            thread_id: 0,
+            thread_name: view(""),
+            cpu_nanos: 1,
+        });
+        // Zero CPU: a sample that used no CPU is not a CPU sample.
+        pyroscope_cpu_push_sample(FFICpuSample {
+            frames: frames.as_ptr(),
+            len: 1,
+            pid: 0,
+            thread_id: 0,
+            thread_name: view(""),
+            cpu_nanos: 0,
+        });
+        // Null frame pointer.
+        pyroscope_cpu_push_sample(FFICpuSample {
+            frames: std::ptr::null(),
+            len: 3,
+            pid: 0,
+            thread_id: 0,
+            thread_name: view(""),
+            cpu_nanos: 1,
+        });
+
+        assert!(take_buffer().unwrap().data.is_empty());
+        clear_state();
+    }
+
+    #[test]
+    fn push_sample_without_config_is_dropped() {
+        let _guard = SINK_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // clear_state() unpublishes the config, mirroring what happens after the
+        // sampler is stopped. A late sample must not be reported with default
+        // (untagged) metadata.
+        clear_state();
+        let frames = [frame("leaf", "/app/a.py", 1)];
+        pyroscope_cpu_push_sample(FFICpuSample {
+            frames: frames.as_ptr(),
+            len: frames.len(),
+            pid: 0,
+            thread_id: 0,
+            thread_name: view(""),
+            cpu_nanos: 1,
+        });
+
+        assert!(take_buffer().unwrap().data.is_empty());
+    }
+}

--- a/rust/src/encode/pprof.rs
+++ b/rust/src/encode/pprof.rs
@@ -105,15 +105,21 @@ impl PProfBuilder {
         });
     }
 
+    /// Add one stack trace with an explicit, final sample value.
+    ///
+    /// `value_nanos` is written to the profile as-is. Callers that count
+    /// sampling ticks must multiply by the period first (see [`encode`]);
+    /// callers whose sampler measures CPU time directly pass that measurement
+    /// through (see [`encode_cpu_nanos`]).
     pub fn add_stacktrace(
         &mut self,
         strings: &mut StringTable,
         stacktrace: StackTrace,
-        value: usize,
+        value_nanos: i64,
     ) {
         let mut sample = Sample {
             location_id: vec![],
-            value: vec![value as i64 * self.profile.period],
+            value: vec![value_nanos],
             label: vec![],
         };
         for sf in stacktrace.frames {
@@ -252,14 +258,44 @@ impl PProfBuilder {
     }
 }
 
+/// Encode reports whose values are counts of sampling ticks.
+///
+/// Each tick is worth one sampling period of CPU. This is correct for a sampler
+/// that fires once per period of CPU actually consumed: py-spy, which with
+/// `gil_only` only ever records the thread holding the GIL.
 pub fn encode(reports: Vec<Report>, sample_rate: u32, time_range: TimeRange) -> Profile {
+    encode_inner(reports, sample_rate, time_range, |value, period| {
+        value as i64 * period
+    })
+}
+
+/// Encode reports whose values are already CPU nanoseconds.
+///
+/// Used by samplers that measure per-thread CPU time themselves rather than
+/// inferring it from a tick count. The distinction matters: a wall-clock
+/// sampler that walks every thread produces one tick per thread per period, so
+/// treating those ticks as CPU would report several times more CPU than the
+/// process actually consumed, and would count blocked threads as busy.
+pub fn encode_cpu_nanos(reports: Vec<Report>, sample_rate: u32, time_range: TimeRange) -> Profile {
+    encode_inner(reports, sample_rate, time_range, |value, _period| {
+        value as i64
+    })
+}
+
+fn encode_inner(
+    reports: Vec<Report>,
+    sample_rate: u32,
+    time_range: TimeRange,
+    to_nanos: impl Fn(usize, i64) -> i64,
+) -> Profile {
     let mut strings: StringTable = StringTable::new();
     let mut b = PProfBuilder::new();
     b.set_time_range(&time_range);
     b.set_cpu_profile_type(&mut strings, sample_rate);
+    let period = b.profile.period;
     for report in reports {
         for (stacktrace, value) in report.data {
-            b.add_stacktrace(&mut strings, stacktrace, value);
+            b.add_stacktrace(&mut strings, stacktrace, to_nanos(value, period));
         }
     }
     b.profile.string_table = strings.into_pprof_table();
@@ -437,6 +473,48 @@ pub mod ffi {
     #[repr(C)]
     pub struct FFIInternedString {
         pub index: u32,
+    }
+
+    /// A single CPU stack frame.
+    ///
+    /// Unlike [`FFIFrame`] (the memory path) the strings are not interned.
+    /// The CPU sink builds owned `String`s so it can feed the existing
+    /// `StackBuffer`/`StackFrame` types unchanged, which is what keeps a
+    /// vendored CPU sampler on the same reporting path as py-spy.
+    ///
+    /// The string data is only borrowed for the duration of the
+    /// `pyroscope_cpu_push_sample` call; the sink copies it.
+    #[repr(C)]
+    pub struct FFICpuFrame {
+        pub function_name: FFIStringView,
+        pub file_name: FFIStringView,
+        pub line: c_int,
+    }
+
+    /// One aggregated CPU stack trace.
+    ///
+    /// `frames` is leaf-first, matching py-spy's ordering.
+    #[repr(C)]
+    pub struct FFICpuSample {
+        pub frames: *const FFICpuFrame,
+        pub len: usize,
+        pub pid: u32,
+        /// `pthread_t` of the sampled thread, so thread tag rules keep working.
+        /// Zero when the sampler cannot attribute the sample to a thread.
+        pub thread_id: u64,
+        /// May be empty when the sampler does not know the thread name.
+        pub thread_name: FFIStringView,
+        /// CPU nanoseconds this sample accounts for.
+        ///
+        /// Deliberately CPU time rather than a tick count. A wall-clock sampler
+        /// that walks every thread produces one tick per thread per period; if
+        /// each of those were credited a full period of CPU, the profile would
+        /// report several times more CPU than the process actually consumed and
+        /// would count blocked threads as busy. A sampler that genuinely fires
+        /// once per period of CPU would simply pass `ticks * period` here.
+        ///
+        /// A sample with zero CPU is dropped.
+        pub cpu_nanos: u64,
     }
 }
 

--- a/rust/src/ffikit.rs
+++ b/rust/src/ffikit.rs
@@ -124,6 +124,10 @@ pub fn stop(py: Python<'_>) -> Result<()> {
 pub fn at_fork_after_in_child(_py: Python<'_>) {
     // Here we intentionally leak the whole running agent.
     // This runs post-fork in the child, the old agent must never be dropped there (its
-    // stop() joins threads that don't survive fork)
+    // stop() joins threads that don't survive fork).
+    //
+    // Leaking the agent means CpuBackend::drop never runs, so a native sampler
+    // would stay armed in the child. crate::cpu::postfork_child() disarms it
+    // directly; it is called from the fork handler in lib.rs before this.
     STATE.leak_and_reset();
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cpu;
 mod memory;
 mod pyspy_backend;
 
@@ -24,8 +25,9 @@ use std::{
 };
 
 use crate::backend::{BackendConfig, Tag, ThreadTagsSet};
+use crate::cpu::{CpuConfig, CpuProfiler};
 use crate::pyroscope::PyroscopeAgentBuilder;
-use pyo3::exceptions::{PyDeprecationWarning, PyValueError};
+use pyo3::exceptions::{PyDeprecationWarning, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
@@ -44,6 +46,9 @@ fn at_fork_after_in_parent(py: Python<'_>) -> PyResult<()> {
 fn at_fork_after_in_child(py: Python<'_>) -> PyResult<()> {
     memory::postfork_child();
     memory::stop(py);
+    // Must run before at_fork_after_in_child, which leaks the whole agent, so
+    // CpuBackend::drop never gets the chance to disarm the native sampler.
+    cpu::postfork_child();
     ffikit::at_fork_after_in_child(py);
     AGENT_RUNNING.store(false, Ordering::Release);
     Ok(())
@@ -152,13 +157,20 @@ fn initialize_agent(
     mem_heap_sample_size: u64,
     mem_enable_mem_domain: bool,
     cpu_enabled: bool,
-) -> bool {
+    cpu_profiler: CpuProfiler,
+) -> PyResult<bool> {
     if !cpu_enabled && !mem_enabled {
         log::error!(
             target: "pyroscope-python",
             "at least one of CPU or memory profiling must be enabled"
         );
-        return false;
+        return Ok(false);
+    }
+
+    // Fail loudly rather than falling back to py-spy: a silent fallback would
+    // report one implementation's profile under another's name.
+    if cpu_enabled && let Err(reason) = cpu_profiler.check_supported(py) {
+        return Err(PyRuntimeError::new_err(reason));
     }
 
     let backend_config = BackendConfig {
@@ -167,18 +179,23 @@ fn initialize_agent(
         report_pid,
     };
 
-    let pyspy_config = cpu_enabled.then(|| py_spy::Config {
-        blocking: py_spy::config::LockingStrategy::NonBlocking,
-        native: false,
-        pid: Some(std::process::id().try_into().unwrap()),
-        sampling_rate: sample_rate.into(),
-        include_idle: !oncpu,
-        include_thread_ids: true,
-        subprocesses: false,
-        gil_only,
-        lineno: line_no.into(),
-        duration: py_spy::config::RecordDuration::Unlimited,
-        ..py_spy::Config::default()
+    let cpu_config = cpu_enabled.then(|| CpuConfig {
+        profiler: cpu_profiler,
+        sample_rate,
+        backend_config,
+        pyspy: py_spy::Config {
+            blocking: py_spy::config::LockingStrategy::NonBlocking,
+            native: false,
+            pid: Some(std::process::id().try_into().unwrap()),
+            sampling_rate: sample_rate.into(),
+            include_idle: !oncpu,
+            include_thread_ids: true,
+            subprocesses: false,
+            gil_only,
+            lineno: line_no.into(),
+            duration: py_spy::config::RecordDuration::Unlimited,
+            ..py_spy::Config::default()
+        },
     });
 
     let dynamic_tags = ThreadTagsSet::new();
@@ -210,16 +227,16 @@ fn initialize_agent(
 
     let result = ffikit::run(
         py,
-        PyroscopeAgentBuilder::new(agent_builder, pyspy_config, backend_config, dynamic_tags),
+        PyroscopeAgentBuilder::new(agent_builder, cpu_config, dynamic_tags),
     );
     match result {
         Ok(_) => {
             AGENT_RUNNING.store(true, Ordering::Release);
-            true
+            Ok(true)
         }
         Err(e) => {
             log::error!(target: "pyroscope-python", "failed to start agent: {}", e);
-            false
+            Ok(false)
         }
     }
 }
@@ -264,6 +281,7 @@ impl From<LineNo> for py_spy::config::LineNo {
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LineNo>()?;
+    m.add_class::<CpuProfiler>()?;
     m.add_function(wrap_pyfunction!(initialize_logging, m)?)?;
     m.add_function(wrap_pyfunction!(initialize_agent, m)?)?;
     m.add_function(wrap_pyfunction!(drop_agent, m)?)?;

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -109,7 +109,9 @@ mod implementation {
             return StringID::empty_ffi_string();
         }
         let unsafe_str = unsafe {
-            let s = std::slice::from_raw_parts(s.data as *const u8, s.len);
+            // See the note in cpu/native.rs: c_char signedness is
+            // target-dependent, so cast() rather than `as *const u8`.
+            let s = std::slice::from_raw_parts(s.data.cast::<u8>(), s.len);
             std::str::from_utf8_unchecked(s)
         };
         match STRING_TABLE.lock() {

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    backend::{BackendConfig, ReportBatch, ReportData, Tag, ThreadTag, ThreadTagsSet},
+    backend::{ReportBatch, ReportData, Tag, ThreadTag, ThreadTagsSet},
     error::Result,
     memory,
     session::{Session, SessionManager, SessionSignal},
@@ -13,7 +13,7 @@ use crate::{
 use std::sync::mpsc::SyncSender;
 use std::time::{Duration, SystemTime};
 
-use crate::pyspy_backend::Pyspy;
+use crate::cpu::{CpuBackend, CpuConfig, CpuReporter};
 use crate::utils::TimeRange;
 const LOG_TAG: &str = "Pyroscope::Agent";
 const DEFAULT_UPLOAD_INTERVAL: Duration = Duration::from_secs(10);
@@ -126,22 +126,20 @@ impl PyroscopeConfig {
 
 pub struct PyroscopeAgentBuilder {
     pub config: PyroscopeConfig,
-    pyspy_config: Option<py_spy::config::Config>,
-    backend_config: BackendConfig,
+    /// `None` when CPU profiling is disabled.
+    cpu_config: Option<CpuConfig>,
     ruleset: ThreadTagsSet,
 }
 
 impl PyroscopeAgentBuilder {
     pub fn new(
         config: PyroscopeConfig,
-        pyspy_config: Option<py_spy::config::Config>,
-        backend_config: BackendConfig,
+        cpu_config: Option<CpuConfig>,
         ruleset: ThreadTagsSet,
     ) -> Self {
         Self {
             config,
-            pyspy_config,
-            backend_config,
+            cpu_config,
             ruleset,
         }
     }
@@ -155,8 +153,8 @@ impl PyroscopeAgentBuilder {
         // }
 
         let backend = self
-            .pyspy_config
-            .map(|config| Pyspy::new(config, self.backend_config, self.ruleset.clone()))
+            .cpu_config
+            .map(|cpu_config| CpuBackend::new(cpu_config, self.ruleset.clone()))
             .transpose()?;
         if backend.is_some() {
             log::trace!(target: LOG_TAG, "Backend initialized");
@@ -182,8 +180,8 @@ pub struct PyroscopeAgent {
     terminate_channel: Option<Sender<()>>,
     /// Handle to the thread that runs the Pyroscope Agent
     handle: Option<JoinHandle<Result<()>>>,
-    /// Profiler backend
-    pub backend: Option<Pyspy>,
+    /// CPU profiler backend
+    pub backend: Option<CpuBackend>,
     /// Configuration Object
     pub config: PyroscopeConfig,
 
@@ -224,7 +222,7 @@ impl PyroscopeAgent {
     pub fn start(mut self) -> Result<PyroscopeAgent> {
         log::debug!(target: LOG_TAG, "Starting");
 
-        let reporter = self.backend.as_ref().map(Pyspy::reporter);
+        let reporter = self.backend.as_ref().map(CpuBackend::reporter);
 
         let (tx, rx) = mpsc::channel();
         self.terminate_channel = Some(tx);
@@ -258,7 +256,7 @@ impl PyroscopeAgent {
     }
 
     fn snapshot(
-        reporter: &Option<crate::pyspy_backend::Reporter>,
+        reporter: &Option<CpuReporter>,
         config: PyroscopeConfig,
         stx: &SyncSender<SessionSignal>,
         stop_watch: &mut StopWatch,

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -123,6 +123,12 @@ impl Session {
                     pprof::encode(reports, self.config.sample_rate, self.time_range.clone())
                         .encode_to_vec()
                 }
+                ReportData::ReportsCpuNanos(reports) => pprof::encode_cpu_nanos(
+                    reports,
+                    self.config.sample_rate,
+                    self.time_range.clone(),
+                )
+                .encode_to_vec(),
             };
 
             let labels = labels_for_profile(&self.config, profile_type);

--- a/scripts/check-cpu-profilers-multiversion.sh
+++ b/scripts/check-cpu-profilers-multiversion.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Compile the vendored CPU profiler against each CPython in the CI matrix.
+#
+# It reads version-specific CPython internals (_PyInterpreterFrame, f_code vs
+# f_executable, cframe vs current_frame, the PEP 657 line table, ...), so a
+# change that builds against the local interpreter can still break on another
+# version. This catches that in a couple of minutes instead of waiting for a
+# full wheel matrix. Run it after every re-vendor and after touching anything
+# under cpp/cpu/.
+#
+# Usage: scripts/check-cpu-profilers-multiversion.sh [version...]
+#
+# Requires Docker. Uses the full python:X images because the -slim ones do not
+# ship the CPython internal headers.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+VERSIONS=("$@")
+if [ ${#VERSIONS[@]} -eq 0 ]; then
+    VERSIONS=(3.10 3.11 3.12 3.13 3.14)
+fi
+
+# The project is Linux-only (see the TODO(macos) in
+# cpp/cpu/ddtrace_stack/src/echion/threads.cc); this script runs in Linux
+# containers, so it is expected to build for every version.
+PROJECTS=(ddtrace_stack)
+
+overall=0
+for version in "${VERSIONS[@]}"; do
+    echo "################ CPython ${version} ################"
+    docker run --rm -v "${REPO}":/src:ro -w /tmp "python:${version}" bash -c '
+        set -e
+        pip install --quiet --disable-pip-version-check cmake >/dev/null 2>&1
+        export PATH=$PATH:$(python -c "import sysconfig; print(sysconfig.get_path(\"scripts\"))")
+        rc=0
+        for proj in '"${PROJECTS[*]}"'; do
+            rm -rf "/tmp/b-$proj"
+            if cmake -S "/src/cpp/cpu/$proj" -B "/tmp/b-$proj" \
+                    -DPython3_EXECUTABLE="$(which python)" \
+                    -DPython3_FIND_STRATEGY=LOCATION >"/tmp/cfg-$proj.log" 2>&1 \
+                && cmake --build "/tmp/b-$proj" -j"$(nproc)" >"/tmp/bld-$proj.log" 2>&1; then
+                echo "  OK    $proj"
+            else
+                echo "  FAIL  $proj"
+                grep -E "error:" "/tmp/cfg-$proj.log" "/tmp/bld-$proj.log" 2>/dev/null | head -10
+                rc=1
+            fi
+        done
+        exit $rc
+    '
+    [ $? -ne 0 ] && overall=1
+done
+
+if [ $overall -eq 0 ]; then
+    echo "the CPU profiler builds on all requested CPython versions"
+else
+    echo "FAILURES above" >&2
+fi
+exit $overall

--- a/scripts/tests/test_ddtrace_cpu.py
+++ b/scripts/tests/test_ddtrace_cpu.py
@@ -1,0 +1,452 @@
+"""End-to-end smoke test for cpu_profiler=CpuProfiler.Ddtrace.
+
+Self-contained: it stands up a local HTTP server that captures the agent's
+push requests and decodes the pprof out of them, so it needs no Pyroscope
+server. Run it with the extension installed:
+
+    python scripts/tests/test_ddtrace_cpu.py
+
+What it checks, in order of how easy each is to break:
+
+1. The busy function appears in the profile at all. If the thread
+   auto-registration patch in cpp/cpu/ddtrace_stack/src/echion/threads.cc were
+   dropped, echion's thread_info_map would stay empty and the profile would be
+   completely blank.
+2. Reported CPU does not exceed what the process could possibly have used.
+   This is the wall-clock-vs-CPU weighting trap: the sampler walks *every*
+   Python thread each tick, so crediting each tick a full sampling period
+   inflates the total by roughly the thread count.
+3. Reported CPU is in the right ballpark versus os.times(), so the previous
+   check cannot be satisfied by reporting nothing.
+4. The same holds under thread churn, which is what the recycled-pthread_t half
+   of the threads.cc patch guards: a new thread inheriting a dead thread's
+   pthread_t must not keep the dead thread's CPU clock.
+5. Selecting the profiler where it cannot work (non-Linux, or CPython 3.10)
+   raises instead of silently falling back to py-spy.
+"""
+
+import gzip
+import hashlib
+import logging
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pyroscope
+
+logger = logging.getLogger("test_ddtrace_cpu")
+
+APP_NAME = "pyroscopers.python.test.ddtrace_cpu"
+SAMPLE_RATE = 100
+UPLOAD_INTERVAL = 1
+
+
+# --------------------------------------------------------------------------
+# Minimal protobuf / pprof reader.
+#
+# Hand-rolled so the test has no dependency beyond the standard library. It
+# only understands the handful of fields it needs; everything else is skipped.
+# --------------------------------------------------------------------------
+
+def _read_varint(buf, pos):
+    result = 0
+    shift = 0
+    while True:
+        byte = buf[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+
+
+def _iter_fields(buf):
+    """Yield (field_number, wire_type, value) for each field in `buf`.
+
+    `value` is bytes for wire type 2 and an int otherwise.
+    """
+    pos = 0
+    end = len(buf)
+    while pos < end:
+        key, pos = _read_varint(buf, pos)
+        field, wire = key >> 3, key & 7
+        if wire == 0:
+            value, pos = _read_varint(buf, pos)
+        elif wire == 1:
+            value = int.from_bytes(buf[pos:pos + 8], "little")
+            pos += 8
+        elif wire == 2:
+            length, pos = _read_varint(buf, pos)
+            value = buf[pos:pos + length]
+            pos += length
+        elif wire == 5:
+            value = int.from_bytes(buf[pos:pos + 4], "little")
+            pos += 4
+        else:
+            raise ValueError("unsupported wire type {}".format(wire))
+        yield field, wire, value
+
+
+def _packed_varints(buf):
+    pos = 0
+    out = []
+    while pos < len(buf):
+        value, pos = _read_varint(buf, pos)
+        out.append(value)
+    return out
+
+
+def _zigzag_free_int64(values):
+    """pprof int64 fields are plain varints, sign-extended at 64 bits."""
+    return [v - (1 << 64) if v >= (1 << 63) else v for v in values]
+
+
+class Profile:
+    """The slice of a pprof Profile this test cares about."""
+
+    def __init__(self, raw):
+        self.strings = []
+        self.functions = {}   # function id -> name string index
+        self.locations = {}   # location id -> [function id]
+        self.samples = []     # (location ids leaf-first, values)
+        self.sample_types = []
+
+        for field, _wire, value in _iter_fields(raw):
+            if field == 1:      # sample_type
+                self.sample_types.append(self._value_type(value))
+            elif field == 2:    # sample
+                self.samples.append(self._sample(value))
+            elif field == 4:    # location
+                loc_id, func_ids = self._location(value)
+                self.locations[loc_id] = func_ids
+            elif field == 5:    # function
+                func_id, name_idx = self._function(value)
+                self.functions[func_id] = name_idx
+            elif field == 6:    # string_table
+                self.strings.append(value.decode("utf-8", "replace"))
+
+    @staticmethod
+    def _value_type(buf):
+        type_idx = unit_idx = 0
+        for field, _wire, value in _iter_fields(buf):
+            if field == 1:
+                type_idx = value
+            elif field == 2:
+                unit_idx = value
+        return type_idx, unit_idx
+
+    @staticmethod
+    def _sample(buf):
+        location_ids = []
+        values = []
+        for field, wire, value in _iter_fields(buf):
+            if field == 1:
+                location_ids.extend(_packed_varints(value) if wire == 2 else [value])
+            elif field == 2:
+                raw = _packed_varints(value) if wire == 2 else [value]
+                values.extend(_zigzag_free_int64(raw))
+        return location_ids, values
+
+    @staticmethod
+    def _location(buf):
+        loc_id = 0
+        func_ids = []
+        for field, _wire, value in _iter_fields(buf):
+            if field == 1:
+                loc_id = value
+            elif field == 4:  # line
+                for lf, _lw, lv in _iter_fields(value):
+                    if lf == 1:
+                        func_ids.append(lv)
+        return loc_id, func_ids
+
+    @staticmethod
+    def _function(buf):
+        func_id = name_idx = 0
+        for field, _wire, value in _iter_fields(buf):
+            if field == 1:
+                func_id = value
+            elif field == 2:
+                name_idx = value
+        return func_id, name_idx
+
+    def function_names(self, location_ids):
+        names = []
+        for loc_id in location_ids:
+            for func_id in self.locations.get(loc_id, ()):
+                names.append(self.strings[self.functions.get(func_id, 0)])
+        return names
+
+    def total_value(self):
+        return sum(values[0] for _locs, values in self.samples if values)
+
+    def value_for_function(self, name):
+        total = 0
+        for locs, values in self.samples:
+            if values and name in self.function_names(locs):
+                total += values[0]
+        return total
+
+    def sample_type_names(self):
+        return [
+            (self.strings[t], self.strings[u]) for t, u in self.sample_types
+        ]
+
+
+def decode_push_request(body):
+    """Return [(labels dict, Profile)] from a gzipped PushRequest."""
+    raw = gzip.decompress(body)
+    out = []
+    for field, _wire, value in _iter_fields(raw):
+        if field != 1:  # series
+            continue
+        labels = {}
+        for sf, _sw, sv in _iter_fields(value):
+            if sf == 1:  # LabelPair
+                name = val = ""
+                for lf, _lw, lv in _iter_fields(sv):
+                    if lf == 1:
+                        name = lv.decode()
+                    elif lf == 2:
+                        val = lv.decode()
+                labels[name] = val
+            elif sf == 2:  # RawSample
+                for rf, _rw, rv in _iter_fields(sv):
+                    if rf == 1:
+                        out.append((labels, Profile(rv)))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Capture server
+# --------------------------------------------------------------------------
+
+class Collector:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.profiles = []  # (labels, Profile)
+
+    def add(self, entries):
+        with self.lock:
+            self.profiles.extend(entries)
+
+    def cpu_profiles(self):
+        with self.lock:
+            return [
+                (labels, profile)
+                for labels, profile in self.profiles
+                if labels.get("__name__") == "process_cpu"
+            ]
+
+    def reset(self):
+        with self.lock:
+            self.profiles = []
+
+
+def make_server(collector):
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                collector.add(decode_push_request(body))
+            except Exception:
+                logger.exception("failed to decode push request")
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+# --------------------------------------------------------------------------
+# Workload
+# --------------------------------------------------------------------------
+
+def cpuhog(stop):
+    """Burn CPU in a distinctively named frame."""
+    value = "seed"
+    while not stop.is_set():
+        for _ in range(2000):
+            value = hashlib.sha256(value.encode()).hexdigest()
+    return value
+
+
+def process_cpu_seconds():
+    times = os.times()
+    return times.user + times.system
+
+
+def run_workload(nthreads, duration, churn=False):
+    """Run `nthreads` busy threads for `duration` seconds.
+
+    With `churn`, threads are short-lived and constantly replaced, so pthread_t
+    values get recycled.
+    """
+    stop = threading.Event()
+    cpu_before = process_cpu_seconds()
+    wall_before = time.monotonic()
+
+    if not churn:
+        threads = [
+            threading.Thread(target=cpuhog, args=(stop,), name="cpuhog-%d" % i)
+            for i in range(nthreads)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(duration)
+        stop.set()
+        for t in threads:
+            t.join()
+    else:
+        deadline = time.monotonic() + duration
+        while time.monotonic() < deadline:
+            round_stop = threading.Event()
+            threads = [
+                threading.Thread(target=cpuhog, args=(round_stop,), name="churn-%d" % i)
+                for i in range(nthreads)
+            ]
+            for t in threads:
+                t.start()
+            time.sleep(0.3)
+            round_stop.set()
+            for t in threads:
+                t.join()
+
+    return process_cpu_seconds() - cpu_before, time.monotonic() - wall_before
+
+
+# --------------------------------------------------------------------------
+# Assertions
+# --------------------------------------------------------------------------
+
+def check_profiles(collector, label, actual_cpu_s, wall_s, nthreads):
+    profiles = collector.cpu_profiles()
+    if not profiles:
+        raise AssertionError("%s: no process_cpu profiles were pushed" % label)
+
+    reported_ns = sum(p.total_value() for _labels, p in profiles)
+    cpuhog_ns = sum(p.value_for_function("cpuhog") for _labels, p in profiles)
+
+    reported_s = reported_ns / 1e9
+    logger.info(
+        "%s: %d profiles, reported %.2fs CPU (%.2fs in cpuhog), "
+        "process used %.2fs over %.2fs wall with %d busy threads",
+        label, len(profiles), reported_s, cpuhog_ns / 1e9,
+        actual_cpu_s, wall_s, nthreads,
+    )
+
+    # 1. The busy frame has to be there at all.
+    if cpuhog_ns == 0:
+        names = set()
+        for _labels, p in profiles:
+            for locs, _values in p.samples:
+                names.update(p.function_names(locs))
+        raise AssertionError(
+            "%s: 'cpuhog' never appeared in the profile; saw %s" % (label, sorted(names)[:20])
+        )
+
+    # 2. Values must be CPU nanoseconds, not one sampling period per thread per
+    #    tick. The ceiling is generous (2x) so this only fires on the real bug,
+    #    which overshoots by roughly the thread count.
+    ceiling_s = actual_cpu_s * 2 + 1.0
+    if reported_s > ceiling_s:
+        raise AssertionError(
+            "%s: reported %.2fs of CPU but the process only used %.2fs. "
+            "Samples are probably weighted by the sampling period instead of "
+            "the per-thread CPU delta -- see the sample weighting section of "
+            "cpp/cpu/ddtrace_stack/VENDOR.md" % (label, reported_s, actual_cpu_s)
+        )
+
+    # 3. ...and it must not be satisfied by reporting almost nothing. A
+    #    sampler that only sees a fraction of the threads (the recycled
+    #    pthread_t bug reported ~5%) fails here.
+    floor_s = actual_cpu_s * 0.25
+    if reported_s < floor_s:
+        raise AssertionError(
+            "%s: reported only %.2fs of CPU for a process that used %.2fs. "
+            "Threads are probably being skipped or billed against a dead CPU "
+            "clock -- see the threads.cc patch in "
+            "cpp/cpu/ddtrace_stack/VENDOR.md" % (label, reported_s, actual_cpu_s)
+        )
+
+    types = profiles[0][1].sample_type_names()
+    logger.info("%s: sample types %s", label, types)
+
+
+def check_unsupported_raises():
+    """Selecting an unbuilt profiler must raise, not fall back to py-spy."""
+    try:
+        pyroscope.configure(
+            application_name=APP_NAME,
+            server_address="http://127.0.0.1:1",
+            cpu_profiler=pyroscope.CpuProfiler.Ddtrace,
+        )
+    except RuntimeError as e:
+        logger.info("unsupported platform raised as expected: %s", e)
+        return True
+    pyroscope.shutdown()
+    return False
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    supported = sys.platform == "linux" and sys.version_info >= (3, 11)
+    if not supported:
+        # cpu_profiler=Ddtrace is Linux/CPython 3.11+ only today; assert that it
+        # says so rather than silently profiling with py-spy.
+        if not check_unsupported_raises():
+            raise AssertionError(
+                "cpu_profiler=Ddtrace is not supported on %s/%d.%d but configure() "
+                "accepted it instead of raising"
+                % (sys.platform, sys.version_info[0], sys.version_info[1])
+            )
+        logger.info("done (unsupported here: only the rejection path is exercised)")
+        return
+
+    collector = Collector()
+    server, _thread = make_server(collector)
+    address = "http://127.0.0.1:%d" % server.server_address[1]
+    logger.info("collector listening on %s", address)
+
+    nthreads = 4
+    pyroscope.configure(
+        application_name=APP_NAME,
+        server_address=address,
+        enable_logging=True,
+        sample_rate=SAMPLE_RATE,
+        upload_interval=UPLOAD_INTERVAL,
+        cpu_profiler=pyroscope.CpuProfiler.Ddtrace,
+        report_pid=True,
+        report_thread_id=True,
+        mem_enabled=False,
+    )
+
+    try:
+        cpu_s, wall_s = run_workload(nthreads, duration=6)
+        # Let the last upload interval land.
+        time.sleep(UPLOAD_INTERVAL * 3)
+        check_profiles(collector, "steady", cpu_s, wall_s, nthreads)
+
+        collector.reset()
+        cpu_s, wall_s = run_workload(nthreads, duration=6, churn=True)
+        time.sleep(UPLOAD_INTERVAL * 3)
+        check_profiles(collector, "churn", cpu_s, wall_s, nthreads)
+    finally:
+        pyroscope.shutdown()
+        server.shutdown()
+
+    logger.info("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_ddtrace_cpu_fork.py
+++ b/scripts/tests/test_ddtrace_cpu_fork.py
@@ -1,0 +1,119 @@
+"""Fork behaviour for cpu_profiler=CpuProfiler.Ddtrace.
+
+Intentionally not run in CI alongside the other suites; fork tests can deadlock
+on unrelated library state. Run manually:
+
+    python scripts/tests/test_ddtrace_cpu_fork.py
+
+The thing being checked is that a forked child does NOT keep sampling. Upstream
+dd-trace-py restarts the sampler from its pthread_atfork child handler; that is
+patched out (see cpp/cpu/ddtrace_stack/VENDOR.md, "do not restart the sampler in
+the fork child") because Pyroscope leaks the agent in the child, so a restarted
+sampler would push into a sink nothing ever drains.
+
+The child proves this by burning CPU and then configuring a fresh agent of its
+own, which only succeeds if the inherited state was properly torn down.
+"""
+
+import hashlib
+import os
+import sys
+import threading
+import time
+
+import pyroscope
+
+APP_NAME = "pyroscope.ddtrace-cpu-fork-test"
+
+
+def burn(seconds):
+    value = "seed"
+    end = time.monotonic() + seconds
+    while time.monotonic() < end:
+        value = hashlib.sha256(value.encode()).hexdigest()
+    return value
+
+
+def child_body():
+    """Runs in the forked child. Returns an exit code."""
+    # If the sampler had been restarted here it would be walking threads and
+    # pushing samples while we do this.
+    burn(1.0)
+
+    # A child that inherited a half-torn-down agent cannot start a new one.
+    if not pyroscope.configure(
+        application_name=APP_NAME + ".child",
+        server_address="http://127.0.0.1:4040",
+        cpu_profiler=pyroscope.CpuProfiler.Ddtrace,
+        mem_enabled=False,
+    ):
+        return 2
+    burn(1.0)
+    if not pyroscope.shutdown():
+        return 3
+    return 0
+
+
+def fork_and_check():
+    pid = os.fork()
+    if pid == 0:
+        code = 1
+        try:
+            code = child_body()
+        except BaseException:
+            code = 4
+        finally:
+            os._exit(code)
+
+    _, status = os.waitpid(pid, 0)
+    code = os.waitstatus_to_exitcode(status)
+    if code != 0:
+        raise AssertionError(
+            "forked child exited with %d; the ddtrace sampler probably survived "
+            "the fork or left state the child could not recover from" % code
+        )
+
+
+def main():
+    if sys.platform != "linux" or sys.version_info < (3, 11):
+        print("skipped: cpu_profiler=Ddtrace requires Linux and CPython 3.11+")
+        return
+
+    if not pyroscope.configure(
+        application_name=APP_NAME,
+        server_address="http://127.0.0.1:4040",
+        cpu_profiler=pyroscope.CpuProfiler.Ddtrace,
+        upload_interval=1,
+        mem_enabled=False,
+    ):
+        raise AssertionError("failed to start the agent with cpu_profiler=Ddtrace")
+
+    try:
+        # Fork while several threads are busy, so the child inherits a
+        # thread_info_map full of threads that do not exist in it.
+        stop = threading.Event()
+        threads = [
+            threading.Thread(target=lambda: [burn(0.1) for _ in iter(lambda: not stop.is_set(), False)])
+            for _ in range(3)
+        ]
+        for t in threads:
+            t.start()
+        time.sleep(1.0)
+
+        fork_and_check()
+
+        stop.set()
+        for t in threads:
+            t.join()
+
+        # The parent must still be profiling: its sampling thread survives the
+        # fork untouched (Sampler::prefork does not stop it).
+        burn(1.0)
+    finally:
+        pyroscope.shutdown()
+
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,13 @@ env.update({
     "Python3_EXECUTABLE": sys.executable,
 })
 
+# The C++ memalloc profiler and the vendored native CPU profiler both read
+# version-specific CPython internals and assume the GIL, so neither is built
+# for free-threaded interpreters.
 features = []
 if sysconfig.get_config_var("Py_GIL_DISABLED") != 1:
     features.append("memory")
+    features.append("cpu_native")
 
 setup(
     rust_extensions=[


### PR DESCRIPTION
Adds a second, selectable CPU profiler alongside py-spy: dd-trace-py 4.14.0's
`stack` sampler (echion), vendored as C++ under `cpp/cpu/ddtrace_stack/` and
linked into `_native` as its own static library, mirroring how the memalloc
profiler in `cpp/` is built.

```python
pyroscope.configure(cpu_profiler=pyroscope.CpuProfiler.Ddtrace, ...)
```

py-spy stays the default. Selecting a profiler that cannot run here raises
instead of falling back, so a profile is never reported under the wrong
implementation's name.

## What was vendored, and what was not

Only C/C++. `cpp/cpu/ddtrace_stack/VENDOR.md` records the upstream release
(`v4.14.0`, `ef86511`), everything dropped, and every local patch.

- **No libdatadog.** Upstream renders through `StackRenderer` -> `ddup_*` ->
  `libdd_wrapper.so` -> Rust libdatadog, which owns pprof encoding and upload.
  None of that chain is here. `src/pyroscope_renderer.cpp` renders into
  `Pyroscope::CpuSample` and pushes over a new C ABI into the existing Rust
  `StackBuffer` -> `Report` -> `pprof` -> `session` path. This is the same seam
  the memalloc port used when it replaced `ddup_interface` with
  `cpp/Pyroscope.h`. `shim/dd_wrapper/include/` holds no-op replacements for the
  few headers the retained code still includes, which is what lets
  `src/sampler.cpp` and `src/echion/stacks.cc` stay byte-identical to upstream.
- **No Python.** `src/stack.cpp` (the `_stack` CPython extension module) is
  replaced by `src/pyroscope_entry.cpp`, a plain C ABI driven from
  `rust/src/cpu/`. Span linking, greenlet tracking, asyncio task attribution and
  `sys.monitoring` native-call tracking go with it -- all Datadog product
  features driven from the Python layer.
- `cpp/profiling_helpers/` is not vendored a second time; it is byte-identical
  to this release's copy, so both archives compile against the one on disk.

## Local patches to vendored files

All marked `// Pyroscope patch:` in-file.

1. **`for_each_thread()` auto-registers threads.** Upstream relies on
   ddtrace patching the `threading` module to call `register_thread()`. With no
   Python layer, echion's thread map would stay empty and the loop's `continue`
   would skip *every* thread -- a completely blank profile. It also has to
   handle recycled `pthread_t` values: a new thread inheriting a dead one's key
   would keep the dead thread's `cpu_clock_id` and report ~0 CPU for its whole
   life.
2. **Dropped a library constructor.** `init_safe_copy()` is
   `__attribute__((constructor))` upstream, so it installed process-wide
   SIGSEGV/SIGBUS handlers and a 1 MiB alt stack on `import pyroscope`, whether
   or not this profiler was ever selected. Now called explicitly at start.
3. **No sampler restart in a fork child.** Upstream restarts from its
   `pthread_atfork` child handler. This repo's policy is the opposite -- the
   agent is deliberately leaked in the child -- so a restarted sampler would
   push into a sink nothing drains.

## Sample weighting

This is a **wall-clock** sampler: it walks every Python thread each tick,
producing one stack per thread whether or not that thread ran. Each sample is
therefore weighted by that thread's CPU delta, not by one sampling period, and
zero-CPU samples are dropped. `ReportData::ReportsCpuNanos` carries those values
through `encode::pprof` unmultiplied. Weighting by the period instead inflates
the profile by roughly the thread count and counts blocked threads as busy.

## Platform support

Linux and CPython 3.11+ for now. Thread discovery needs
`PyThreadState::native_thread_id` (3.11+) and a per-thread CPU clock derived
from it (Linux). The tree still compiles on macOS and on 3.10; it just cannot
discover threads, so `check_supported()` refuses rather than report a blank
profile. `TODO(macos)` with the likely fix is recorded in `VENDOR.md` and in the
`threads.cc` patch.

## Verification

- `scripts/check-cpu-profilers-multiversion.sh` -- builds against CPython
  3.10-3.14 in Docker. All green. (This is what caught the 3.11 requirement.)
- `nm` on the built archive and on `_native.so`: no `ddog_`/`libdatadog`
  symbols; exactly the three documented entry points exported;
  `vm.cc.o` no longer has an `.init_array`.
- `cargo test` -- 34 pass, including 5 new ones for the sink (leaf-first
  ordering, CPU-nanos passthrough, tag rules, empty/zero/null rejection,
  drop-without-config).
- `scripts/tests/test_ddtrace_cpu.py` -- self-contained (captures pushes on a
  local HTTP server and decodes the pprof, no Pyroscope server needed). Reports
  **6.15s of CPU for a process that used 6.23s** with 4 busy threads, and holds
  under thread churn (6.11s vs 6.39s).
- `scripts/tests/test_ddtrace_cpu_fork.py` -- the child does not keep sampling
  and can start a fresh agent.

## Not included

No Go integration test yet (`integration-test/integration_test.go`). The
existing CPU cases run across 3.10-3.14 and would need a version gate; adding it
untested felt worse than leaving it for a follow-up commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
