### PR TITLE
feat: add Google Cloud CPU profiler backend

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -40,6 +40,10 @@ jobs:
           toolchain: 1.96.0
           components: clippy
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
+        with:
+          python-version: "3.11"
+
       - name: Run clippy
         run: |
           cargo clippy --all-targets --no-default-features -- --deny warnings
@@ -68,11 +72,15 @@ jobs:
         with:
           toolchain: 1.96.0
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
+        with:
+          python-version: "3.11"
+
       - name: Run tests without memory profiling
         run: cargo test --locked --no-default-features
         working-directory: rust
 
-      - name: Run tests with memory profiling
+      - name: Run tests with native profilers
         run: |
           export Python3_ROOT_DIR=$(python3 -c 'import sys, pathlib; print(pathlib.Path(sys.base_prefix).resolve())')
           export Python3_EXECUTABLE=$(python3 -c 'import sys; print(sys.executable)')

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,8 @@ include cpp/BundleStaticLibrary.cmake
 recursive-include cpp/ *.h
 recursive-include cpp/ *.cpp
 recursive-include cpp/ *.hpp
+include gcp_patches.md
+include gcp/CMakeLists.txt
+include gcp/LICENSE
+recursive-include gcp/ *.cc
+recursive-include gcp/ *.h

--- a/README.md
+++ b/README.md
@@ -2,13 +2,35 @@
 
 Pyroscope continuous profiling agent for Python applications.
 
-Uses [py-spy](https://github.com/benfred/py-spy) for stack sampling and the [pyroscope](https://crates.io/crates/pyroscope) Rust crate to send profiles to a Pyroscope server.
+Uses [py-spy](https://github.com/benfred/py-spy) by default, with an optional
+Google Cloud Profiler CPU sampler, and sends profiles to a Pyroscope server.
 
 ## Installation
 
 ```bash
 pip install pyroscope-io
 ```
+
+## GCP CPU profiler
+
+The default CPU profiler remains `pyspy`. On Linux with a GIL-enabled CPython
+3.10 or 3.11 build, the native CPU sampler from Google Cloud Profiler can be
+selected:
+
+```python
+import pyroscope
+
+pyroscope.configure(
+    application_name="my.service",
+    cpu_profiler="gcp",
+)
+```
+
+The GCP backend is CPU-only, uses the same default sampling rate of 100 Hz
+(10 ms), and does not implement wall profiling or GIL-only sampling. Set
+`oncpu=True` (the default). The py-spy-specific `gil_only`, `line_no`,
+`report_thread_id`, and `report_thread_name` options, as well as dynamic
+thread tags, do not affect GCP samples. `report_pid` remains supported.
 
 ## License
 

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -43,6 +43,7 @@ ADD --chown=builder:builder pyproject.toml \
 ADD --chown=builder:builder rust/ rust/
 ADD --chown=builder:builder python/ python/
 ADD --chown=builder:builder cpp/ cpp/
+ADD --chown=builder:builder gcp/ gcp/
 ADD --chown=builder:builder docker/wheels.sh wheels.sh
 
 

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -43,6 +43,7 @@ ADD --chown=builder:builder pyproject.toml \
 ADD --chown=builder:builder rust/ rust/
 ADD --chown=builder:builder python/ python/
 ADD --chown=builder:builder cpp/ cpp/
+ADD --chown=builder:builder gcp/ gcp/
 ADD --chown=builder:builder docker/wheels.sh wheels.sh
 
 RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \

--- a/gcp/CMakeLists.txt
+++ b/gcp/CMakeLists.txt
@@ -38,8 +38,9 @@ set_target_properties(
 
 target_include_directories(
   gcp_cpu_profiler
-  PUBLIC
+  PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../rust/include"
 )
 
 target_link_libraries(

--- a/gcp/CMakeLists.txt
+++ b/gcp/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(gcp_cpu_profiler LANGUAGES CXX)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  message(FATAL_ERROR "gcp_cpu_profiler is supported only on Linux")
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+set(GCP_PYTHON_VERSION "${Python3_VERSION}")
+find_package(
+  Python3 "${GCP_PYTHON_VERSION}" EXACT REQUIRED
+  COMPONENTS Development.Module
+)
+find_package(Threads REQUIRED)
+
+add_library(
+  gcp_cpu_profiler STATIC
+  bridge.cc
+  clock.cc
+  log.cc
+  populate_frames.cc
+  profiler.cc
+  stacktraces.cc
+)
+
+set_target_properties(
+  gcp_cpu_profiler
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
+target_include_directories(
+  gcp_cpu_profiler
+  PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+target_link_libraries(
+  gcp_cpu_profiler
+  PUBLIC
+    Python3::Module
+    Threads::Threads
+)
+
+install(TARGETS gcp_cpu_profiler ARCHIVE DESTINATION .)

--- a/gcp/LICENSE
+++ b/gcp/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gcp/bridge.cc
+++ b/gcp/bridge.cc
@@ -1,0 +1,9 @@
+#include "bridge.h"
+
+#include "profiler.h"
+
+extern "C" PyObject *gcp_cpu_profiler_collect(int64_t duration_nanos,
+                                              int64_t period_nanos) {
+  CPUProfiler profiler(duration_nanos, period_nanos);
+  return profiler.Collect();
+}

--- a/gcp/bridge.cc
+++ b/gcp/bridge.cc
@@ -2,8 +2,8 @@
 
 #include "profiler.h"
 
-extern "C" PyObject *gcp_cpu_profiler_collect(int64_t duration_nanos,
-                                              int64_t period_nanos) {
+extern "C" int gcp_cpu_profiler_collect(int64_t duration_nanos,
+                                         int64_t period_nanos) {
   CPUProfiler profiler(duration_nanos, period_nanos);
-  return profiler.Collect();
+  return profiler.CollectSamples(&pyroscope_gcp_push_sample) ? 0 : -1;
 }

--- a/gcp/bridge.h
+++ b/gcp/bridge.h
@@ -8,10 +8,8 @@
 extern "C" {
 #endif
 
-// The caller must hold the GIL. Returns a new reference, or nullptr with a
-// Python exception set.
-PyObject *gcp_cpu_profiler_collect(int64_t duration_nanos,
-                                   int64_t period_nanos);
+// The caller must hold the GIL. Returns 0 on success and -1 on failure.
+int gcp_cpu_profiler_collect(int64_t duration_nanos, int64_t period_nanos);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/gcp/bridge.h
+++ b/gcp/bridge.h
@@ -1,0 +1,20 @@
+#ifndef PYROSCOPE_GCP_BRIDGE_H_
+#define PYROSCOPE_GCP_BRIDGE_H_
+
+#include <Python.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The caller must hold the GIL. Returns a new reference, or nullptr with a
+// Python exception set.
+PyObject *gcp_cpu_profiler_collect(int64_t duration_nanos,
+                                   int64_t period_nanos);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // PYROSCOPE_GCP_BRIDGE_H_

--- a/gcp/clock.cc
+++ b/gcp/clock.cc
@@ -1,0 +1,41 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "clock.h"
+
+namespace {
+Clock DefaultClockInstance;
+}  // namespace
+
+Clock *DefaultClock() { return &DefaultClockInstance; }
+
+struct timespec TimeAdd(const struct timespec t1, const struct timespec t2) {
+  struct timespec t = {t1.tv_sec + t2.tv_sec, t1.tv_nsec + t2.tv_nsec};
+  if (t.tv_nsec > kNanosPerSecond) {
+    t.tv_sec += t.tv_nsec / kNanosPerSecond;
+    t.tv_nsec = t.tv_nsec % kNanosPerSecond;
+  }
+  return t;
+}
+
+bool TimeLessThan(const struct timespec &t1, const struct timespec &t2) {
+  return (t1.tv_sec < t2.tv_sec) ||
+         (t1.tv_sec == t2.tv_sec && t1.tv_nsec < t2.tv_nsec);
+}
+
+struct timespec NanosToTimeSpec(int64_t nanos) {
+  time_t seconds = nanos / kNanosPerSecond;
+  int32_t nano_seconds = nanos % kNanosPerSecond;
+  return timespec{seconds, nano_seconds};
+}

--- a/gcp/clock.h
+++ b/gcp/clock.h
@@ -1,0 +1,58 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLECLOUDPROFILER_SRC_CLOCK_H_
+#define GOOGLECLOUDPROFILER_SRC_CLOCK_H_
+
+#include <stdint.h>
+#include <time.h>
+
+static const int64_t kNanosPerSecond = 1000 * 1000 * 1000;
+static const int64_t kMicrosPerSecond = 1000 * 1000;
+static const int64_t kNanosPerMilli = 1000 * 1000;
+
+// Clock interface that can be mocked for tests. The default implementation
+// delegates to the system and so is thread-safe.
+class Clock {
+ public:
+  virtual ~Clock() {}
+
+  // Returns the current time.
+  virtual struct timespec Now() {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return now;
+  }
+
+  // Blocks the current thread until the specified point in time.
+  virtual void SleepUntil(struct timespec ts) {
+    while (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr) > 0) {
+    }
+  }
+
+  // Blocks the current thread for the specified duration.
+  virtual void SleepFor(struct timespec ts) {
+    while (clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, &ts) > 0) {
+    }
+  }
+};
+
+struct timespec TimeAdd(const struct timespec t1, const struct timespec t2);
+struct timespec NanosToTimeSpec(int64_t nanos);
+bool TimeLessThan(const struct timespec &t1, const struct timespec &t2);
+
+// Returns a singleton Clock instance which uses the system implementation.
+Clock *DefaultClock();
+
+#endif  // GOOGLECLOUDPROFILER_SRC_CLOCK_H_

--- a/gcp/log.cc
+++ b/gcp/log.cc
@@ -1,0 +1,75 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "log.h"
+
+#include <Python.h>
+
+void Log(const char *level, const char *fmt, ...) {
+  // Ensures the current thread is ready to call the Python C API. GIL is
+  // garanteed to be held.
+  PyGILState_STATE gil_state = PyGILState_Ensure();
+  static PyObject *logging = nullptr;
+  if (logging == nullptr) {
+    // GIL is held as PyGILState_Ensure is called above, no need to worry about
+    // thread safety.
+    logging = PyImport_ImportModuleNoBlock("logging");
+  }
+  if (logging == nullptr) {
+    fputs(
+        "googlecloudprofiler: failed to import logging module, logging "
+        "is not enabled.\n",
+        stderr);
+    PyGILState_Release(gil_state);
+    return;
+  }
+  char msg[200];
+  va_list ap;
+  va_start(ap, fmt);
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  va_end(ap);
+  PyObject_CallMethod(logging, const_cast<char *>(level),
+                      const_cast<char *>("s"), msg);
+  // Resets the Python state to be the same as it was prior to the
+  // corresponding PyGILState_Ensure() call.
+  PyGILState_Release(gil_state);
+}
+
+void LogError(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  Log("error", fmt, ap);
+  va_end(ap);
+}
+
+void LogWarning(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  Log("warning", fmt, ap);
+  va_end(ap);
+}
+
+void LogInfo(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  Log("info", fmt, ap);
+  va_end(ap);
+}
+
+void LogDebug(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  Log("debug", fmt, ap);
+  va_end(ap);
+}

--- a/gcp/log.h
+++ b/gcp/log.h
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLECLOUDPROFILER_SRC_LOG_H_
+#define GOOGLECLOUDPROFILER_SRC_LOG_H_
+
+// Logs the error message using Python logging.error. It accepts arguments
+// like printf: format specifiers in the given fmt are replaced by the
+// corresponding additional arguments.
+void LogError(const char *fmt, ...);
+
+// Logs the warning message using Python logging.warning. It accepts arguments
+// like printf: format specifiers in the given fmt are replaced by the
+// corresponding additional arguments.
+void LogWarning(const char *fmt, ...);
+
+// Logs the info message using Python logging.info. It accepts arguments
+// like printf: format specifiers in the given fmt are replaced by the
+// corresponding additional arguments.
+void LogInfo(const char *fmt, ...);
+
+// Logs the debug message using Python logging.debug. It accepts arguments
+// like printf: format specifiers in the given fmt are replaced by the
+// corresponding additional arguments.
+void LogDebug(const char *fmt, ...);
+
+#endif  // GOOGLECLOUDPROFILER_SRC_LOG_H_

--- a/gcp/populate_frames.cc
+++ b/gcp/populate_frames.cc
@@ -1,0 +1,120 @@
+#include "populate_frames.h"
+
+#include <Python.h>
+
+#include "stacktraces.h"
+
+// 0x030B0000 is 3.11.
+#define PY_311 0x030B0000
+#if PY_VERSION_HEX >= PY_311
+
+/**
+ * The PyFrameObject structure members have been removed from the public C API
+ * in 3.11:
+https://docs.python.org/3/whatsnew/3.11.html#pyframeobject-3-11-hiding.
+ *
+ * Instead, getters are provided which participate in reference counting; since
+ * this code runs as part of the SIGPROF handler, it cannot modify Python
+ * objects (including their refcounts) and the getters can't be used. Instead,
+ * we expose the internal _PyInterpreterFrame and use that directly.
+ *
+ */
+
+#define Py_BUILD_CORE
+#include "internal/pycore_frame.h"
+#undef Py_BUILD_CORE
+
+// Modified from
+// https://github.com/python/cpython/blob/v3.11.4/Python/pystate.c#L1278-L1285
+static inline _PyInterpreterFrame *unsafe_PyThreadState_GetInterpreterFrame(
+    PyThreadState *tstate) {
+  assert(tstate != NULL);
+  _PyInterpreterFrame *f = tstate->cframe->current_frame;
+  while (f && _PyFrame_IsIncomplete(f)) {
+    f = f->previous;
+  }
+  if (f == NULL) {
+    return NULL;
+  }
+  return f;
+}
+
+// Modified from
+// https://github.com/python/cpython/blob/v3.11.4/Objects/frameobject.c#L1310-L1315
+// with refcounting removed
+static inline PyCodeObject *unsafe_PyInterpreterFrame_GetCode(
+    _PyInterpreterFrame *frame) {
+  assert(frame != NULL);
+  assert(!_PyFrame_IsIncomplete(frame));
+  PyCodeObject *code = frame->f_code;
+  assert(code != NULL);
+  return code;
+}
+
+// Modified from
+// https://github.com/python/cpython/blob/v3.11.4/Objects/frameobject.c#L1326-L1329
+// with refcounting removed
+static inline _PyInterpreterFrame *unsafe_PyInterpreterFrame_GetBack(
+    _PyInterpreterFrame *frame) {
+  assert(frame != NULL);
+  assert(!_PyFrame_IsIncomplete(frame));
+  _PyInterpreterFrame *prev = frame->previous;
+  while (prev && _PyFrame_IsIncomplete(prev)) {
+    prev = prev->previous;
+  }
+  return prev;
+}
+
+// Copied from
+// https://github.com/python/cpython/blob/v3.11.4/Python/frame.c#L165-L170 as
+// this function is not available in libpython
+int _PyInterpreterFrame_GetLine(_PyInterpreterFrame *frame) {
+  int addr = _PyInterpreterFrame_LASTI(frame) * sizeof(_Py_CODEUNIT);
+  return PyCode_Addr2Line(frame->f_code, addr);
+}
+
+int PopulateFrames(CallFrame *frames, PyThreadState *ts) {
+  if (ts == nullptr) {
+    frames[0].lineno = kNoPyState;
+    frames[0].py_code = nullptr;
+    return 1;
+  }
+
+  // We are running in the context of the thread interrupted by the signal
+  // so the frame object for the current thread is stable.
+  // Unfortunately, we can't use PyFrameObjects because they are initialized
+  // lazily and will not have the info we need directly.
+  _PyInterpreterFrame *frame = unsafe_PyThreadState_GetInterpreterFrame(ts);
+  int num_frames = 0;
+  while (frame != nullptr && num_frames < kMaxFramesToCapture) {
+    frames[num_frames].lineno = _PyInterpreterFrame_GetLine(frame);
+    frames[num_frames].py_code = unsafe_PyInterpreterFrame_GetCode(frame);
+    num_frames++;
+    frame = unsafe_PyInterpreterFrame_GetBack(frame);
+  }
+  return num_frames;
+}
+
+#else
+// python versions before 3.11
+
+int PopulateFrames(CallFrame *frames, PyThreadState *ts) {
+  if (ts == nullptr) {
+    frames[0].lineno = kNoPyState;
+    frames[0].py_code = nullptr;
+    return 1;
+  }
+  // We are running in the context of the thread interrupted by the signal
+  // so the frame object for the current thread is stable.
+  PyFrameObject *frame = ts->frame;
+  int num_frames = 0;
+  while (frame != nullptr && num_frames < kMaxFramesToCapture) {
+    frames[num_frames].lineno = frame->f_lineno;
+    frames[num_frames].py_code = frame->f_code;
+    num_frames++;
+    frame = frame->f_back;
+  }
+  return num_frames;
+}
+
+#endif  // PY_VERSION_HEX >= PY_311

--- a/gcp/populate_frames.h
+++ b/gcp/populate_frames.h
@@ -1,0 +1,14 @@
+#ifndef THIRD_PARTY_PY_GOOGLECLOUDPROFILER_SRC_POPULATE_FRAMES_H_
+#define THIRD_PARTY_PY_GOOGLECLOUDPROFILER_SRC_POPULATE_FRAMES_H_
+
+#include <Python.h>
+
+#include "stacktraces.h"
+
+/**
+ * Populates the CallFrame array with at-most kMaxFramesToCapture python frames
+ * from the provided PyThreadState. Returns the number of frames populated.
+ */
+int PopulateFrames(CallFrame* frames, PyThreadState* ts);
+
+#endif  // THIRD_PARTY_PY_GOOGLECLOUDPROFILER_SRC_POPULATE_FRAMES_H_

--- a/gcp/profiler.cc
+++ b/gcp/profiler.cc
@@ -1,0 +1,341 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "profiler.h"
+
+#include <errno.h>
+#include <pythread.h>
+#include <sys/time.h>
+#include <sys/ucontext.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+#include "clock.h"
+#include "log.h"
+#include "populate_frames.h"
+
+AsyncSafeTraceMultiset *Profiler::fixed_traces_ = nullptr;
+std::atomic<int> Profiler::unknown_stack_count_;
+GetThreadStateFunc get_thread_state_func = PyGILState_GetThisThreadState;
+bool CPUProfiler::fork_handlers_registered_;
+
+namespace {
+
+struct PyObjectDecReffer {
+  void operator()(PyObject *py_object) const {
+    // Ensures the current thread is ready to call the Python C API.
+    PyGILState_STATE gil_state = PyGILState_Ensure();
+    Py_XDECREF(py_object);
+    PyGILState_Release(gil_state);
+  }
+};
+
+typedef std::unique_ptr<PyObject, PyObjectDecReffer> PyObjectRef;
+
+// Helper class to store and reset errno when in a signal handler.
+class ErrnoRaii {
+ public:
+  ErrnoRaii() { stored_errno_ = errno; }
+  // Not copyable or assignable.
+  ErrnoRaii(const ErrnoRaii &) = delete;
+  ErrnoRaii &operator=(const ErrnoRaii &) = delete;
+
+  ~ErrnoRaii() { errno = stored_errno_; }
+
+ private:
+  int stored_errno_;
+};
+
+}  // namespace
+
+destructor CodeDeallocHook::old_code_dealloc_ = nullptr;
+std::unordered_map<PyCodeObject *, FuncLoc>
+    *CodeDeallocHook::deallocated_code_ = nullptr;
+
+void CodeDeallocHook::CodeDealloc(PyObject *py_object) {
+  FuncLoc func_loc;
+  PyCodeObject *code_object = reinterpret_cast<PyCodeObject *>(py_object);
+  GetFuncLoc(code_object, &func_loc);
+  deallocated_code_->insert(std::make_pair(code_object, func_loc));
+
+  old_code_dealloc_(py_object);
+}
+
+void CodeDeallocHook::Reset() {
+  if (deallocated_code_ == nullptr) {
+    deallocated_code_ = new std::unordered_map<PyCodeObject *, FuncLoc>;
+  } else {
+    deallocated_code_->clear();
+  }
+}
+
+bool CodeDeallocHook::Find(PyCodeObject *pointer, FuncLoc *func_loc) {
+  auto recorded_code = deallocated_code_->find(pointer);
+  if (recorded_code == deallocated_code_->end()) {
+    return false;
+  }
+  *func_loc = recorded_code->second;
+  return true;
+}
+
+// This method schedules the SIGPROF timer to go off every specified interval.
+bool SignalHandler::SetSigprofInterval(int64_t period_usec) {
+  static struct itimerval timer;
+  timer.it_interval.tv_sec = period_usec / kMicrosPerSecond;
+  timer.it_interval.tv_usec = period_usec % kMicrosPerSecond;
+  timer.it_value = timer.it_interval;
+  if (setitimer(ITIMER_PROF, &timer, NULL) == -1) {
+    LogError("Failed to set ITIMER_PROF: %s", strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+struct sigaction SignalHandler::SetAction(void (*action)(int, siginfo_t *,
+                                                         void *)) {
+  struct sigaction sa;
+  sa.sa_handler = nullptr;
+  sa.sa_sigaction = action;
+  sa.sa_flags = SA_RESTART | SA_SIGINFO;
+
+  sigemptyset(&sa.sa_mask);
+
+  struct sigaction old_handler;
+  if (sigaction(SIGPROF, &sa, &old_handler) != 0) {
+    LogError("Failed to set SIGPROF handler: %s", strerror(errno));
+    return old_handler;
+  }
+
+  return old_handler;
+}
+
+const char *CallTraceErrorToName(CallTraceErrors err) {
+  switch (err) {
+    case kNoPyState:
+      return "[Unknown - No Python thread state]";
+    default:
+      return "[Unknown]";
+  }
+}
+
+void Profiler::Handle(int signum, siginfo_t *info, void *context) {
+  // Gets around -Wunused-parameter.
+  (void)signum;
+  (void)info;
+  (void)context;
+
+  ErrnoRaii err_storage;  // stores and resets errno
+
+  CallTrace trace;
+  CallFrame frames[kMaxFramesToCapture];
+  trace.frames = frames;
+  trace.num_frames = 0;
+
+  // PyGILState_GetThisThreadState uses pthread_getspecific which is not
+  // guaranteed to be async-signal-safe per POSIX. Some issues can be
+  // found at https://sourceware.org/glibc/wiki/TLSandSignals.
+  // TODO: check if the limitations are practical here and if
+  // there are ways to avoid the problems.
+  PyThreadState *ts = get_thread_state_func();
+
+  trace.num_frames = PopulateFrames(frames, ts);
+  if (!fixed_traces_->Add(&trace)) {
+    unknown_stack_count_++;
+    return;
+  }
+}
+
+void GetFuncLoc(PyCodeObject *code_object, FuncLoc *func_loc) {
+#if PY_MAJOR_VERSION < 3
+  const char *name = PyString_AS_STRING(code_object->co_name);
+  const char *filename = PyString_AS_STRING(code_object->co_filename);
+#else
+  // Note that PyUnicode_AsUTF8 caches the char array in the unicodeobject
+  // and the memory is released when the unicodeobject is deallocated.
+  const char *name = PyUnicode_AsUTF8(code_object->co_name);
+  const char *filename = PyUnicode_AsUTF8(code_object->co_filename);
+#endif
+  func_loc->name = name != nullptr ? name : "unknown";
+  func_loc->filename = filename != nullptr ? filename : "unknown";
+}
+
+// Should be called when GIL is held if PyCode_Type.tp_dealloc is modified,
+// otherwise PyCode_Type.tp_dealloc may be updating
+// CodeDeallocHook.deallocated_code_ in another thread.
+void Profiler::Reset() {
+  if (fixed_traces_ == nullptr) {
+    fixed_traces_ = new AsyncSafeTraceMultiset();
+  } else {
+    fixed_traces_->Reset();
+  }
+  CodeDeallocHook::Reset();
+  unknown_stack_count_ = 0;
+  handler_.SetAction(&Profiler::Handle);
+}
+
+// Must be called when GIL is held.
+PyObject *Profiler::PythonTraces() {
+#if PY_MAJOR_VERSION >= 3
+  // Asserts that GIL is held in debug mode.
+  assert(PyGILState_Check());
+#endif
+  if (unknown_stack_count_ > 0) {
+    CallFrame fakeFrame = {kUnknown, nullptr};
+    aggregated_traces_.Add(1, &fakeFrame, unknown_stack_count_);
+  }
+
+  PyObjectRef py_traces(PyDict_New());
+  if (py_traces == nullptr) {
+    return nullptr;
+  }
+  for (const auto &trace : aggregated_traces_) {
+    PyObjectRef py_frames(PyTuple_New(trace.first.size()));
+    if (py_frames == nullptr) {
+      return nullptr;
+    }
+
+    for (size_t i = 0; i < trace.first.size(); i++) {
+      const auto &frame = trace.first[i];
+      FuncLoc func_loc;
+      PyCodeObject *pointer = frame.py_code;
+      if (pointer == nullptr) {
+        func_loc = {
+            CallTraceErrorToName(static_cast<CallTraceErrors>(frame.lineno)),
+            ""};
+      } else {
+        // All PyCodeObjects deallocated during profiling should be recorded
+        // by CodeDeallocHook. As we are holding GIL, no deallocation can happen
+        // elsewhere now. It's safe to assume that a PyCodeObject pointer not
+        // recorded by CodeDeallocHook points to a live object.
+        // TODO: If multiple code objects are allocated at the same
+        // address, the func_loc stored by CodeDeallocHook may not belong to the
+        // sampled frame. At least we should mark the func_loc as invalid if we
+        // see an address is reused, probably by hooking PyCode_Type.tp_alloc.
+        if (!CodeDeallocHook::Find(pointer, &func_loc)) {
+          GetFuncLoc(pointer, &func_loc);
+        }
+      }
+      PyObject *py_frame =
+          Py_BuildValue("(ssi)", func_loc.name.c_str(),
+                        func_loc.filename.c_str(), frame.lineno);
+      if (py_frame == nullptr) {
+        return nullptr;
+      }
+      // PyTuple_SET_ITEM is like PyTuple_SetItem(), but does no error checking.
+      // Error checking is unnecessary here as we are filling precreated brand
+      // new tuple. Note that PyTuple_SET_ITEM does NOT increase the reference
+      // count for the inserted item. We are no longer responsible for
+      // decreasing the reference count of py_frame. It'll be decreased when
+      // py_frames is deallocated.
+      PyTuple_SET_ITEM(py_frames.get(), i, py_frame);
+    }
+    uint64_t count = trace.second;
+    PyObject *py_count = PyDict_GetItem(py_traces.get(), py_frames.get());
+    if (py_count != nullptr) {
+      uint64_t previous_count = PyLong_AsUnsignedLong(py_count);
+      if (PyErr_Occurred()) {
+        return nullptr;
+      }
+      count += previous_count;
+    }
+    PyObjectRef trace_count(PyLong_FromUnsignedLongLong(count));
+    // PyDict_SetItem increases the reference count for both key and item. We
+    // are responsible for decreasing the reference count for py_frames and
+    // trace_count.
+    if (PyDict_SetItem(py_traces.get(), py_frames.get(), trace_count.get()) <
+        0) {
+      return nullptr;
+    }
+  }
+
+  return py_traces.release();
+}
+
+bool AlmostThere(const struct timespec &finish, const struct timespec &lap) {
+  // Determine if there is time for another lap before reaching the
+  // finish line. Have a margin of multiple laps to ensure we do not
+  // overrun the finish line.
+  int64_t margin_laps = 2;
+
+  struct timespec now = DefaultClock()->Now();
+  struct timespec laps = {lap.tv_sec * margin_laps, lap.tv_nsec * margin_laps};
+
+  return TimeLessThan(finish, TimeAdd(now, laps));
+}
+
+PyObject *CPUProfiler::Collect() {
+  Reset();
+  // Hooks to PyCode_Type.tp_dealloc so that a PyCodeObject is recorded before
+  // being deallocated. The hook is cancelled when dealloc_hook goes out of
+  // scope.
+  CodeDeallocHook dealloc_hook;
+
+  if (!Start()) {
+    return nullptr;
+  }
+  // Releases GIL so that the user threads can execute.
+  Py_BEGIN_ALLOW_THREADS;
+
+  Clock *clock = DefaultClock();
+  // Flush the async table every 100 ms
+  struct timespec flush_interval = {0, 100 * 1000 * 1000};  // 100 millisec
+  struct timespec finish_line =
+      TimeAdd(clock->Now(), NanosToTimeSpec(duration_nanos_));
+
+  // Sleep until finish_line, but wakeup periodically to flush the
+  // internal tables.
+  while (!AlmostThere(finish_line, flush_interval)) {
+    clock->SleepFor(flush_interval);
+    Flush();
+  }
+  clock->SleepUntil(finish_line);
+  Stop();
+  // Delay to allow last signals to be processed.
+  clock->SleepUntil(TimeAdd(finish_line, flush_interval));
+  Flush();
+  // Reacquire the GIL.
+  Py_END_ALLOW_THREADS;
+
+  PyObject *traces = PythonTraces();
+  return traces;
+}
+
+bool CPUProfiler::Start() {
+  int period_usec = period_nanos_ / 1000;
+  return handler_.SetSigprofInterval(period_usec);
+}
+
+void CPUProfiler::Stop() {
+  handler_.SetSigprofInterval(0);
+  // Breaks encapsulation, but whatever.
+  signal(SIGPROF, SIG_IGN);
+}
+
+// Blocks the SIGPROF signal for the calling thread.
+void BlockSigprof() {
+  sigset_t signals;
+  sigemptyset(&signals);
+  sigaddset(&signals, SIGPROF);
+  pthread_sigmask(SIG_BLOCK, &signals, nullptr);
+}
+
+// Unblocks the SIGPROF signal for the calling thread.
+void UnblockSigprof() {
+  sigset_t signals;
+  sigemptyset(&signals);
+  sigaddset(&signals, SIGPROF);
+  pthread_sigmask(SIG_UNBLOCK, &signals, nullptr);
+}

--- a/gcp/profiler.cc
+++ b/gcp/profiler.cc
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modified by Grafana Labs; see ../gcp_patches.md.
 
 #include "profiler.h"
 
@@ -89,6 +91,14 @@ bool CodeDeallocHook::Find(PyCodeObject *pointer, FuncLoc *func_loc) {
   }
   *func_loc = recorded_code->second;
   return true;
+}
+
+const FuncLoc *CodeDeallocHook::FindView(PyCodeObject *pointer) {
+  auto recorded_code = deallocated_code_->find(pointer);
+  if (recorded_code == deallocated_code_->end()) {
+    return nullptr;
+  }
+  return &recorded_code->second;
 }
 
 // This method schedules the SIGPROF timer to go off every specified interval.
@@ -264,6 +274,59 @@ PyObject *Profiler::PythonTraces() {
   return py_traces.release();
 }
 
+// Must be called when GIL is held.
+void Profiler::PushTraces(TraceCallback callback) {
+#if PY_MAJOR_VERSION >= 3
+  // Asserts that GIL is held in debug mode.
+  assert(PyGILState_Check());
+#endif
+  if (unknown_stack_count_ > 0) {
+    CallFrame fake_frame = {kUnknown, nullptr};
+    aggregated_traces_.Add(1, &fake_frame, unknown_stack_count_);
+  }
+
+  for (const auto &trace : aggregated_traces_) {
+    FFIGcpFrame frames[kMaxFramesToCapture];
+    size_t frame_count = 0;
+    for (const auto &frame : trace.first) {
+      const char *name;
+      size_t name_len;
+      const char *filename;
+      size_t filename_len;
+      PyCodeObject *pointer = frame.py_code;
+      if (pointer == nullptr) {
+        name = CallTraceErrorToName(
+            static_cast<CallTraceErrors>(frame.lineno));
+        name_len = strlen(name);
+        filename = "";
+        filename_len = 0;
+      } else if (const FuncLoc *func_loc =
+                     CodeDeallocHook::FindView(pointer)) {
+        name = func_loc->name.data();
+        name_len = func_loc->name.size();
+        filename = func_loc->filename.data();
+        filename_len = func_loc->filename.size();
+      } else {
+        name = PyUnicode_AsUTF8(pointer->co_name);
+        filename = PyUnicode_AsUTF8(pointer->co_filename);
+        if (name == nullptr) {
+          name = "unknown";
+        }
+        if (filename == nullptr) {
+          filename = "unknown";
+        }
+        name_len = strlen(name);
+        filename_len = strlen(filename);
+      }
+
+      frames[frame_count++] = {{name, name_len}, {filename, filename_len},
+                               frame.lineno};
+    }
+
+    callback({frames, frame_count, trace.second});
+  }
+}
+
 bool AlmostThere(const struct timespec &finish, const struct timespec &lap) {
   // Determine if there is time for another lap before reaching the
   // finish line. Have a margin of multiple laps to ensure we do not
@@ -283,8 +346,28 @@ PyObject *CPUProfiler::Collect() {
   // scope.
   CodeDeallocHook dealloc_hook;
 
-  if (!Start()) {
+  if (!CollectRaw()) {
     return nullptr;
+  }
+
+  return PythonTraces();
+}
+
+bool CPUProfiler::CollectSamples(TraceCallback callback) {
+  Reset();
+  CodeDeallocHook dealloc_hook;
+
+  if (!CollectRaw()) {
+    return false;
+  }
+
+  PushTraces(callback);
+  return true;
+}
+
+bool CPUProfiler::CollectRaw() {
+  if (!Start()) {
+    return false;
   }
   // Releases GIL so that the user threads can execute.
   Py_BEGIN_ALLOW_THREADS;
@@ -309,8 +392,7 @@ PyObject *CPUProfiler::Collect() {
   // Reacquire the GIL.
   Py_END_ALLOW_THREADS;
 
-  PyObject *traces = PythonTraces();
-  return traces;
+  return true;
 }
 
 bool CPUProfiler::Start() {

--- a/gcp/profiler.h
+++ b/gcp/profiler.h
@@ -1,0 +1,188 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLECLOUDPROFILER_SRC_PROFILER_H_
+#define GOOGLECLOUDPROFILER_SRC_PROFILER_H_
+
+#include <Python.h>
+#include <signal.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "stacktraces.h"
+
+struct FuncLoc {
+  std::string name;
+  std::string filename;
+};
+
+void GetFuncLoc(PyCodeObject *code_object, FuncLoc *func_loc);
+
+// Blocks the SIGPROF signal for the calling thread.
+void BlockSigprof();
+
+// Unblocks the SIGPROF signal for the calling thread.
+void UnblockSigprof();
+
+class SignalHandler {
+ public:
+  SignalHandler() {}
+
+  // Not copyable or assignable.
+  SignalHandler(const SignalHandler &) = delete;
+  SignalHandler &operator=(const SignalHandler &) = delete;
+
+  struct sigaction SetAction(void (*sigaction)(int, siginfo_t *, void *));
+
+  bool SetSigprofInterval(int64_t period_usec);
+};
+
+class CodeDeallocHook {
+ public:
+  // The constructor must be called when GIL is held.
+  CodeDeallocHook() {
+    Reset();
+    old_code_dealloc_ = PyCode_Type.tp_dealloc;
+    PyCode_Type.tp_dealloc = &CodeDealloc;
+  }
+  // Not copyable or assignable.
+  CodeDeallocHook(const CodeDeallocHook &) = delete;
+  CodeDeallocHook &operator=(const CodeDeallocHook &) = delete;
+
+  // The destructor must be called when GIL is held.
+  ~CodeDeallocHook() { PyCode_Type.tp_dealloc = old_code_dealloc_; }
+
+  // A wrapper function on PyCode_Type.tp_dealloc that records the code object
+  // to deallocated_code_ before the actual deallocation.
+  static void CodeDealloc(PyObject *py_object);
+
+  // The first call to Reset() allocates deallocated_code_. Subsequent calls
+  // clear deallocated_code_. When PyCode_Type.tp_dealloc points to CodeDealloc,
+  // this function must be called when GIL is held, otherwise another thread
+  // may be updating allocated_code_ during PyCodeObject deallocation.
+  static void Reset();
+
+  // If the given pointer exists in deallocated_code_ as key, assign the value
+  // to func_loc and return true, otherwise return false. When
+  // PyCode_Type.tp_dealloc points to CodeDealloc, this function must be called
+  // when GIL is held, otherwise another thread may be updating
+  // allocated_code_ during PyCodeObject deallocation.
+  static bool Find(PyCodeObject *pointer, FuncLoc *func_loc);
+
+ private:
+  // When PyCode_Type.tp_dealloc points to CodeDealloc, a code object is
+  // recorded in this map before being deallocated. The map maps a code object
+  // pointer to function information of interest.
+  static std::unordered_map<PyCodeObject *, FuncLoc> *deallocated_code_;
+
+  static destructor old_code_dealloc_;
+};
+
+typedef PyThreadState *(*GetThreadStateFunc)();
+
+// get_thread_state_func defaults to PyGILState_GetThisThreadState. It's
+// declared here so that PyGILState_GetThisThreadState can be stubbed in tests.
+extern GetThreadStateFunc get_thread_state_func;
+
+class Profiler {
+ public:
+  Profiler(int64_t duration_nanos, int64_t period_nanos)
+      : duration_nanos_(duration_nanos), period_nanos_(period_nanos) {
+    Reset();
+  }
+  // Not copyable or assignable.
+  Profiler(const Profiler &) = delete;
+  Profiler &operator=(const Profiler &) = delete;
+
+  virtual ~Profiler() {}
+
+  // Collects performance data.
+  // Implicitly does a Reset() before starting collection.
+  virtual PyObject *Collect() = 0;
+
+  // Returns the traces as a Python dictionary object, which maps a trace to its
+  // count.
+  PyObject *PythonTraces();
+
+  // Signal handler, which records the current stack trace.
+  static void Handle(int signum, siginfo_t *info, void *context);
+
+  // Resets internal state to support data collection.
+  void Reset();
+
+  // Migrates data from fixed internal table into growable data structure.
+  // Returns number of entries extracted.
+  int Flush() { return HarvestSamples(fixed_traces_, &aggregated_traces_); }
+
+ protected:
+  SignalHandler handler_;
+  int64_t duration_nanos_;
+  int64_t period_nanos_;
+
+ private:
+  // Points to a fixed multiset of traces used during collection. This
+  // is allocated on the first call to Reset(). Will be reused by
+  // subsequent allocations. Cannot be deallocated as it could be in
+  // use by other threads, triggered from a signal handler.
+  static AsyncSafeTraceMultiset *fixed_traces_;
+
+  // Aggregated profile data, populated using data extracted from
+  // fixed_traces.
+  TraceMultiset aggregated_traces_;
+
+  static std::atomic<int> unknown_stack_count_;
+};
+
+// CPUProfiler collects cpu profiles by setting up a CPU timer and
+// collecting a sample each time it is triggered (via SIGPROF).
+class CPUProfiler : public Profiler {
+ public:
+  CPUProfiler(int64_t duration_nanos, int64_t period_nanos)
+      : Profiler(duration_nanos, period_nanos) {
+    // When a fork runs longer than the signal interval, it gets interrupted by
+    // the signal and then retry. This will never end until the profiler
+    // thread stops sending the signal. In unlucky cases, the profiler
+    // thread gets blocked on acquiring the memory lock, which is held by
+    // fork. The process may thus hang unpredictably long.
+    // The fix is to block the signal for the calling thread before fork and
+    // reenable it after fork. The caveat is that forks will not be sampled.
+    if (!fork_handlers_registered_) {
+      pthread_atfork(&BlockSigprof, &UnblockSigprof, &UnblockSigprof);
+      // Updating fork_handlers_registered_ here is not thread safe. It's
+      // fine because the profiler is only allowed to start once, which means
+      // that CPUProfiler is only created by a single thread.
+      fork_handlers_registered_ = true;
+    }
+  }
+  // Not copyable or assignable.
+  CPUProfiler(const CPUProfiler &) = delete;
+  CPUProfiler &operator=(const CPUProfiler &) = delete;
+
+  // Collects profiling data.
+  PyObject *Collect() override;
+
+ private:
+  // Initiates data collection at a fixed interval.
+  bool Start();
+
+  // Stops data collection.
+  void Stop();
+
+  static bool fork_handlers_registered_;
+};
+
+#endif  // GOOGLECLOUDPROFILER_SRC_PROFILER_H_

--- a/gcp/profiler.h
+++ b/gcp/profiler.h
@@ -11,12 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Modified by Grafana Labs; see ../gcp_patches.md.
 
 #ifndef GOOGLECLOUDPROFILER_SRC_PROFILER_H_
 #define GOOGLECLOUDPROFILER_SRC_PROFILER_H_
 
 #include <Python.h>
 #include <signal.h>
+
+#ifdef Py_GIL_DISABLED
+#error "gcp_cpu_profiler requires a GIL-enabled CPython build"
+#endif
 
 #include <atomic>
 #include <memory>

--- a/gcp/profiler.h
+++ b/gcp/profiler.h
@@ -19,6 +19,9 @@
 
 #include <Python.h>
 #include <signal.h>
+extern "C" {
+#include "pyroscope_ffi.h"
+}
 
 #ifdef Py_GIL_DISABLED
 #error "gcp_cpu_profiler requires a GIL-enabled CPython build"
@@ -35,6 +38,8 @@ struct FuncLoc {
   std::string name;
   std::string filename;
 };
+
+typedef void (*TraceCallback)(FFIGcpSample sample);
 
 void GetFuncLoc(PyCodeObject *code_object, FuncLoc *func_loc);
 
@@ -89,6 +94,9 @@ class CodeDeallocHook {
   // allocated_code_ during PyCodeObject deallocation.
   static bool Find(PyCodeObject *pointer, FuncLoc *func_loc);
 
+  // Returns a stable view of recorded function data. Must be called with GIL.
+  static const FuncLoc *FindView(PyCodeObject *pointer);
+
  private:
   // When PyCode_Type.tp_dealloc points to CodeDealloc, a code object is
   // recorded in this map before being deallocated. The map maps a code object
@@ -123,6 +131,9 @@ class Profiler {
   // Returns the traces as a Python dictionary object, which maps a trace to its
   // count.
   PyObject *PythonTraces();
+
+  // Resolves and emits traces directly without creating Python containers.
+  void PushTraces(TraceCallback callback);
 
   // Signal handler, which records the current stack trace.
   static void Handle(int signum, siginfo_t *info, void *context);
@@ -181,7 +192,12 @@ class CPUProfiler : public Profiler {
   // Collects profiling data.
   PyObject *Collect() override;
 
+  // Collects profiling data and emits traces without creating a Python dict.
+  bool CollectSamples(TraceCallback callback);
+
  private:
+  bool CollectRaw();
+
   // Initiates data collection at a fixed interval.
   bool Start();
 

--- a/gcp/stacktraces.cc
+++ b/gcp/stacktraces.cc
@@ -1,0 +1,155 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stacktraces.h"
+
+bool AsyncSafeTraceMultiset::Add(const CallTrace *trace) {
+  uint64_t hash_val = CalculateHash(trace->num_frames, trace->frames);
+  for (int64_t i = 0; i < MaxEntries(); i++) {
+    int64_t idx = (i + hash_val) % MaxEntries();
+    auto &entry = traces_[idx];
+    int64_t count_zero = 0;
+    entry.active_updates.fetch_add(1, std::memory_order_acquire);
+    int64_t count = entry.count.load(std::memory_order_acquire);
+    switch (count) {
+      case 0:
+        if (entry.count.compare_exchange_weak(count_zero, kTraceCountLocked,
+                                              std::memory_order_relaxed)) {
+          // This entry is reserved, there is no danger of interacting
+          // with Extract, so decrement active_updates early.
+          entry.active_updates.fetch_sub(1, std::memory_order_release);
+
+          // memcpy is not async safe
+          CallFrame *fb = entry.frame_buffer;
+          for (int frame_num = 0; frame_num < trace->num_frames; ++frame_num) {
+            fb[frame_num].lineno = trace->frames[frame_num].lineno;
+            fb[frame_num].py_code = trace->frames[frame_num].py_code;
+          }
+          entry.trace.frames = fb;
+          entry.trace.num_frames = trace->num_frames;
+          entry.count.store(int64_t(1), std::memory_order_release);
+          return true;
+        }
+        break;
+      case kTraceCountLocked:
+        // This entry is being updated by another thread. Move on.
+        // Worst case we may end with multiple entries with the same trace.
+        break;
+      default:
+        if (trace->num_frames == entry.trace.num_frames &&
+            Equal(trace->num_frames, trace->frames, entry.trace.frames)) {
+          // Bump using a compare-swap instead of fetch_add to ensure
+          // it hasn't been locked by a thread doing Extract().
+          // Reload count in case it was updated while we were
+          // examining the trace.
+          count = entry.count.load(std::memory_order_relaxed);
+          if (count != kTraceCountLocked &&
+              entry.count.compare_exchange_weak(count, count + 1,
+                                                std::memory_order_relaxed)) {
+            entry.active_updates.fetch_sub(1, std::memory_order_release);
+            return true;
+          }
+        }
+    }
+    // Did nothing, but we still need storage ordering between this
+    // store and preceding loads.
+    entry.active_updates.fetch_sub(1, std::memory_order_release);
+  }
+  return false;
+}
+
+int AsyncSafeTraceMultiset::Extract(int location, int max_frames,
+                                    CallFrame *frames, int64_t *count) {
+  if (location < 0 || location >= MaxEntries()) {
+    return 0;
+  }
+  auto &entry = traces_[location];
+  int64_t c = entry.count.load(std::memory_order_acquire);
+  if (c <= 0) {
+    // Unused or in process of being updated, skip for now.
+    return 0;
+  }
+  int num_frames = entry.trace.num_frames;
+  if (num_frames > max_frames) {
+    num_frames = max_frames;
+  }
+
+  c = entry.count.exchange(kTraceCountLocked, std::memory_order_acquire);
+
+  for (int i = 0; i < num_frames; ++i) {
+    frames[i].lineno = entry.trace.frames[i].lineno;
+    frames[i].py_code = entry.trace.frames[i].py_code;
+  }
+
+  while (entry.active_updates.load(std::memory_order_acquire) != 0) {
+    // spin
+    // TODO: Introduce a limit to detect and break
+    // deadlock
+  }
+
+  entry.count.store(0, std::memory_order_release);
+  *count = c;
+  return num_frames;
+}
+
+void TraceMultiset::Add(int num_frames, CallFrame *frames, int64_t count) {
+  std::vector<CallFrame> trace(frames, frames + num_frames);
+
+  auto entry = traces_.find(trace);
+  if (entry != traces_.end()) {
+    entry->second += count;
+    return;
+  }
+  traces_.emplace(std::move(trace), count);
+}
+
+int HarvestSamples(AsyncSafeTraceMultiset *from, TraceMultiset *to) {
+  int trace_count = 0;
+  int64_t num_traces = from->MaxEntries();
+  for (int64_t i = 0; i < num_traces; i++) {
+    CallFrame frame[kMaxFramesToCapture];
+    int64_t count;
+
+    int num_frames = from->Extract(i, kMaxFramesToCapture, &frame[0], &count);
+    if (num_frames > 0 && count > 0) {
+      ++trace_count;
+      to->Add(num_frames, &frame[0], count);
+    }
+  }
+  return trace_count;
+}
+
+uint64_t CalculateHash(int num_frames, const CallFrame *frame) {
+  uint64_t h = 0;
+  for (int i = 0; i < num_frames; i++) {
+    h += static_cast<uintptr_t>(frame[i].lineno);
+    h += h << 10;
+    h ^= h >> 6;
+    h += reinterpret_cast<uintptr_t>(frame[i].py_code);
+    h += h << 10;
+    h ^= h >> 6;
+  }
+  h += h << 3;
+  h ^= h >> 11;
+  return h;
+}
+
+bool Equal(int num_frames, const CallFrame *f1, const CallFrame *f2) {
+  for (int i = 0; i < num_frames; i++) {
+    if (f1[i].lineno != f2[i].lineno || f1[i].py_code != f2[i].py_code) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/gcp/stacktraces.h
+++ b/gcp/stacktraces.h
@@ -1,0 +1,174 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLECLOUDPROFILER_SRC_STACKTRACES_H_
+#define GOOGLECLOUDPROFILER_SRC_STACKTRACES_H_
+
+#include <Python.h>
+#include <frameobject.h>
+
+#include <atomic>
+#include <mutex>  // NOLINT
+#include <unordered_map>
+#include <vector>
+
+typedef struct {
+  int lineno;
+  PyCodeObject *py_code;
+} CallFrame;
+
+typedef struct {
+  int num_frames;
+  CallFrame *frames;
+} CallTrace;
+
+enum CallTraceErrors {
+  kUnknown = 0,
+  kNoPyState = -1,
+};
+
+// Maximum number of frames to store from the stack traces sampled.
+const int kMaxFramesToCapture = 128;
+
+uint64_t CalculateHash(int num_frames, const CallFrame *frame);
+bool Equal(int num_frames, const CallFrame *f1, const CallFrame *f2);
+
+// Multiset of stack traces. There is a maximum number of distinct
+// traces that can be held, return by MaxEntries();
+//
+// The Add() operation is async-safe, but will fail and return false
+// if there is no room to store the trace.
+//
+// The Extract() operation will remove a specific entry, and it can
+// run concurrently with multiple Add() operations. Multiple
+// invocations of Extract() cannot be executed concurrently.
+//
+// The synchronization is implemented by using a sentinel count value
+// to reserve entries. Add() will reserve the first available entry,
+// save the stack frame, and then release the entry for other calls to
+// Add() or Extract(). Extract() will reserve the entry, wait until no
+// additions are in progress, and then release the entry to be reused
+// by a subsequent call to Add(). It is important for Extract() to
+// wait until no additions are in progress to avoid releasing the
+// entry while another thread is inspecting it.
+class AsyncSafeTraceMultiset {
+ public:
+  AsyncSafeTraceMultiset() { Reset(); }
+  // Not copyable or assignable.
+  AsyncSafeTraceMultiset(const AsyncSafeTraceMultiset &) = delete;
+  AsyncSafeTraceMultiset &operator=(const AsyncSafeTraceMultiset &) = delete;
+
+  void Reset() { memset(traces_, 0, sizeof(traces_)); }
+
+  // Adds a trace to the set. If it is already present, increments its
+  // count. This operation is thread safe and async safe.
+  bool Add(const CallTrace *trace);
+
+  // Extracts a trace from the array. frames must point to at least
+  // max_frames contiguous frames. It will return the number of frames
+  // written starting at frames[0], up to max_frames. Returns 0 if
+  // there is no valid trace at this location.  This operation is
+  // thread safe with respect to Add() but only a single call to
+  // Extract can be done at a time.
+  int Extract(int location, int max_frames, CallFrame *frames, int64_t *count);
+
+  int64_t MaxEntries() const { return kMaxStackTraces; }
+
+ private:
+  struct TraceData {
+    // trace contains the frame count and a pointer to the frames. The
+    // frames are stored in frame_buffer.
+    CallTrace trace;
+    // frame_buffer is the storage for stack frames.
+    CallFrame frame_buffer[kMaxFramesToCapture];
+    // Number of times a trace has been encountered.
+    // 0 indicates that the trace is unused,
+    // <0 values are reserved, used for concurrency control.
+    std::atomic<int64_t> count;
+    // Number of active attempts to increase the counter on the trace.
+    std::atomic<int> active_updates;
+  };
+
+  // TODO: Re-evaluate MaxStackTraces, to minimize storage
+  // consumption while maintaining good performance and avoiding
+  // overflow.
+  static const int kMaxStackTraces = 2048;
+
+  // Sentinel to use as trace count while the frames are being updated.
+  static const int64_t kTraceCountLocked = -1;
+
+  TraceData traces_[kMaxStackTraces];
+};
+
+// TraceMultiset implements a growable multi-set of traces. It is not
+// thread or async safe. Is it intended to be used to aggregate traces
+// collected atomically from AsyncSafeTraceMultiset, which implements
+// async and thread safe add/extract methods, but has fixed maximum
+// size.
+class TraceMultiset {
+ private:
+  struct TraceHash {
+    std::size_t operator()(const std::vector<CallFrame> &t) const {
+      return CalculateHash(t.size(), t.data());
+    }
+  };
+
+  struct TraceEqual {
+    bool operator()(const std::vector<CallFrame> &t1,
+                    const std::vector<CallFrame> &t2) const {
+      if (t1.size() != t2.size()) {
+        return false;
+      }
+      return Equal(t1.size(), t1.data(), t2.data());
+    }
+  };
+
+  typedef std::unordered_map<std::vector<CallFrame>, uint64_t, TraceHash,
+                             TraceEqual>
+      CountMap;
+
+ public:
+  TraceMultiset() {}
+  // Not copyable or assignable.
+  TraceMultiset(const TraceMultiset &) = delete;
+  TraceMultiset &operator=(const TraceMultiset &) = delete;
+
+  // Add a trace to the array. If it is already in the array,
+  // increment its count.
+  void Add(int num_frames, CallFrame *frames, int64_t count);
+
+  typedef CountMap::iterator iterator;
+  typedef CountMap::const_iterator const_iterator;
+
+  iterator begin() { return traces_.begin(); }
+  iterator end() { return traces_.end(); }
+
+  const_iterator begin() const { return const_iterator(traces_.begin()); }
+  const_iterator end() const { return const_iterator(traces_.end()); }
+
+  iterator erase(iterator it) { return traces_.erase(it); }
+
+  void Clear() { traces_.clear(); }
+
+ private:
+  CountMap traces_;
+};
+
+// HarvestSamples extracts traces from an asyncsafe trace multiset
+// and copies them into a trace multiset. It returns the number of samples
+// that were copied. This is thread-safe with respect to other threads adding
+// samples into the asyncsafe set.
+int HarvestSamples(AsyncSafeTraceMultiset *from, TraceMultiset *to);
+
+#endif  // GOOGLECLOUDPROFILER_SRC_STACKTRACES_H_

--- a/gcp_patches.md
+++ b/gcp_patches.md
@@ -1,0 +1,57 @@
+# Vendored Google Cloud Profiler native sources
+
+## Baseline and provenance
+
+The copied sources under `gcp/` come from
+`GoogleCloudPlatform/cloud-profiler-python` release `v4.1.0`, commit
+`23e3c4845b6fc6aa07b362ffe8f1be74630cc0d2`.
+
+## File inventory
+
+Copied from `googlecloudprofiler/src/`:
+
+- `gcp/profiler.h`
+- `gcp/profiler.cc`
+- `gcp/stacktraces.h`
+- `gcp/stacktraces.cc`
+- `gcp/populate_frames.h`
+- `gcp/populate_frames.cc`
+- `gcp/clock.h`
+- `gcp/clock.cc`
+- `gcp/log.h`
+- `gcp/log.cc`
+
+Copied unchanged from the repository root:
+
+- `gcp/LICENSE`
+
+Intentionally omitted:
+
+- `googlecloudprofiler/src/_profiler.cc`, the upstream Python extension wrapper
+- all non-native Python client and packaging files
+- wall-profiler code; none is copied or introduced
+
+## Patch 1: reject free-threaded CPython
+
+File: `gcp/profiler.h`
+
+The vendored collector relies on the GIL for code-object lifetime tracking and
+profile materialization. A compile-time `Py_GIL_DISABLED` guard prevents an
+unsupported free-threaded build. The file carries a Grafana modification
+notice pointing to this document.
+
+No Python-version compatibility code has been added. The collector retains
+upstream's CPython support and implementation unchanged.
+
+## Behavior retained
+
+Collection remains synchronous: `CPUProfiler::Collect()` releases the GIL,
+samples with `ITIMER_PROF`/`SIGPROF`, then reacquires the GIL and returns the
+Python dictionary. Frame capture and output remain leaf-first. No wall
+profiler or GIL-only mode is included.
+
+## Apache 2.0 notice
+
+The vendored Google files are Copyright 2018 Google LLC and are licensed under
+the Apache License, Version 2.0. The full upstream license is preserved at
+`gcp/LICENSE`. Upstream source license headers are retained.

--- a/gcp_patches.md
+++ b/gcp_patches.md
@@ -31,6 +31,13 @@ Intentionally omitted:
 - all non-native Python client and packaging files
 - wall-profiler code; none is copied or introduced
 
+New integration files, not copied from upstream:
+
+- `gcp/CMakeLists.txt`
+- `gcp/bridge.h`
+- `gcp/bridge.cc`
+- this `gcp_patches.md`
+
 ## Patch 1: reject free-threaded CPython
 
 File: `gcp/profiler.h`

--- a/gcp_patches.md
+++ b/gcp_patches.md
@@ -50,6 +50,24 @@ notice pointing to this document.
 No Python-version compatibility code has been added. The collector retains
 upstream's CPython support and implementation unchanged.
 
+## Patch 2: emit resolved traces without Python containers
+
+Files: `gcp/profiler.h`, `gcp/profiler.cc`
+
+Adds `CPUProfiler::CollectSamples()` and a trace callback that resolve the
+already-aggregated native samples while the GIL is held. Pyroscope's bridge
+uses this path to pass each trace directly to the Rust pprof builder without
+constructing Python frame tuples or a `PyDict`.
+
+The callback uses the collector's fixed 128-frame maximum as stack storage.
+Live code-object strings and saved deallocation-hook strings are passed as
+borrowed views, avoiding per-trace frame buffers and per-frame string copies.
+
+The upstream `Collect()` and `PythonTraces()` APIs remain available and retain
+their original behavior. The timer, signal handler, frame collection, flush
+interval, stack order, and code-object lifetime hook are shared unchanged by
+both output paths.
+
 ## Behavior retained
 
 Collection remains synchronous: `CPUProfiler::Collect()` releases the GIL,

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -27,8 +27,10 @@ const (
 )
 
 type profileConfig struct {
-	onCPU   bool
-	gilOnly bool
+	onCPU       bool
+	gilOnly     bool
+	cpuProfiler string
+	memEnabled  bool
 }
 
 func TestPythonProfilerOnCPUWithGILOnly(t *testing.T) {
@@ -45,6 +47,18 @@ func TestPythonProfilerOffCPUWithGILOnly(t *testing.T) {
 
 func TestPythonProfilerOffCPUWithoutGILOnly(t *testing.T) {
 	testPythonProfilerConfiguration(t, profileConfig{onCPU: false, gilOnly: false})
+}
+
+func TestPythonGCPProfiler(t *testing.T) {
+	pythonVersion := envOrDefault("PYTHON_VERSION", "3.11")
+	if pythonVersion != "3.10" && pythonVersion != "3.11" {
+		t.Skipf("GCP CPU profiler is not supported on Python %s", pythonVersion)
+	}
+	testPythonProfilerConfiguration(t, profileConfig{
+		onCPU:       true,
+		cpuProfiler: "gcp",
+		memEnabled:  true,
+	})
 }
 
 func TestPythonNonCPUIntegrationSuites(t *testing.T) {
@@ -195,6 +209,10 @@ func startPyroscope(t *testing.T, net *dockertest.Network) string {
 
 func startWorkload(t *testing.T, net *dockertest.Network, appName, canary string, cfg profileConfig, wheelDir string) *dockertest.Container {
 	t.Helper()
+	cpuProfiler := cfg.cpuProfiler
+	if cpuProfiler == "" {
+		cpuProfiler = "pyspy"
+	}
 	return dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:    pythonImage(),
 		Platform: wheelDockerPlatform(),
@@ -206,6 +224,8 @@ func startWorkload(t *testing.T, net *dockertest.Network, appName, canary string
 			"PYROSCOPE_SERVER_ADDRESS":      "http://pyroscope:4040",
 			"ONCPU":                         boolString(cfg.onCPU),
 			"GIL_ONLY":                      boolString(cfg.gilOnly),
+			"CPU_PROFILER":                  cpuProfiler,
+			"MEM_ENABLED":                   boolString(cfg.memEnabled),
 			"CANARY":                        canary,
 			"PIP_DISABLE_PIP_VERSION_CHECK": "1",
 		},

--- a/integration-test/testdata/workload.py
+++ b/integration-test/testdata/workload.py
@@ -57,16 +57,19 @@ def main():
 
     oncpu = env_bool("ONCPU")
     gil_only = env_bool("GIL_ONLY")
+    cpu_profiler = os.environ["CPU_PROFILER"]
+    mem_enabled = env_bool("MEM_ENABLED")
     canary = os.environ["CANARY"]
     application_name = os.environ["PYROSCOPE_APPLICATION_NAME"]
     server_address = os.environ["PYROSCOPE_SERVER_ADDRESS"]
 
     logger.info(
-        "starting workload application_name=%s server_address=%s oncpu=%s gil_only=%s canary=%s",
+        "starting workload application_name=%s server_address=%s oncpu=%s gil_only=%s cpu_profiler=%s canary=%s",
         application_name,
         server_address,
         oncpu,
         gil_only,
+        cpu_profiler,
         canary,
     )
     pyroscope.configure(
@@ -75,6 +78,8 @@ def main():
         enable_logging=True,
         oncpu=oncpu,
         gil_only=gil_only,
+        cpu_profiler=cpu_profiler,
+        mem_enabled=mem_enabled,
         report_pid=True,
         report_thread_id=True,
         report_thread_name=True,
@@ -82,6 +87,7 @@ def main():
         tags={
             "oncpu": str(oncpu).lower(),
             "gil_only": str(gil_only).lower(),
+            "cpu_profiler": cpu_profiler,
             "canary": canary,
         },
     )

--- a/python/pyroscope/__init__.py
+++ b/python/pyroscope/__init__.py
@@ -1,6 +1,7 @@
 import warnings
 import logging
 import sys
+import sysconfig
 
 from . import _native as lib
 
@@ -34,6 +35,7 @@ def configure(
         mem_heap_sample_size=512 * 1024,
         mem_enable_mem_domain=True,
         cpu_enabled=True,
+        cpu_profiler="pyspy",
 ):
     if app_name is not None:
         warnings.warn("app_name is deprecated, use application_name", DeprecationWarning)
@@ -41,6 +43,23 @@ def configure(
 
     if native is not None:
         warnings.warn("native is deprecated and not supported", DeprecationWarning)
+
+    if cpu_profiler not in ("pyspy", "gcp"):
+        raise ValueError('cpu_profiler must be either "pyspy" or "gcp"')
+
+    if cpu_enabled and cpu_profiler == "gcp":
+        if not sys.platform.startswith("linux"):
+            raise ValueError("the GCP CPU profiler is supported only on Linux")
+        if sys.version_info[:2] > (3, 11):
+            raise ValueError("the GCP CPU profiler supports CPython 3.11 and earlier")
+        if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+            raise ValueError("the GCP CPU profiler requires a GIL-enabled CPython build")
+        if not oncpu:
+            raise ValueError("the GCP CPU profiler does not support wall profiling; oncpu must be true")
+        if not 0 < sample_rate <= 1_000_000:
+            raise ValueError("GCP CPU profiler sample_rate must be between 1 and 1,000,000")
+        if upload_interval <= 0:
+            raise ValueError("GCP CPU profiler upload_interval must be greater than zero")
 
     LOGGER.disabled = not enable_logging
     if enable_logging:
@@ -70,6 +89,7 @@ def configure(
         mem_heap_sample_size,
         mem_enable_mem_domain,
         cpu_enabled,
+        cpu_profiler,
     )
 
 def shutdown():

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,3 +32,4 @@ cmake = "0.1"
 [features]
 default = []
 memory = []
+gcp = []

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -2,7 +2,7 @@ use cmake::Config;
 use std::env;
 use std::path::{Path, PathBuf};
 
-const NATIVE_SOURCES: &[&str] = &[
+const MEMALLOC_SOURCES: &[&str] = &[
     "CMakeLists.txt",
     "Pyroscope.h",
     "_memalloc.cpp",
@@ -21,33 +21,36 @@ const NATIVE_SOURCES: &[&str] = &[
     "profiling_helpers/version_compat.h",
 ];
 
+const GCP_SOURCES: &[&str] = &[
+    "CMakeLists.txt",
+    "bridge.cc",
+    "bridge.h",
+    "clock.cc",
+    "clock.h",
+    "log.cc",
+    "log.h",
+    "populate_frames.cc",
+    "populate_frames.h",
+    "profiler.cc",
+    "profiler.h",
+    "stacktraces.cc",
+    "stacktraces.h",
+];
+
 fn main() {
-    if cfg!(not(feature = "memory")) {
+    if cfg!(not(any(feature = "memory", feature = "gcp"))) {
         return;
     }
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let cpp_dir = manifest_dir.join("../cpp");
-    let cpp_dir = cpp_dir.canonicalize().unwrap();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    rerun_if_native_sources_changed(&manifest_dir, &cpp_dir);
-
-    let mut cfg = Config::new(&cpp_dir);
-
-    println!("cargo:rerun-if-env-changed=Python3_ROOT_DIR");
-    let python_root = env::var_os("Python3_ROOT_DIR")
-        .expect("Python3_ROOT_DIR must be set (passed from setup.py) so the C++ memalloc profiler is compiled against the target Python version");
-    cfg.define("Python3_ROOT_DIR", &python_root);
-    println!("cargo:rerun-if-env-changed=Python3_EXECUTABLE");
-    let python_executable = env::var_os("Python3_EXECUTABLE")
-        .expect("Python3_EXECUTABLE must be set (passed from setup.py) so the C++ memalloc profiler is compiled against the exact target Python interpreter");
-    cfg.define("Python3_EXECUTABLE", &python_executable);
-    cfg.define("Python3_FIND_STRATEGY", "LOCATION");
-
-    let dst = cfg.build();
-
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib=static=datadog_mem_profiler_bundled");
+    if cfg!(feature = "memory") {
+        build_memalloc(&manifest_dir, &out_dir);
+    }
+    if cfg!(feature = "gcp") {
+        build_gcp(&manifest_dir, &out_dir);
+    }
 
     if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
         println!("cargo:rustc-link-lib=static=c++");
@@ -58,12 +61,52 @@ fn main() {
     }
 }
 
-fn rerun_if_native_sources_changed(manifest_dir: &Path, cpp_dir: &Path) {
-    for source in NATIVE_SOURCES {
-        let path = cpp_dir.join(source);
-        println!("cargo:rerun-if-changed={}", path.display());
-    }
+fn configure_python(cfg: &mut Config) {
+    println!("cargo:rerun-if-env-changed=Python3_ROOT_DIR");
+    let python_root = env::var_os("Python3_ROOT_DIR")
+        .expect("Python3_ROOT_DIR must be set so native profilers use the target Python");
+    cfg.define("Python3_ROOT_DIR", &python_root);
+    println!("cargo:rerun-if-env-changed=Python3_EXECUTABLE");
+    let python_executable = env::var_os("Python3_EXECUTABLE")
+        .expect("Python3_EXECUTABLE must be set so native profilers use the target Python");
+    cfg.define("Python3_EXECUTABLE", &python_executable);
+    cfg.define("Python3_FIND_STRATEGY", "LOCATION");
+}
+
+fn build_memalloc(manifest_dir: &Path, out_dir: &Path) {
+    let cpp_dir = manifest_dir.join("../cpp").canonicalize().unwrap();
+    rerun_if_sources_changed(&cpp_dir, MEMALLOC_SOURCES);
+
+    let mut cfg = Config::new(&cpp_dir);
+    configure_python(&mut cfg);
+    cfg.out_dir(out_dir.join("memalloc"));
+
+    let dst = cfg.build();
+
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=static=datadog_mem_profiler_bundled");
 
     let ffi_header = manifest_dir.join("include/pyroscope_ffi.h");
     println!("cargo:rerun-if-changed={}", ffi_header.display());
+}
+
+fn build_gcp(manifest_dir: &Path, out_dir: &Path) {
+    let gcp_dir = manifest_dir.join("../gcp").canonicalize().unwrap();
+    rerun_if_sources_changed(&gcp_dir, GCP_SOURCES);
+
+    let mut cfg = Config::new(&gcp_dir);
+    configure_python(&mut cfg);
+    cfg.out_dir(out_dir.join("gcp"));
+
+    let dst = cfg.build();
+
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=static=gcp_cpu_profiler");
+}
+
+fn rerun_if_sources_changed(source_dir: &Path, sources: &[&str]) {
+    for source in sources {
+        let path = source_dir.join(source);
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
 }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -93,6 +93,8 @@ fn build_memalloc(manifest_dir: &Path, out_dir: &Path) {
 fn build_gcp(manifest_dir: &Path, out_dir: &Path) {
     let gcp_dir = manifest_dir.join("../gcp").canonicalize().unwrap();
     rerun_if_sources_changed(&gcp_dir, GCP_SOURCES);
+    let ffi_header = manifest_dir.join("include/pyroscope_ffi.h");
+    println!("cargo:rerun-if-changed={}", ffi_header.display());
 
     let mut cfg = Config::new(&gcp_dir);
     configure_python(&mut cfg);

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -23,10 +23,14 @@ include = [
   "FFIFrame",
   "FFIHeapSampleValues",
   "FFISample",
+  "FFIGcpFrame",
+  "FFIGcpSample",
   "pyroscope_memprof_string_table_intern_string",
   "pyroscope_memprof_push_sample",
+  "pyroscope_gcp_push_sample",
 ]
 exclude = [
+  "gcp_cpu_profiler_collect",
   "memalloc_start",
   "memalloc_stop",
   "memalloc_heap_py",

--- a/rust/include/pyroscope_ffi.h
+++ b/rust/include/pyroscope_ffi.h
@@ -11,13 +11,25 @@
 #include <stdlib.h>
 
 typedef struct {
-  uint32_t index;
-} FFIInternedString;
-
-typedef struct {
   const char *data;
   uintptr_t len;
 } FFIStringView;
+
+typedef struct {
+  FFIStringView function_name;
+  FFIStringView file_name;
+  int line;
+} FFIGcpFrame;
+
+typedef struct {
+  const FFIGcpFrame *frames;
+  uintptr_t len;
+  uint64_t count;
+} FFIGcpSample;
+
+typedef struct {
+  uint32_t index;
+} FFIInternedString;
 
 typedef struct {
   FFIInternedString function_name;
@@ -37,6 +49,8 @@ typedef struct {
   uintptr_t len;
   FFIHeapSampleValues values;
 } FFISample;
+
+void pyroscope_gcp_push_sample(FFIGcpSample sample);
 
 extern void memalloc_heap_postfork_child(void);
 

--- a/rust/src/encode/pprof.rs
+++ b/rust/src/encode/pprof.rs
@@ -135,6 +135,43 @@ impl PProfBuilder {
         self.profile.sample.push(sample);
     }
 
+    pub fn add_cpu_sample<'a, I>(
+        &mut self,
+        strings: &mut StringTable,
+        frames: I,
+        value: usize,
+        labels: &[(StringID, StringID)],
+    ) where
+        I: ExactSizeIterator<Item = (&'a str, &'a str, i32)>,
+    {
+        let mut location_id = Vec::with_capacity(frames.len());
+        for (name, filename, line) in frames {
+            let name = strings.add(name);
+            let filename = strings.add(filename);
+            let function_id = self.add_function_mirror(FunctionMirror { name, filename });
+            location_id.push(self.add_location_mirror(LocationMirror {
+                function_id,
+                line: i64::from(line.max(0)),
+            }));
+        }
+
+        let mut sample_labels = Vec::with_capacity(labels.len());
+        for (key, value) in labels {
+            sample_labels.push(Label {
+                key: key.pprof(),
+                str: value.pprof(),
+                num: 0,
+                num_unit: 0,
+            });
+        }
+
+        self.profile.sample.push(Sample {
+            location_id,
+            value: vec![value as i64 * self.profile.period],
+            label: sample_labels,
+        });
+    }
+
     pub fn add_ffi_sample(&mut self, frames: &[FFIFrame], values: &FFIHeapSampleValues) {
         let mut location_ids = std::mem::take(&mut self.ffi_locations_scratch);
         location_ids.clear();
@@ -246,6 +283,23 @@ impl PProfBuilder {
         }
         self.set_time_range(time_range);
         st.clone_pprof_table(&mut self.profile.string_table);
+        let profile = std::mem::take(&mut self.profile);
+        self.reset();
+        Some(profile)
+    }
+
+    pub fn take_profile_and_reset_owned(
+        &mut self,
+        st: StringTable,
+        time_range: &TimeRange,
+    ) -> Option<Profile> {
+        self.flush_memory_samples();
+        if self.profile.sample.is_empty() {
+            self.reset();
+            return None;
+        }
+        self.set_time_range(time_range);
+        self.profile.string_table = st.into_pprof_table();
         let profile = std::mem::take(&mut self.profile);
         self.reset();
         Some(profile)
@@ -365,6 +419,21 @@ impl StringTable {
                 next_id
             }
         }
+    }
+
+    pub fn add_owned(&mut self, s: String) -> StringID {
+        if let Some((existing, _)) = self.set.get_key_value(s.as_str()) {
+            return existing.index.clone();
+        }
+        let index = StringID::new(&self.set);
+        self.set.insert(
+            StringSetKey {
+                str: s,
+                index: index.clone(),
+            },
+            (),
+        );
+        index
     }
 
     #[cfg(debug_assertions)]

--- a/rust/src/gcp_backend.rs
+++ b/rust/src/gcp_backend.rs
@@ -1,15 +1,30 @@
 use crate::backend::{BackendConfig, ReportBatch};
-#[cfg(any(feature = "gcp", test))]
-use crate::backend::{Report, ReportData, StackBuffer, StackFrame, StackTrace};
+use crate::encode::pprof::ffi::FFIStringView;
 use crate::error::{PyroscopeError, Result};
-#[cfg(feature = "gcp")]
-use pyo3::prelude::*;
-#[cfg(feature = "gcp")]
-use pyo3::types::{PyDict, PyTuple};
+use std::ffi::c_int;
 use std::time::Duration;
 
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const NANOS_PER_MICROSECOND: u64 = 1_000;
+
+#[allow(dead_code)]
+pub mod ffi {
+    use super::FFIStringView;
+
+    #[repr(C)]
+    pub struct FFIGcpFrame {
+        pub function_name: FFIStringView,
+        pub file_name: FFIStringView,
+        pub line: super::c_int,
+    }
+
+    #[repr(C)]
+    pub struct FFIGcpSample {
+        pub frames: *const FFIGcpFrame,
+        pub len: usize,
+        pub count: u64,
+    }
+}
 
 #[derive(Clone, Copy)]
 pub struct Config {
@@ -45,7 +60,7 @@ impl Gcp {
 }
 
 impl Reporter {
-    pub fn report(&self, duration: Duration) -> Result<ReportBatch> {
+    pub fn report(&self, duration: Duration) -> Result<Option<ReportBatch>> {
         implementation::collect(duration, self.config)
     }
 }
@@ -71,85 +86,196 @@ pub fn period_nanos(sample_rate: u32) -> Result<i64> {
 }
 
 #[cfg(feature = "gcp")]
-fn traces_to_batch(
-    traces: &Bound<'_, PyDict>,
-    backend_config: &BackendConfig,
-) -> Result<ReportBatch> {
-    let mut samples = Vec::with_capacity(traces.len());
-    for (trace, count) in traces.iter() {
-        let frames = trace
-            .cast::<PyTuple>()
-            .map_err(|err| gcp_error("trace is not a tuple", err))?;
-        let mut stack_frames = Vec::with_capacity(frames.len());
-        for frame in frames.iter() {
-            let (name, filename, line): (String, String, i32) = frame
-                .extract()
-                .map_err(|err| gcp_error("frame has an invalid shape", err))?;
-            stack_frames.push(StackFrame {
-                name,
-                filename,
-                line: line.max(0) as u32,
-            });
-        }
-
-        let count: usize = count
-            .extract()
-            .map_err(|err| gcp_error("sample count is not an integer", err))?;
-        samples.push((stack_frames, count));
-    }
-
-    samples_to_batch(samples, backend_config)
-}
-
-#[cfg(any(feature = "gcp", test))]
-fn samples_to_batch(
-    samples: impl IntoIterator<Item = (Vec<StackFrame>, usize)>,
-    backend_config: &BackendConfig,
-) -> Result<ReportBatch> {
-    let mut buffer = StackBuffer::default();
-    for (frames, count) in samples {
-        let stacktrace =
-            StackTrace::new(backend_config, Some(std::process::id()), None, None, frames);
-        buffer.record_with_count(stacktrace, count)?;
-    }
-
-    let reports: Vec<Report> = buffer.into();
-    Ok(ReportBatch {
-        profile_type: "process_cpu".to_owned(),
-        data: ReportData::Reports(reports),
-    })
-}
-
-#[cfg(feature = "gcp")]
-fn gcp_error(context: &str, error: impl std::fmt::Display) -> PyroscopeError {
-    PyroscopeError::new(&format!("GCP CPU profiler {context}: {error}"))
-}
-
-#[cfg(feature = "gcp")]
 mod implementation {
+    #[cfg(test)]
+    use super::ffi::FFIGcpFrame;
+    use super::ffi::FFIGcpSample;
     use super::*;
-    use pyo3::ffi;
+    use crate::backend::ReportData;
+    use crate::encode::pprof::{PProfBuilder, StringID, StringTable};
+    use crate::utils::TimeRange;
+    use prost::Message;
+    use pyo3::prelude::*;
+    use std::sync::Mutex;
+    use std::time::SystemTime;
+
+    struct ProfileState {
+        builder: PProfBuilder,
+        strings: StringTable,
+        pid_label: Option<(StringID, StringID)>,
+    }
+
+    static PROFILE_STATE: Mutex<Option<ProfileState>> = Mutex::new(None);
 
     unsafe extern "C" {
-        fn gcp_cpu_profiler_collect(duration_nanos: i64, period_nanos: i64) -> *mut ffi::PyObject;
+        fn gcp_cpu_profiler_collect(duration_nanos: i64, period_nanos: i64) -> c_int;
     }
 
-    pub fn collect(duration: Duration, config: Config) -> Result<ReportBatch> {
+    fn start_profile(config: Config) -> Result<()> {
+        let mut strings = StringTable::new();
+        let mut builder = PProfBuilder::new();
+        builder.set_cpu_profile_type(&mut strings, config.sample_rate);
+        let pid_label = config.backend_config.report_pid.then(|| {
+            let pid = std::process::id().to_string();
+            (strings.add("pid"), strings.add_owned(pid))
+        });
+        *PROFILE_STATE.lock()? = Some(ProfileState {
+            builder,
+            strings,
+            pid_label,
+        });
+        Ok(())
+    }
+
+    fn clear_profile() {
+        if let Ok(mut state) = PROFILE_STATE.lock() {
+            *state = None;
+        }
+    }
+
+    fn finish_profile(time_range: &TimeRange) -> Result<Option<Vec<u8>>> {
+        let Some(mut state) = PROFILE_STATE.lock()?.take() else {
+            return Err(PyroscopeError::new(
+                "GCP CPU profiler profile state is not initialized",
+            ));
+        };
+        let profile = state
+            .builder
+            .take_profile_and_reset_owned(state.strings, time_range);
+        Ok(profile.map(|profile| profile.encode_to_vec()))
+    }
+
+    unsafe fn string_from_view<'a>(
+        data: *const std::ffi::c_char,
+        len: usize,
+    ) -> Option<&'a str> {
+        if data.is_null() {
+            return (len == 0).then_some("");
+        }
+        let bytes = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) };
+        Some(unsafe { std::str::from_utf8_unchecked(bytes) })
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyroscope_gcp_push_sample(sample: FFIGcpSample) {
+        if sample.frames.is_null() || sample.len == 0 {
+            return;
+        }
+        let ffi_frames = unsafe { std::slice::from_raw_parts(sample.frames, sample.len) };
+        let Ok(count) = usize::try_from(sample.count) else {
+            return;
+        };
+
+        let Ok(mut guard) = PROFILE_STATE.lock() else {
+            return;
+        };
+        let Some(state) = guard.as_mut() else {
+            return;
+        };
+        let frames = ffi_frames.iter().map(|frame| unsafe {
+            (
+                string_from_view(frame.function_name_data, frame.function_name_len).unwrap_or(""),
+                string_from_view(frame.file_name_data, frame.file_name_len).unwrap_or(""),
+                frame.line,
+            )
+        });
+        let labels = state.pid_label.as_slice();
+        state
+            .builder
+            .add_cpu_sample(&mut state.strings, frames, count, labels);
+    }
+
+    pub fn collect(duration: Duration, config: Config) -> Result<Option<ReportBatch>> {
         let duration_nanos = i64::try_from(duration.as_nanos())
             .map_err(|_| PyroscopeError::new("GCP CPU profiler duration is too large"))?;
         let period_nanos = period_nanos(config.sample_rate)?;
-
-        Python::attach(|py| unsafe {
-            let traces = gcp_cpu_profiler_collect(duration_nanos, period_nanos);
-            if traces.is_null() {
-                let error = PyErr::fetch(py);
-                return Err(gcp_error("collection failed", error));
+        start_profile(config)?;
+        let started = SystemTime::now();
+        let status =
+            Python::attach(|_| unsafe { gcp_cpu_profiler_collect(duration_nanos, period_nanos) });
+        let time_range = match TimeRange::new(started, SystemTime::now()) {
+            Ok(time_range) => time_range,
+            Err(error) => {
+                clear_profile();
+                return Err(error);
             }
-            let traces = Bound::from_owned_ptr(py, traces)
-                .cast_into::<PyDict>()
-                .map_err(|err| gcp_error("returned a non-dictionary result", err))?;
-            traces_to_batch(&traces, &config.backend_config)
-        })
+        };
+        if status != 0 {
+            clear_profile();
+            return Err(PyroscopeError::new("GCP CPU profiler collection failed"));
+        }
+
+        Ok(finish_profile(&time_range)?.map(|pprof| ReportBatch {
+            profile_type: "process_cpu".to_owned(),
+            data: ReportData::RawPprof(pprof),
+        }))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::encode::r#gen::google::Profile;
+        use std::ffi::c_char;
+        use std::time::{Duration, UNIX_EPOCH};
+
+        fn string_view(value: &str) -> FFIStringView {
+            FFIStringView {
+                data: value.as_ptr().cast::<c_char>(),
+                len: value.len(),
+            }
+        }
+
+        #[test]
+        fn incrementally_builds_cpu_pprof() {
+            start_profile(Config {
+                sample_rate: 100,
+                backend_config: BackendConfig {
+                    report_pid: true,
+                    ..BackendConfig::default()
+                },
+            })
+            .unwrap();
+
+            let frames = [
+                FFIGcpFrame {
+                    function_name: string_view("leaf"),
+                    file_name: string_view("/app/work.py"),
+                    line: 42,
+                },
+                FFIGcpFrame {
+                    function_name: string_view("root"),
+                    file_name: string_view("/app/main.py"),
+                    line: 7,
+                },
+            ];
+            pyroscope_gcp_push_sample(FFIGcpSample {
+                frames: frames.as_ptr(),
+                len: frames.len(),
+                count: 3,
+            });
+
+            let time_range =
+                TimeRange::new(UNIX_EPOCH, UNIX_EPOCH + Duration::from_secs(1)).unwrap();
+            let encoded = finish_profile(&time_range).unwrap().unwrap();
+            let profile = Profile::decode(encoded.as_slice()).unwrap();
+
+            assert_eq!(profile.sample.len(), 1);
+            assert_eq!(profile.sample[0].value, vec![30_000_000]);
+            assert_eq!(profile.sample[0].location_id.len(), 2);
+            let lines: Vec<i64> = profile.sample[0]
+                .location_id
+                .iter()
+                .map(|id| profile.location[(*id - 1) as usize].line[0].line)
+                .collect();
+            assert_eq!(lines, vec![42, 7]);
+            assert_eq!(profile.period, 10_000_000);
+            assert!(
+                profile.sample[0]
+                    .label
+                    .iter()
+                    .any(|label| profile.string_table[label.key as usize] == "pid")
+            );
+        }
     }
 }
 
@@ -157,7 +283,7 @@ mod implementation {
 mod implementation {
     use super::*;
 
-    pub fn collect(_duration: Duration, _config: Config) -> Result<ReportBatch> {
+    pub fn collect(_duration: Duration, _config: Config) -> Result<Option<ReportBatch>> {
         Err(PyroscopeError::new(
             "GCP CPU profiler is not available in this build",
         ))
@@ -177,40 +303,5 @@ mod tests {
     fn rejects_sample_rates_the_native_timer_cannot_represent() {
         assert!(period_nanos(0).is_err());
         assert!(period_nanos(1_000_001).is_err());
-    }
-
-    #[test]
-    fn converts_leaf_first_traces_and_preserves_counts() {
-        let frames = vec![
-            StackFrame {
-                name: "leaf".to_owned(),
-                filename: "/app/work.py".to_owned(),
-                line: 42,
-            },
-            StackFrame {
-                name: "root".to_owned(),
-                filename: "/app/main.py".to_owned(),
-                line: 7,
-            },
-        ];
-        let batch = samples_to_batch(
-            [(frames, 3)],
-            &BackendConfig {
-                report_pid: true,
-                ..BackendConfig::default()
-            },
-        )
-        .unwrap();
-
-        assert_eq!(batch.profile_type, "process_cpu");
-        let ReportData::Reports(reports) = batch.data else {
-            panic!("expected structured reports");
-        };
-        assert_eq!(reports.len(), 1);
-        let (stacktrace, count) = reports[0].data.iter().next().unwrap();
-        assert_eq!(*count, 3);
-        assert_eq!(stacktrace.frames[0].name, "leaf");
-        assert_eq!(stacktrace.frames[1].name, "root");
-        assert!(reports[0].metadata.tags.iter().any(|tag| tag.key == "pid"));
     }
 }

--- a/rust/src/gcp_backend.rs
+++ b/rust/src/gcp_backend.rs
@@ -1,0 +1,216 @@
+use crate::backend::{BackendConfig, ReportBatch};
+#[cfg(any(feature = "gcp", test))]
+use crate::backend::{Report, ReportData, StackBuffer, StackFrame, StackTrace};
+use crate::error::{PyroscopeError, Result};
+#[cfg(feature = "gcp")]
+use pyo3::prelude::*;
+#[cfg(feature = "gcp")]
+use pyo3::types::{PyDict, PyTuple};
+use std::time::Duration;
+
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+const NANOS_PER_MICROSECOND: u64 = 1_000;
+
+#[derive(Clone, Copy)]
+pub struct Config {
+    pub sample_rate: u32,
+    pub backend_config: BackendConfig,
+}
+
+pub struct Gcp {
+    config: Config,
+}
+
+#[derive(Clone, Copy)]
+pub struct Reporter {
+    config: Config,
+}
+
+impl Gcp {
+    pub fn new(config: Config) -> Result<Self> {
+        period_nanos(config.sample_rate)?;
+        if !is_available() {
+            return Err(PyroscopeError::new(
+                "GCP CPU profiler is not available in this build",
+            ));
+        }
+        Ok(Self { config })
+    }
+
+    pub fn reporter(&self) -> Reporter {
+        Reporter {
+            config: self.config,
+        }
+    }
+}
+
+impl Reporter {
+    pub fn report(&self, duration: Duration) -> Result<ReportBatch> {
+        implementation::collect(duration, self.config)
+    }
+}
+
+pub fn is_available() -> bool {
+    cfg!(all(feature = "gcp", target_os = "linux"))
+}
+
+pub fn period_nanos(sample_rate: u32) -> Result<i64> {
+    if sample_rate == 0 {
+        return Err(PyroscopeError::new(
+            "GCP CPU profiler sample_rate must be greater than zero",
+        ));
+    }
+    let period = NANOS_PER_SECOND / u64::from(sample_rate);
+    if period < NANOS_PER_MICROSECOND {
+        return Err(PyroscopeError::new(
+            "GCP CPU profiler sample_rate must not exceed 1,000,000",
+        ));
+    }
+    i64::try_from(period)
+        .map_err(|_| PyroscopeError::new("GCP CPU profiler sample period is too large"))
+}
+
+#[cfg(feature = "gcp")]
+fn traces_to_batch(
+    traces: &Bound<'_, PyDict>,
+    backend_config: &BackendConfig,
+) -> Result<ReportBatch> {
+    let mut samples = Vec::with_capacity(traces.len());
+    for (trace, count) in traces.iter() {
+        let frames = trace
+            .cast::<PyTuple>()
+            .map_err(|err| gcp_error("trace is not a tuple", err))?;
+        let mut stack_frames = Vec::with_capacity(frames.len());
+        for frame in frames.iter() {
+            let (name, filename, line): (String, String, i32) = frame
+                .extract()
+                .map_err(|err| gcp_error("frame has an invalid shape", err))?;
+            stack_frames.push(StackFrame {
+                name,
+                filename,
+                line: line.max(0) as u32,
+            });
+        }
+
+        let count: usize = count
+            .extract()
+            .map_err(|err| gcp_error("sample count is not an integer", err))?;
+        samples.push((stack_frames, count));
+    }
+
+    samples_to_batch(samples, backend_config)
+}
+
+#[cfg(any(feature = "gcp", test))]
+fn samples_to_batch(
+    samples: impl IntoIterator<Item = (Vec<StackFrame>, usize)>,
+    backend_config: &BackendConfig,
+) -> Result<ReportBatch> {
+    let mut buffer = StackBuffer::default();
+    for (frames, count) in samples {
+        let stacktrace =
+            StackTrace::new(backend_config, Some(std::process::id()), None, None, frames);
+        buffer.record_with_count(stacktrace, count)?;
+    }
+
+    let reports: Vec<Report> = buffer.into();
+    Ok(ReportBatch {
+        profile_type: "process_cpu".to_owned(),
+        data: ReportData::Reports(reports),
+    })
+}
+
+#[cfg(feature = "gcp")]
+fn gcp_error(context: &str, error: impl std::fmt::Display) -> PyroscopeError {
+    PyroscopeError::new(&format!("GCP CPU profiler {context}: {error}"))
+}
+
+#[cfg(feature = "gcp")]
+mod implementation {
+    use super::*;
+    use pyo3::ffi;
+
+    unsafe extern "C" {
+        fn gcp_cpu_profiler_collect(duration_nanos: i64, period_nanos: i64) -> *mut ffi::PyObject;
+    }
+
+    pub fn collect(duration: Duration, config: Config) -> Result<ReportBatch> {
+        let duration_nanos = i64::try_from(duration.as_nanos())
+            .map_err(|_| PyroscopeError::new("GCP CPU profiler duration is too large"))?;
+        let period_nanos = period_nanos(config.sample_rate)?;
+
+        Python::attach(|py| unsafe {
+            let traces = gcp_cpu_profiler_collect(duration_nanos, period_nanos);
+            if traces.is_null() {
+                let error = PyErr::fetch(py);
+                return Err(gcp_error("collection failed", error));
+            }
+            let traces = Bound::from_owned_ptr(py, traces)
+                .cast_into::<PyDict>()
+                .map_err(|err| gcp_error("returned a non-dictionary result", err))?;
+            traces_to_batch(&traces, &config.backend_config)
+        })
+    }
+}
+
+#[cfg(not(feature = "gcp"))]
+mod implementation {
+    use super::*;
+
+    pub fn collect(_duration: Duration, _config: Config) -> Result<ReportBatch> {
+        Err(PyroscopeError::new(
+            "GCP CPU profiler is not available in this build",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_sample_rate_is_ten_milliseconds() {
+        assert_eq!(period_nanos(100).unwrap(), 10_000_000);
+    }
+
+    #[test]
+    fn rejects_sample_rates_the_native_timer_cannot_represent() {
+        assert!(period_nanos(0).is_err());
+        assert!(period_nanos(1_000_001).is_err());
+    }
+
+    #[test]
+    fn converts_leaf_first_traces_and_preserves_counts() {
+        let frames = vec![
+            StackFrame {
+                name: "leaf".to_owned(),
+                filename: "/app/work.py".to_owned(),
+                line: 42,
+            },
+            StackFrame {
+                name: "root".to_owned(),
+                filename: "/app/main.py".to_owned(),
+                line: 7,
+            },
+        ];
+        let batch = samples_to_batch(
+            [(frames, 3)],
+            &BackendConfig {
+                report_pid: true,
+                ..BackendConfig::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(batch.profile_type, "process_cpu");
+        let ReportData::Reports(reports) = batch.data else {
+            panic!("expected structured reports");
+        };
+        assert_eq!(reports.len(), 1);
+        let (stacktrace, count) = reports[0].data.iter().next().unwrap();
+        assert_eq!(*count, 3);
+        assert_eq!(stacktrace.frames[0].name, "leaf");
+        assert_eq!(stacktrace.frames[1].name, "root");
+        assert!(reports[0].metadata.tags.iter().any(|tag| tag.key == "pid"));
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,4 @@
+mod gcp_backend;
 mod memory;
 mod pyspy_backend;
 
@@ -24,7 +25,7 @@ use std::{
 };
 
 use crate::backend::{BackendConfig, Tag, ThreadTagsSet};
-use crate::pyroscope::PyroscopeAgentBuilder;
+use crate::pyroscope::{CpuProfilerConfig, PyroscopeAgentBuilder};
 use pyo3::exceptions::{PyDeprecationWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -32,6 +33,7 @@ use pyo3::wrap_pyfunction;
 
 const PYSPY_NAME: &str = "pyspy";
 const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GCP_NAME: &str = "gcp";
 
 static AGENT_RUNNING: AtomicBool = AtomicBool::new(false);
 
@@ -152,6 +154,7 @@ fn initialize_agent(
     mem_heap_sample_size: u64,
     mem_enable_mem_domain: bool,
     cpu_enabled: bool,
+    cpu_profiler: String,
 ) -> bool {
     if !cpu_enabled && !mem_enabled {
         log::error!(
@@ -167,19 +170,56 @@ fn initialize_agent(
         report_pid,
     };
 
-    let pyspy_config = cpu_enabled.then(|| py_spy::Config {
-        blocking: py_spy::config::LockingStrategy::NonBlocking,
-        native: false,
-        pid: Some(std::process::id().try_into().unwrap()),
-        sampling_rate: sample_rate.into(),
-        include_idle: !oncpu,
-        include_thread_ids: true,
-        subprocesses: false,
-        gil_only,
-        lineno: line_no.into(),
-        duration: py_spy::config::RecordDuration::Unlimited,
-        ..py_spy::Config::default()
-    });
+    let cpu_config = if cpu_enabled {
+        match cpu_profiler.as_str() {
+            PYSPY_NAME => Some(CpuProfilerConfig::Pyspy(py_spy::Config {
+                blocking: py_spy::config::LockingStrategy::NonBlocking,
+                native: false,
+                pid: Some(std::process::id().try_into().unwrap()),
+                sampling_rate: sample_rate.into(),
+                include_idle: !oncpu,
+                include_thread_ids: true,
+                subprocesses: false,
+                gil_only,
+                lineno: line_no.into(),
+                duration: py_spy::config::RecordDuration::Unlimited,
+                ..py_spy::Config::default()
+            })),
+            GCP_NAME => {
+                if !oncpu {
+                    log::error!(
+                        target: "pyroscope-python",
+                        "the GCP CPU profiler does not support wall profiling; oncpu must be true"
+                    );
+                    return false;
+                }
+                if !gcp_backend::is_available() {
+                    log::error!(
+                        target: "pyroscope-python",
+                        "the GCP CPU profiler is only available in Linux builds with the GIL"
+                    );
+                    return false;
+                }
+                if let Err(error) = gcp_backend::period_nanos(sample_rate) {
+                    log::error!(target: "pyroscope-python", "{error}");
+                    return false;
+                }
+                Some(CpuProfilerConfig::Gcp(gcp_backend::Config {
+                    sample_rate,
+                    backend_config,
+                }))
+            }
+            other => {
+                log::error!(
+                    target: "pyroscope-python",
+                    "unknown CPU profiler {other:?}; expected \"pyspy\" or \"gcp\""
+                );
+                return false;
+            }
+        }
+    } else {
+        None
+    };
 
     let dynamic_tags = ThreadTagsSet::new();
 
@@ -187,7 +227,11 @@ fn initialize_agent(
         server_address,
         application_name,
         sample_rate,
-        PYSPY_NAME,
+        if cpu_enabled {
+            cpu_profiler.as_str()
+        } else {
+            PYSPY_NAME
+        },
         PYSPY_VERSION,
         memory::Config {
             enabled: mem_enabled,
@@ -210,7 +254,7 @@ fn initialize_agent(
 
     let result = ffikit::run(
         py,
-        PyroscopeAgentBuilder::new(agent_builder, pyspy_config, backend_config, dynamic_tags),
+        PyroscopeAgentBuilder::new(agent_builder, cpu_config, backend_config, dynamic_tags),
     );
     match result {
         Ok(_) => {

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -109,7 +109,7 @@ mod implementation {
             return StringID::empty_ffi_string();
         }
         let unsafe_str = unsafe {
-            let s = std::slice::from_raw_parts(s.data as *const u8, s.len);
+            let s = std::slice::from_raw_parts(s.data, s.len);
             std::str::from_utf8_unchecked(s)
         };
         match STRING_TABLE.lock() {

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::{
     backend::{BackendConfig, ReportBatch, ReportData, Tag, ThreadTag, ThreadTagsSet},
     error::Result,
+    gcp_backend::{self, Gcp},
     memory,
     session::{Session, SessionManager, SessionSignal},
 };
@@ -17,6 +18,51 @@ use crate::pyspy_backend::Pyspy;
 use crate::utils::TimeRange;
 const LOG_TAG: &str = "Pyroscope::Agent";
 const DEFAULT_UPLOAD_INTERVAL: Duration = Duration::from_secs(10);
+
+pub enum CpuProfilerConfig {
+    Pyspy(py_spy::config::Config),
+    Gcp(gcp_backend::Config),
+}
+
+pub enum CpuBackend {
+    Pyspy(Box<Pyspy>),
+    Gcp(Gcp),
+}
+
+enum CpuReporter {
+    Pyspy(crate::pyspy_backend::Reporter),
+    Gcp(gcp_backend::Reporter),
+}
+
+impl CpuBackend {
+    fn reporter(&self) -> CpuReporter {
+        match self {
+            Self::Pyspy(backend) => CpuReporter::Pyspy(backend.reporter()),
+            Self::Gcp(backend) => CpuReporter::Gcp(backend.reporter()),
+        }
+    }
+
+    fn shutdown(&mut self) -> Result<()> {
+        match self {
+            Self::Pyspy(backend) => backend.shutdown_thread(),
+            Self::Gcp(_) => Ok(()),
+        }
+    }
+}
+
+impl CpuReporter {
+    fn is_gcp(&self) -> bool {
+        matches!(self, Self::Gcp(_))
+    }
+
+    fn report(&self, duration: Duration) -> Result<ReportBatch> {
+        match self {
+            Self::Pyspy(reporter) => reporter.report(),
+            Self::Gcp(reporter) => reporter.report(duration),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct PyroscopeConfig {
     /// Pyroscope Server Address
@@ -126,7 +172,7 @@ impl PyroscopeConfig {
 
 pub struct PyroscopeAgentBuilder {
     pub config: PyroscopeConfig,
-    pyspy_config: Option<py_spy::config::Config>,
+    cpu_config: Option<CpuProfilerConfig>,
     backend_config: BackendConfig,
     ruleset: ThreadTagsSet,
 }
@@ -134,13 +180,13 @@ pub struct PyroscopeAgentBuilder {
 impl PyroscopeAgentBuilder {
     pub fn new(
         config: PyroscopeConfig,
-        pyspy_config: Option<py_spy::config::Config>,
+        cpu_config: Option<CpuProfilerConfig>,
         backend_config: BackendConfig,
         ruleset: ThreadTagsSet,
     ) -> Self {
         Self {
             config,
-            pyspy_config,
+            cpu_config,
             backend_config,
             ruleset,
         }
@@ -155,8 +201,15 @@ impl PyroscopeAgentBuilder {
         // }
 
         let backend = self
-            .pyspy_config
-            .map(|config| Pyspy::new(config, self.backend_config, self.ruleset.clone()))
+            .cpu_config
+            .map(|config| match config {
+                CpuProfilerConfig::Pyspy(config) => {
+                    Pyspy::new(config, self.backend_config, self.ruleset.clone())
+                        .map(Box::new)
+                        .map(CpuBackend::Pyspy)
+                }
+                CpuProfilerConfig::Gcp(config) => Gcp::new(config).map(CpuBackend::Gcp),
+            })
             .transpose()?;
         if backend.is_some() {
             log::trace!(target: LOG_TAG, "Backend initialized");
@@ -183,7 +236,7 @@ pub struct PyroscopeAgent {
     /// Handle to the thread that runs the Pyroscope Agent
     handle: Option<JoinHandle<Result<()>>>,
     /// Profiler backend
-    pub backend: Option<Pyspy>,
+    pub backend: Option<CpuBackend>,
     /// Configuration Object
     pub config: PyroscopeConfig,
 
@@ -195,7 +248,7 @@ impl PyroscopeAgent {
         log::debug!(target: LOG_TAG, "PyroscopeAgent::drop()");
 
         if let Some(backend) = &mut self.backend {
-            match backend.shutdown_thread() {
+            match backend.shutdown() {
                 Ok(_) => log::debug!(target: LOG_TAG, "Backend shutdown"),
                 Err(e) => log::error!(target: LOG_TAG, "Backend shutdown error: {e}"),
             }
@@ -224,7 +277,7 @@ impl PyroscopeAgent {
     pub fn start(mut self) -> Result<PyroscopeAgent> {
         log::debug!(target: LOG_TAG, "Starting");
 
-        let reporter = self.backend.as_ref().map(Pyspy::reporter);
+        let reporter = self.backend.as_ref().map(CpuBackend::reporter);
 
         let (tx, rx) = mpsc::channel();
         self.terminate_channel = Some(tx);
@@ -237,18 +290,46 @@ impl PyroscopeAgent {
         self.handle = Some(std::thread::spawn(move || {
             log::trace!(target: LOG_TAG, "Main Thread started");
             let mut sw = StopWatch::new();
-            loop {
-                match rx.recv_timeout(config.upload_interval) {
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        Self::snapshot(&reporter, config.clone(), &stx, &mut sw)?;
+            if reporter.as_ref().is_some_and(CpuReporter::is_gcp) {
+                loop {
+                    let cpu_report = reporter
+                        .as_ref()
+                        .map(|reporter| reporter.report(config.upload_interval))
+                        .transpose()?;
+                    Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
+                    match rx.try_recv() {
+                        Err(mpsc::TryRecvError::Empty) => {}
+                        Err(mpsc::TryRecvError::Disconnected) => {
+                            log::trace!(target: LOG_TAG, "Session Killed");
+                            break Ok(());
+                        }
+                        Ok(_) => {
+                            // unreachable: nothing is ever sent
+                        }
                     }
-                    Err(mpsc::RecvTimeoutError::Disconnected) => {
-                        Self::snapshot(&reporter, config.clone(), &stx, &mut sw)?;
-                        log::trace!(target: LOG_TAG, "Session Killed");
-                        break Ok(());
-                    }
-                    Ok(_) => {
-                        // unreachable: nothing is ever sent;
+                }
+            } else {
+                loop {
+                    match rx.recv_timeout(config.upload_interval) {
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            let cpu_report = reporter
+                                .as_ref()
+                                .map(|reporter| reporter.report(Duration::ZERO))
+                                .transpose()?;
+                            Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
+                        }
+                        Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            let cpu_report = reporter
+                                .as_ref()
+                                .map(|reporter| reporter.report(Duration::ZERO))
+                                .transpose()?;
+                            Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
+                            log::trace!(target: LOG_TAG, "Session Killed");
+                            break Ok(());
+                        }
+                        Ok(_) => {
+                            // unreachable: nothing is ever sent
+                        }
                     }
                 }
             }
@@ -258,7 +339,7 @@ impl PyroscopeAgent {
     }
 
     fn snapshot(
-        reporter: &Option<crate::pyspy_backend::Reporter>,
+        cpu_report: Option<ReportBatch>,
         config: PyroscopeConfig,
         stx: &SyncSender<SessionSignal>,
         stop_watch: &mut StopWatch,
@@ -278,8 +359,7 @@ impl PyroscopeAgent {
         }
         log::trace!(target: LOG_TAG, "Sending session {:?}",  time_range);
 
-        if let Some(reporter) = reporter {
-            let report = reporter.report()?;
+        if let Some(report) = cpu_report {
             batch.push(report);
         }
 

--- a/rust/src/pyroscope.rs
+++ b/rust/src/pyroscope.rs
@@ -55,9 +55,9 @@ impl CpuReporter {
         matches!(self, Self::Gcp(_))
     }
 
-    fn report(&self, duration: Duration) -> Result<ReportBatch> {
+    fn report(&self, duration: Duration) -> Result<Option<ReportBatch>> {
         match self {
-            Self::Pyspy(reporter) => reporter.report(),
+            Self::Pyspy(reporter) => reporter.report().map(Some),
             Self::Gcp(reporter) => reporter.report(duration),
         }
     }
@@ -292,10 +292,10 @@ impl PyroscopeAgent {
             let mut sw = StopWatch::new();
             if reporter.as_ref().is_some_and(CpuReporter::is_gcp) {
                 loop {
-                    let cpu_report = reporter
-                        .as_ref()
-                        .map(|reporter| reporter.report(config.upload_interval))
-                        .transpose()?;
+                    let cpu_report = match reporter.as_ref() {
+                        Some(reporter) => reporter.report(config.upload_interval)?,
+                        None => None,
+                    };
                     Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
                     match rx.try_recv() {
                         Err(mpsc::TryRecvError::Empty) => {}
@@ -312,17 +312,17 @@ impl PyroscopeAgent {
                 loop {
                     match rx.recv_timeout(config.upload_interval) {
                         Err(mpsc::RecvTimeoutError::Timeout) => {
-                            let cpu_report = reporter
-                                .as_ref()
-                                .map(|reporter| reporter.report(Duration::ZERO))
-                                .transpose()?;
+                            let cpu_report = match reporter.as_ref() {
+                                Some(reporter) => reporter.report(Duration::ZERO)?,
+                                None => None,
+                            };
                             Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
                         }
                         Err(mpsc::RecvTimeoutError::Disconnected) => {
-                            let cpu_report = reporter
-                                .as_ref()
-                                .map(|reporter| reporter.report(Duration::ZERO))
-                                .transpose()?;
+                            let cpu_report = match reporter.as_ref() {
+                                Some(reporter) => reporter.report(Duration::ZERO)?,
+                                None => None,
+                            };
                             Self::snapshot(cpu_report, config.clone(), &stx, &mut sw)?;
                             log::trace!(target: LOG_TAG, "Session Killed");
                             break Ok(());

--- a/scripts/tests/test_gcp_smoke.py
+++ b/scripts/tests/test_gcp_smoke.py
@@ -1,0 +1,70 @@
+import hashlib
+import http.server
+import sys
+import threading
+import time
+
+import pyroscope
+
+
+class PushHandler(http.server.BaseHTTPRequestHandler):
+    requests = 0
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        type(self).requests += 1
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        pass
+
+
+def burn_cpu():
+    value = b"gcp-profiler-smoke"
+    deadline = time.monotonic() + 2.5
+    while time.monotonic() < deadline:
+        value = hashlib.sha256(value).digest()
+    return value
+
+
+def assert_configuration_rejected(**kwargs):
+    try:
+        pyroscope.configure(application_name="invalid", **kwargs)
+    except ValueError:
+        return
+    raise AssertionError("configuration should have been rejected: {!r}".format(kwargs))
+
+
+def main():
+    assert_configuration_rejected(cpu_profiler="unknown")
+    if sys.version_info[:2] > (3, 11):
+        assert_configuration_rejected(cpu_profiler="gcp")
+        return
+
+    assert_configuration_rejected(cpu_profiler="gcp", oncpu=False)
+    assert_configuration_rejected(cpu_profiler="gcp", sample_rate=0)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), PushHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    configured = pyroscope.configure(
+        application_name="gcp.profiler.smoke",
+        server_address="http://127.0.0.1:{}".format(server.server_port),
+        cpu_profiler="gcp",
+        mem_enabled=True,
+        upload_interval=1,
+    )
+    assert configured
+    burn_cpu()
+    assert pyroscope.shutdown()
+
+    server.shutdown()
+    server_thread.join()
+    assert PushHandler.requests > 0
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ env.update({
 features = []
 if sysconfig.get_config_var("Py_GIL_DISABLED") != 1:
     features.append("memory")
+    if sys.platform.startswith("linux") and sys.version_info < (3, 12):
+        features.append("gcp")
 
 setup(
     rust_extensions=[


### PR DESCRIPTION
## Summary
- vendor the upstream Google Cloud Profiler CPU collector as a Linux static library while retaining its supported CPython 3.10-3.11 behavior
- add an opt-in `cpu_profiler=\"gcp\"` backend; py-spy remains the default and wall/GIL-only modes are not added
- stream borrowed native frames through FFI into pprof directly, avoiding Python dictionaries and transient per-frame string allocations
- document every vendored-source patch in `gcp_patches.md`

## Test plan
- [x] Rust unit tests and clippy without native features
- [x] Rust all-feature unit tests and clippy with Python 3.11
- [x] manylinux ARM64 wheel matrix build and GCP smoke test
- [x] musllinux ARM64 wheel matrix build and GCP smoke test
- [ ] full integration matrix (deferred)